### PR TITLE
Removed getEnumOutputValues

### DIFF
--- a/layers/Engine/packages/component-model/src/Directives/DirectiveTypes.php
+++ b/layers/Engine/packages/component-model/src/Directives/DirectiveTypes.php
@@ -6,9 +6,9 @@ namespace PoP\ComponentModel\Directives;
 
 class DirectiveTypes
 {
-    const SCHEMA = 'schema';
-    const QUERY = 'query';
-    const SYSTEM = 'system';
-    const SCRIPTING = 'scripting';
-    const INDEXING = 'indexing';
+    public const SCHEMA = 'SCHEMA';
+    public const QUERY = 'QUERY';
+    public const SYSTEM = 'SYSTEM';
+    public const SCRIPTING = 'SCRIPTING';
+    public const INDEXING = 'INDEXING';
 }

--- a/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/FieldOrDirectiveResolverTrait.php
@@ -184,7 +184,7 @@ trait FieldOrDirectiveResolverTrait
         string $type
     ): void {
         $errorItems = $deprecationItems = [];
-        $schemaFieldOrDirectiveArgumentEnumTypeValues = $fieldOrDirectiveArgumentEnumTypeResolver->getEnumOutputValues();
+        $schemaFieldOrDirectiveArgumentEnumTypeValues = $fieldOrDirectiveArgumentEnumTypeResolver->getEnumValues();
         $schemaFieldOrDirectiveArgumentEnumTypeDeprecationMessages = $fieldOrDirectiveArgumentEnumTypeResolver->getEnumValueDeprecationMessages();
         foreach ($fieldOrDirectiveArgumentValueItems as $fieldOrDirectiveArgumentValueItem) {
             if (!in_array($fieldOrDirectiveArgumentValueItem, $schemaFieldOrDirectiveArgumentEnumTypeValues)) {

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/AbstractEnumTypeResolver.php
@@ -11,13 +11,6 @@ use stdClass;
 abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements EnumTypeResolverInterface
 {
     /**
-     * Provide a mapping of enum values from output to real value,
-     * such as entries [VALUE => value] for "uppercase" output
-     *
-     * @var array<string,string>|null
-     */
-    protected ?array $outputValueToValueMappings = null;
-    /**
      * Description for all enum values (which have a description)
      *
      * @var array<string,string>|null
@@ -29,68 +22,6 @@ abstract class AbstractEnumTypeResolver extends AbstractTypeResolver implements 
      * @var array<string,string> Key: enum value, Value: deprecation message
      */
     protected ?array $enumValueDeprecationMessages = null;
-
-    /**
-     * By default, use the original values
-     */
-    public function getOutputEnumValueCallable(): ?callable
-    {
-        return null;
-    }
-
-    /**
-     * The values in the enum as they must be output (eg: in UPPERCASE)
-     *
-     * @return string[]
-     */
-    final public function getEnumOutputValues(): array
-    {
-        $outputValueToValueMappings = $this->getOutputValueToValueMappings();
-        return array_keys($outputValueToValueMappings);
-    }
-
-    /**
-     * The input may in in UPPERCASE while the enum value in the app
-     * is stored in lowercase, then convert from one to the other.
-     *
-     * @param string $inputEnumValue The input enum value, possibly as UPPERCASE
-     * @return string|null The found enum value, or `null` if it doesn't exist
-     */
-    final public function getEnumValueFromInput(string $inputEnumValue): ?string
-    {
-        $outputValueToValueMappings = $this->getOutputValueToValueMappings();
-        return $outputValueToValueMappings[$inputEnumValue] ?? null;
-    }
-
-    /**
-     * Provide a mapping of enum values from uppercase to real value,
-     * as entries: [VALUE => value]
-     *
-     * @return array<string,string>
-     */
-    private function getOutputValueToValueMappings(): array
-    {
-        if ($this->outputValueToValueMappings === null) {
-            $this->outputValueToValueMappings = [];
-            foreach ($this->getEnumValues() as $enumValue) {
-                $this->outputValueToValueMappings[$this->getOutputEnumValue($enumValue)] = $enumValue;
-            }
-        }
-        return $this->outputValueToValueMappings;
-    }
-
-    /**
-     * Transform the enum value to its output, or return
-     * the same enum value if there is no callable provided
-     */
-    private function getOutputEnumValue(string $enumValue): string
-    {
-        $outputEnumValueCallable = $this->getOutputEnumValueCallable();
-        if ($outputEnumValueCallable !== null) {
-            return $outputEnumValueCallable($enumValue);
-        }
-        return $enumValue;
-    }
 
     /**
      * Description for all enum values (which have a description)

--- a/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/EnumTypeResolverInterface.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/EnumType/EnumTypeResolverInterface.php
@@ -16,12 +16,6 @@ interface EnumTypeResolverInterface extends ConcreteTypeResolverInterface, Input
      */
     public function getEnumValues(): array;
     /**
-     * The values in the enum as they must be output (eg: in UPPERCASE)
-     *
-     * @return string[]
-     */
-    public function getEnumOutputValues(): array;
-    /**
      * Description for all enum values (which have a description)
      *
      * @return array<string,string> Key: enum value, Value: description
@@ -41,18 +35,4 @@ interface EnumTypeResolverInterface extends ConcreteTypeResolverInterface, Input
      * Deprecation message for a specific enum value
      */
     public function getEnumValueDeprecationMessage(string $enumValue): ?string;
-    /**
-     * Enable to output the enum values in UPPERCASE
-     * (even if those values are handled as lowercase)
-     * or some different format, through a custom callable
-     */
-    public function getOutputEnumValueCallable(): ?callable;
-    /**
-     * The input may in in UPPERCASE while the enum value in the app
-     * is stored in lowercase, then convert from one to the other.
-     *
-     * @param string $inputEnumValue The input enum value, possibly as UPPERCASE
-     * @return string|null The found enum value, or `null` if it doesn't exist
-     */
-    public function getEnumValueFromInput(string $inputEnumValue): ?string;
 }

--- a/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/FilterSystemDirectiveSchemaObjectTypeFieldResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/FieldResolvers/ObjectType/Extensions/FilterSystemDirectiveSchemaObjectTypeFieldResolver.php
@@ -10,6 +10,7 @@ use GraphQLByPoP\GraphQLServer\Schema\SchemaDefinitionHelpers;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\EnumType\DirectiveTypeEnumTypeResolver;
 use GraphQLByPoP\GraphQLServer\TypeResolvers\ObjectType\SchemaObjectTypeResolver;
 use PoP\API\Schema\SchemaDefinition;
+use PoP\ComponentModel\DirectiveResolvers\DirectiveResolverInterface;
 use PoP\ComponentModel\Registries\DirectiveRegistryInterface;
 use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
@@ -113,20 +114,13 @@ class FilterSystemDirectiveSchemaObjectTypeFieldResolver extends SchemaObjectTyp
             case 'directives':
                 $directiveIDs = $schema->getDirectiveIDs();
                 if ($ofTypes = $fieldArgs['ofTypes'] ?? null) {
-                    // Convert the enum from uppercase (as exposed in the API) to lowercase (as is its real value)
-                    $ofTypes = array_map(
-                        fn (string $enumValue) => $this->directiveTypeEnumTypeResolver->getEnumValueFromInput($enumValue),
-                        $ofTypes
-                    );
                     $ofTypeDirectiveResolvers = array_filter(
                         $this->directiveRegistry->getDirectiveResolvers(),
-                        function ($directiveResolver) use ($ofTypes) {
-                            return in_array($directiveResolver->getDirectiveType(), $ofTypes);
-                        }
+                        fn (DirectiveResolverInterface $directiveResolver) => in_array($directiveResolver->getDirectiveType(), $ofTypes)
                     );
                     // Calculate the directive IDs
                     $ofTypeDirectiveIDs = array_map(
-                        function ($directiveResolver) {
+                        function (DirectiveResolverInterface $directiveResolver): string {
                             // To retrieve the ID, use the same method to calculate the ID
                             // used when creating a new Directive instance
                             // (which we can't do here, since it has side-effects)

--- a/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/EnumType/DirectiveTypeEnumTypeResolver.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/src/TypeResolvers/EnumType/DirectiveTypeEnumTypeResolver.php
@@ -29,12 +29,4 @@ class DirectiveTypeEnumTypeResolver extends AbstractEnumTypeResolver
             ] : [],
         );
     }
-
-    /**
-     * Output the enum value in UPPERCASE
-     */
-    public function getOutputEnumValueCallable(): ?callable
-    {
-        return 'strtoupper';
-    }
 }


### PR DESCRIPTION
Because in the GraphQL spec, enum items only have a value, not a value and name. Then, enum item `pending` must be `pending`, it can't be `PENDING` with value `pending`.

See: https://spec.graphql.org/draft/#sec-Enums