### PR TITLE
Check why Rector v0.11.59 removes typehint in autowire functions

### DIFF
--- a/src/Config/Rector/Downgrade/Configurators/AbstractDowngradeContainerConfigurationService.php
+++ b/src/Config/Rector/Downgrade/Configurators/AbstractDowngradeContainerConfigurationService.php
@@ -7,12 +7,22 @@ namespace PoP\PoP\Config\Rector\Downgrade\Configurators;
 use PoP\PoP\Config\Rector\Configurators\AbstractContainerConfigurationService;
 use Rector\Core\Configuration\Option;
 use Rector\Core\ValueObject\PhpVersion;
+use Rector\Set\ValueObject\DowngradeLevelSetList;
 use Rector\Set\ValueObject\DowngradeSetList;
 
 abstract class AbstractDowngradeContainerConfigurationService extends AbstractContainerConfigurationService
 {
     public function configureContainer(): void
     {
+        /**
+         * This line produces a bug, executing `DowngradeParameterTypeWideningRector`
+         * when it should not.
+         * 
+         * @todo Check if it is fixed in Rector v0.11.60, then revert this code
+         * 
+         * @see https://github.com/leoloso/PoP/pull/1181
+         */
+        // $this->containerConfigurator->import(DowngradeLevelSetList::DOWN_TO_PHP_71);
         $this->containerConfigurator->import(DowngradeSetList::PHP_80);
         $this->containerConfigurator->import(DowngradeSetList::PHP_74);
         $this->containerConfigurator->import(DowngradeSetList::PHP_73);


### PR DESCRIPTION
With Rector v0.11.58, this function:

```php
#[Required]
final public function autowireUserAuthorization(UserAuthorizationSchemeRegistryInterface $userAuthorizationSchemeRegistry): void
{
    $this->userAuthorizationSchemeRegistry = $userAuthorizationSchemeRegistry;
}
```

is downgraded like this:

```php
/**
 * @required
 */
public final function autowireUserAuthorization(UserAuthorizationSchemeRegistryInterface $userAuthorizationSchemeRegistry): void
{
    $this->userAuthorizationSchemeRegistry = $userAuthorizationSchemeRegistry;
}
```

Since Rector upgrading to v0.11.59, it is downgraded like this:

```php
/**
 * @param \GraphQLAPI\GraphQLAPI\Registries\UserAuthorizationSchemeRegistryInterface $userAuthorizationSchemeRegistry
 * @required
 */
public final function autowireUserAuthorization($userAuthorizationSchemeRegistry): void
{
    $this->userAuthorizationSchemeRegistry = $userAuthorizationSchemeRegistry;
}
```

So now Symfony DependencyInjection doesn't work anymore, throwing an exception:

```
Cannot autowire service "GraphQLAPI\GraphQLAPI\Security\UserAuthorizationInterface": argument "$userAuthorizationSchemeRegistry" of method "GraphQLAPI\GraphQLAPI\Security\UserAuthorization::autowireUserAuthorization()" has no type-hint, you should configure its value explicitly.

Stack trace:

#0 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/Compiler/AbstractRecursivePass.php(77): PrefixedByPoP\Symfony\Component\DependencyInjection\Compiler\DefinitionErrorExceptionPass->processValue(Object(PrefixedByPoP\Symfony\Component\DependencyInjection\Definition), true)
#1 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/Compiler/DefinitionErrorExceptionPass.php(31): PrefixedByPoP\Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->processValue(Array, true)
#2 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/Compiler/AbstractRecursivePass.php(42): PrefixedByPoP\Symfony\Component\DependencyInjection\Compiler\DefinitionErrorExceptionPass->processValue(Array, true)
#3 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/Compiler/Compiler.php(87): PrefixedByPoP\Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->process(Object(PrefixedByPoP\Symfony\Component\DependencyInjection\ContainerBuilder))
#4 /app/wordpress/wp-content/plugins/graphql-api/vendor/symfony/dependency-injection/ContainerBuilder.php(648): PrefixedByPoP\Symfony\Component\DependencyInjection\Compiler\Compiler->compile(Object(PrefixedByPoP\Symfony\Component\DependencyInjection\ContainerBuilder))
#5 /app/wordpress/wp-content/plugins/graphql-api/vendor/getpop/root/src/Container/ContainerBuilderFactoryTrait.php(137): PrefixedByPoP\Symfony\Component\DependencyInjection\ContainerBuilder->compile()
#6 /app/wordpress/wp-content/plugins/graphql-api/vendor/getpop/root/src/AppLoader.php(158): PoP\Root\Container\SystemContainerBuilderFactory::maybeCompileAndCacheContainer(Array)
#7 /app/wordpress/wp-content/plugins/graphql-api/src/PluginSkeleton/AbstractMainPlugin.php(438): PoP\Root\AppLoader::bootSystem(true, '_v0.8.1_1634640...', '/app/wordpress/...')
#8 /app/wordpress/wp-content/plugins/graphql-api/src/PluginSkeleton/AbstractMainPlugin.php(366): GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractMainPlugin->bootSystem()
#9 /app/wordpress/wp-includes/class-wp-hook.php(303): GraphQLAPI\GraphQLAPI\PluginSkeleton\AbstractMainPlugin->GraphQLAPI\GraphQLAPI\PluginSkeleton\{closure}('')
#10 /app/wordpress/wp-includes/class-wp-hook.php(327): WP_Hook->apply_filters(NULL, Array)
#11 /app/wordpress/wp-includes/plugin.php(470): WP_Hook->do_action(Array)
#12 /app/wordpress/wp-settings.php(441): do_action('plugins_loaded')
#13 /app/wordpress/wp-config.php(90): require_once('/app/wordpress/...')
#14 /app/wordpress/wp-load.php(50): require_once('/app/wordpress/...')
#15 /app/wordpress/wp-admin/admin.php(34): require_once('/app/wordpress/...')
#16 /app/wordpress/wp-admin/index.php(10): require_once('/app/wordpress/...')
#17 {main}
```

Running Rector with `--dry-run`, it says it's running these rules:

```
Applied rules:
 * DowngradeParameterTypeWideningRector (https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.param-type-widening)
 * DowngradeTypedPropertyRector
 * DowngradeNonCapturingCatchesRector (https://wiki.php.net/rfc/non-capturing_catches)
 * DowngradeAttributeToAnnotationRector (https://php.watch/articles/php-attributes#syntax)
```

So we must check which one is making mess.