### PR TITLE
Switch the "Upload to Release" GitHub Action

### DIFF
--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -223,9 +223,9 @@ jobs:
     ###########################################################################
 
             -   name: Upload to release
-                uses: JasonEtco/upload-to-release@master
+                uses: softprops/action-gh-release@v1
                 with:
-                    args: build/${{ matrix.pluginConfig.zip_file }}.zip application/zip
+                    files: build/${{ matrix.pluginConfig.zip_file }}.zip
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 if: github.event_name == 'release'


### PR DESCRIPTION
Replace https://github.com/JasonEtco/upload-to-release with https://github.com/softprops/action-gh-release because of [this error](https://github.com/GatoGraphQL/GatoGraphQL/actions/runs/6095787004/job/16540073242):

```
curl: (22) The requested URL returned error: 403
```