### PR TITLE
Commented out `nikic/fast-route` (removed as `brain/cortex` has been removed)

### DIFF
--- a/ci/scoping/rector-test-scoping-gatographql.php
+++ b/ci/scoping/rector-test-scoping-gatographql.php
@@ -49,7 +49,14 @@ return static function (RectorConfig $rectorConfig): void {
         // $pluginDir . '/vendor/getpop/migrate-*',
         // $pluginDir . '/vendor/pop-schema/migrate-*',
         // Exclude tests from libraries
-        $pluginDir . '/vendor/nikic/fast-route/test/*',
+        /**
+         * Gato GraphQL plugin: This code is commented out as it is
+         * not needed anymore, because package `brain/cortex`
+         * is not loaded
+         *
+         * @see layers/Engine/packages/root-wp/src/Module.php
+         */
+        // $pluginDir . '/vendor/nikic/fast-route/test/*',
         $pluginDir . '/vendor/psr/log/Psr/Log/Test/*',
         $pluginDir . '/vendor/symfony/dom-crawler/Test/*',
         $pluginDir . '/vendor/symfony/http-foundation/Test/*',

--- a/ci/scoping/scoper-gatographql.inc.php
+++ b/ci/scoping/scoper-gatographql.inc.php
@@ -61,7 +61,14 @@ return [
                 // Exclude libraries
                 '#symfony/deprecation-contracts/#',
                 // Exclude tests from libraries
-                '#nikic/fast-route/test/#',
+                /**
+                 * Gato GraphQL plugin: This code is commented out as it is
+                 * not needed anymore, because package `brain/cortex`
+                 * is not loaded
+                 *
+                 * @see layers/Engine/packages/root-wp/src/Module.php
+                 */
+                // '#nikic/fast-route/test/#',
                 '#psr/log/Psr/Log/Test/#',
                 '#symfony/dom-crawler/Test/#',
                 '#symfony/http-foundation/Test/#',
@@ -105,28 +112,27 @@ return [
     'patchers' => [
         function (string $filePath, string $prefix, string $content): string {
             /**
-             * File vendor/nikic/fast-route/src/bootstrap.php has this code:
-             *
-             * if (\strpos($class, 'FastRoute\\') === 0) {
-             *   $name = \substr($class, \strlen('FastRoute'));
-             *
-             * Fix it
-             */
-            if ($filePath === convertRelativeToFullPath('vendor/nikic/fast-route/src/bootstrap.php')) {
-                return str_replace(
-                    ["'FastRoute\\\\'", "'FastRoute'"],
-                    [sprintf("'%s\\\\FastRoute\\\\'", $prefix), sprintf("'%s\\\\FastRoute'", $prefix)],
-                    $content
-                );
-            }
-
-            /**
              * Gato GraphQL plugin: This code is commented out as it is
              * not needed anymore, because package `brain/cortex`
              * is not loaded
              *
              * @see layers/Engine/packages/root-wp/src/Module.php
-             */
+             */            
+            // /**
+            //  * File vendor/nikic/fast-route/src/bootstrap.php has this code:
+            //  *
+            //  * if (\strpos($class, 'FastRoute\\') === 0) {
+            //  *   $name = \substr($class, \strlen('FastRoute'));
+            //  *
+            //  * Fix it
+            //  */
+            // if ($filePath === convertRelativeToFullPath('vendor/nikic/fast-route/src/bootstrap.php')) {
+            //     return str_replace(
+            //         ["'FastRoute\\\\'", "'FastRoute'"],
+            //         [sprintf("'%s\\\\FastRoute\\\\'", $prefix), sprintf("'%s\\\\FastRoute'", $prefix)],
+            //         $content
+            //     );
+            // }
             // /**
             //  * Brain/Cortex is prefixing classes \WP and \WP_Rewrite
             //  * Avoid it!

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/SkipDowngradeTestPathsDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/SkipDowngradeTestPathsDataSource.php
@@ -40,7 +40,14 @@ class SkipDowngradeTestPathsDataSource
             // This library is used for testing the source; it is added under "require" so it must be excluded
             'vendor/fakerphp/faker/',
             'vendor/michelf/php-markdown/test/',
-            'vendor/nikic/fast-route/test/',
+            /**
+             * Gato GraphQL plugin: This code is commented out as it is
+             * not needed anymore, because package `brain/cortex`
+             * is not loaded
+             *
+             * @see layers/Engine/packages/root-wp/src/Module.php
+             */            
+            // 'vendor/nikic/fast-route/test/',
             'vendor/psr/log/Psr/Log/Test/',
             'vendor/symfony/cache/DataCollector/CacheDataCollector.php',
             'vendor/symfony/cache/DoctrineProvider.php',


### PR DESCRIPTION
Continuation of #2534 