### PR TITLE
Create `AnyScalar` scalar type

### DIFF
--- a/layers/Engine/packages/component-model/src/TypeResolvers/ScalarType/AnyScalarScalarTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ScalarType/AnyScalarScalarTypeResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoP\ComponentModel\TypeResolvers\ScalarType;
+
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\GraphQLParser\Spec\Parser\Ast\AstInterface;
+use stdClass;
+
+class AnyScalarScalarTypeResolver extends AbstractScalarTypeResolver
+{
+    public function getTypeName(): string
+    {
+        return 'AnyScalar';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Wildcard type representing any of GraphQL\'s scalar types, including built-in types (String, Int, Boolean, Float or ID) and custom types', 'component-model');
+    }
+
+    /**
+     * Accept anything and everything
+     */
+    public function coerceValue(
+        string|int|float|bool|stdClass $inputValue,
+        AstInterface $astNode,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): string|int|float|bool|object|null {
+        return $inputValue;
+    }
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,7 +6,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 1.0.13 - DATE
 
+### Added
 
+- Scalar type `AnyScalar`
 
 ## 1.0.12 - 26/10/2023
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -170,6 +170,9 @@ You can even synchronize content across a network of sites, such as from an upst
 
 == Changelog ==
 
+= 1.0.13 =
+* Added scalar type `AnyScalar`
+
 = 1.0.12 =
 * Adapted the plugin following the assessment by the WordPress Plugin Review team.
 * Recipes: Replace `mysite.com` with the site domain


### PR DESCRIPTION
`AnyScalar` is a wildcard type representing any of GraphQL's scalar types, including built-in types (`String`, `Int`, `Boolean`, `Float` or `ID`) and custom types (such as `JSONObject`)