### PR TITLE
Add `failIfNonExistingKeyOrPath: false` to the translate persisted query

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 1.1.2 - DATE
 
+### Fixed
+
+- In predefined persisted queries "Translate post" and "Translate posts", added `failIfNonExistingKeyOrPath: false` when selecting a block's `attributes.{something}` property (as it may sometimes not be defined)
+
 ## 1.1.1 - 21/11/2013
 
 ### Fixed

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/recipes/bulk-translating-block-content-in-multiple-posts-to-a-different-language/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/recipes/bulk-translating-block-content-in-multiple-posts-to-a-different-language/en.md
@@ -284,6 +284,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreHeadingContentItems"
@@ -297,6 +298,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreParagraphContentItems"
@@ -337,6 +339,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.text" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreButtonTextItems"
@@ -385,6 +388,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreListItemContentItems"
@@ -398,6 +402,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.alt" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreCoverAltItems"
@@ -411,6 +416,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.mediaAlt" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreMediaTextAltItems"
@@ -424,6 +430,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreVerseContentItems"
@@ -437,6 +444,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.citation" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreQuoteCitationItems"
@@ -477,6 +485,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreAudioCaptionItems"
@@ -490,6 +499,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreVideoCaptionItems"
@@ -503,6 +513,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "corePreformattedContentItems"
@@ -516,6 +527,7 @@ query FetchData($postIDs: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreEmbedCaptionItems"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/recipes/translating-block-content-in-a-post-to-a-different-language/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/recipes/translating-block-content-in-a-post-to-a-different-language/en.md
@@ -128,6 +128,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreHeadingContentItems"
@@ -140,6 +141,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreParagraphContentItems"
@@ -177,6 +179,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.text" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreButtonTextItems"
@@ -222,6 +225,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreListItemContentItems"
@@ -234,6 +238,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.alt" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreCoverAltItems"
@@ -246,6 +251,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.mediaAlt" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreMediaTextAltItems"
@@ -258,6 +264,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreVerseContentItems"
@@ -270,6 +277,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.citation" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreQuoteCitationItems"
@@ -307,6 +315,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreAudioCaptionItems"
@@ -319,6 +328,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreVideoCaptionItems"
@@ -331,6 +341,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "corePreformattedContentItems"
@@ -343,6 +354,7 @@ query FetchData($postID: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreEmbedCaptionItems"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -170,6 +170,9 @@ You can even synchronize content across a network of sites, such as from an upst
 
 == Changelog ==
 
+= 1.1.2 =
+* In predefined persisted queries "Translate post" and "Translate posts", added `failIfNonExistingKeyOrPath: false` when selecting a block's `attributes.{something}` property (as it may sometimes not be defined)
+
 = 1.1.1 =
 * Fixed bug on the caching component (a downgraded `reset` method was called on a non array)
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-post.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-post.gql
@@ -134,6 +134,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreHeadingContentItems"
@@ -146,6 +147,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreParagraphContentItems"
@@ -183,6 +185,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.text" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreButtonTextItems"
@@ -228,6 +231,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreListItemContentItems"
@@ -240,6 +244,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.alt" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreCoverAltItems"
@@ -252,6 +257,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.mediaAlt" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreMediaTextAltItems"
@@ -264,6 +270,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreVerseContentItems"
@@ -276,6 +283,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.citation" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreQuoteCitationItems"
@@ -313,6 +321,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreAudioCaptionItems"
@@ -325,6 +334,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreVideoCaptionItems"
@@ -337,6 +347,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "corePreformattedContentItems"
@@ -349,6 +360,7 @@ query FetchData($postId: ID!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreEmbedCaptionItems"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts.gql
@@ -278,6 +278,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreHeadingContentItems"
@@ -291,6 +292,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreParagraphContentItems"
@@ -331,6 +333,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.text" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreButtonTextItems"
@@ -379,6 +382,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreListItemContentItems"
@@ -392,6 +396,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.alt" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreCoverAltItems"
@@ -405,6 +410,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.mediaAlt" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreMediaTextAltItems"
@@ -418,6 +424,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreVerseContentItems"
@@ -431,6 +438,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.citation" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreQuoteCitationItems"
@@ -471,6 +479,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreAudioCaptionItems"
@@ -484,6 +493,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreVideoCaptionItems"
@@ -497,6 +507,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.content" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "corePreformattedContentItems"
@@ -510,6 +521,7 @@ query FetchData($postIds: [ID!]!)
       @underEachArrayItem
         @underJSONObjectProperty(
           by: { path: "attributes.caption" }
+          failIfNonExistingKeyOrPath: false
         )
           @export(
             as: "coreEmbedCaptionItems"


### PR DESCRIPTION
In predefined persisted queries "Translate post" and "Translate posts", added `failIfNonExistingKeyOrPath: false` when selecting a block's `attributes.{something}` property (as it may sometimes not be defined)