### PR TITLE
Add predefined persisted query "Translate content from URL"

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,8 @@ composer fix-style
 
 ## Release notes
 
-- **[1.1](docs/release-notes/1.1/en.md)** (current)
+- **[1.2](docs/release-notes/1.2/en.md)** (current)
+- [1.1](docs/release-notes/1.1/en.md)
 - [1.0](docs/release-notes/1.0/en.md)
 - [0.10](docs/release-notes/0.10/en.md)
 - [0.9](docs/release-notes/0.9/en.md)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Added
 
 - Recipe "Translating content from URL"
+- Predefined Persisted Query "Translate content from URL"
 
 ### Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/README.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/README.md
@@ -177,7 +177,8 @@ composer fix-style
 
 ## Release notes
 
-- **[1.1](docs/release-notes/1.1/en.md)** (current)
+- **[1.2](docs/release-notes/1.2/en.md)** (current)
+- [1.1](docs/release-notes/1.1/en.md)
 - [1.0](docs/release-notes/1.0/en.md)
 - [0.10](docs/release-notes/0.10/en.md)
 - [0.9](docs/release-notes/0.9/en.md)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/general/about/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/general/about/en.md
@@ -142,7 +142,8 @@ Subscribe to our newsletter and receive timely updates concerning:
 
 New features released on each version:
 
-- **[1.1](../../release-notes/1.1/en.md)** (current)
+- **[1.2](../../release-notes/1.2/en.md)** (current)
+- [1.1](../../release-notes/1.1/en.md)
 - [1.0](../../release-notes/1.0/en.md)
 - [0.10](../../release-notes/0.10/en.md)
 - [0.9](../../release-notes/0.9/en.md)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.2/en.md
@@ -2,9 +2,11 @@
 
 Here's a description of all the changes.
 
-## Added "Translating content from URL" as recipe and predefined persisted query
+## Added predefined Persisted Query "Translate content from URL"
 
-This query, given a URL as input, its language, and what language to translate it to, fetches the content from the URL and performs the translation using Google Translate:
+A new predefined Persisted Query has been added: "Translating content from URL".
+
+Given a URL as input, its language, and what language to translate it to, fetches the content from the URL and performs the translation using Google Translate:
 
 ```graphql
 query TranslateContent(
@@ -25,7 +27,30 @@ query TranslateContent(
 }
 ```
 
-It's been added as a predefined Persisted Query, and also to the Recipes section.
+For instance, passing the [URL of some Markdown file in a GitHub repo](https://raw.githubusercontent.com/GatoGraphQL/GatoGraphQL/c870d8906ae1aec3c81acc039c53acc7aab5dff0/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/single-endpoint/en.md), and language code `"es"`:
+
+```json
+{
+  "url": "https://raw.githubusercontent.com/GatoGraphQL/GatoGraphQL/c870d8906ae1aec3c81acc039c53acc7aab5dff0/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/single-endpoint/en.md",
+  "fromLang": "en",
+  "toLang": "es"
+}
+```
+
+...will translate the Markdown content to Spanish:
+
+```json
+{
+  "data": {
+    "_sendHTTPRequest": {
+      "body": "# Single Endpoint\n\nExecute queries against the GraphQL server through the public single endpoint.\n\nBy default the endpoint is `/graphql/`, and the path can be configured through the Settings.\n\n![Single endpoint in Settings](../../images/settings-single-endpoint.png \"Single endpoint in Settings\")\n\nThe GraphQL single endpoint can be configured by assigning a Schema Configuration to it. To do this, on section \"Schema Configuration\" select the desired entry from the dropdown for \"Schema Configuration for the Single Endpoint\":\n\n<div class=\"img-width-1024\" markdown=1>\n\n![Settings for the Schema Configuration for the Single Endpoint](../../images/settings-schema-configuration-for-single-endpoint.png)\n\n</div>\n\n## Clients\n\nInteract with the single endpoint via the available clients.\n\n### GraphiQL\n\nIf module \"GraphiQL for Single Endpoint\" is enabled, then the single endpoint's GraphiQL client becomes publicly available.\n\nTo open it, click on link \"🟢 GraphiQL (public)\" on the plugin's menu:\n\n<div class=\"img-width-1024\" markdown=1>\n\n![Single endpoint's link to the GraphiQL client](../../images/single-endpoint-graphiql-link.png)\n\n</div>\n\nBy default, the client is exposed under `/graphiql/`. This path can be modified on the Settings, under tab \"GraphiQL for Single Endpoint\":\n\n<div class=\"img-width-1024\" markdown=1>\n\n![Path to GraphiQL client](../../images/settings-graphiql-for-single-endpoint.png)\n\n</div>\n\n### Interactive Schema (Voyager)\n\nIf module \"Interactive Schema for Single Endpoint\" is enabled, then the single endpoint's Voyager client becomes publicly available.\n\nTo open it, click on link \"🟢 Schema (public)\" on the plugin's menu:\n\n<div class=\"img-width-1024\" markdown=1>\n\n![Single endpoint's link to the Interactive Schema client](../../images/single-endpoint-interactive-schema-link.png)\n\n</div>\n\nBy default, the client is exposed under `/schema/`. This path can be modified on the Settings, under tab \"Interactive Schema for Single Endpoint\":\n\n<div class=\"img-width-1024\" markdown=1>\n\n![Path to Voyager client](../../images/settings-interactive-schema-for-single-endpoint.png)\n\n</div>\n",
+      "translated": "# Punto final único\n\nEjecute consultas en el servidor GraphQL a través del punto final único público.\n\nDe forma predeterminada, el punto final es `/graphql/` y la ruta se puede configurar a través de Configuración.\n\n![Punto final único en Configuración](../../images/settings-single-endpoint.png \"Punto final único en Configuración\")\n\nEl punto final único GraphQL se puede configurar asignándole una configuración de esquema. Para hacer esto, en la sección \"Configuración del esquema\", seleccione la entrada deseada del menú desplegable para \"Configuración del esquema para el punto final único\":\n\n<div class=\"img-width-1024\" descuento=1>\n\n![Configuración del esquema para el punto final único](../../images/settings-schema-configuration-for-single-endpoint.png)\n\n</div>\n\n## Clientes\n\nInteractúe con el punto final único a través de los clientes disponibles.\n\n### GrafiQL\n\nSi el módulo \"GraphiQL para punto final único\" está habilitado, el cliente GraphiQL del punto final único estará disponible públicamente.\n\nPara abrirlo, haga clic en el enlace \"🟢 GraphiQL (público)\" en el menú del complemento:\n\n<div class=\"img-width-1024\" descuento=1>\n\n![Enlace del punto final único al cliente GraphiQL](../../images/single-endpoint-graphiql-link.png)\n\n</div>\n\nDe forma predeterminada, el cliente está expuesto en `/graphiql/`. Esta ruta se puede modificar en Configuración, en la pestaña \"GraphiQL para punto final único\":\n\n<div class=\"img-width-1024\" descuento=1>\n\n![Ruta al cliente GraphiQL](../../images/settings-graphiql-for-single-endpoint.png)\n\n</div>\n\n### Esquema interactivo (Voyager)\n\nSi el módulo \"Esquema interactivo para punto final único\" está habilitado, el cliente Voyager del punto final único estará disponible públicamente.\n\nPara abrirlo, haga clic en el enlace \"🟢 Esquema (público)\" en el menú del complemento:\n\n<div class=\"img-width-1024\" descuento=1>\n\n![Enlace del punto final único al cliente de esquema interactivo](../../images/single-endpoint-interactive-schema-link.png)\n\n</div>\n\nDe forma predeterminada, el cliente está expuesto en `/schema/`. Esta ruta se puede modificar en Configuración, en la pestaña \"Esquema interactivo para punto final único\":\n\n<div class=\"img-width-1024\" descuento=1>\n\n![Ruta al cliente Voyager](../../images/settings-interactive-schema-for-single-endpoint.png)\n\n</div>\n"
+    }
+  }
+}
+```
+
+It has been added to the Recipes section too, under "Translating content from URL".
 
 ## Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.2/en.md
@@ -2,3 +2,32 @@
 
 Here's a description of all the changes.
 
+## Added "Translating content from URL" as recipe and predefined persisted query
+
+This query, given a URL as input, its language, and what language to translate it to, fetches the content from the URL and performs the translation using Google Translate:
+
+```graphql
+query TranslateContent(
+  $url: URL!
+  $fromLang: String!
+  $toLang: String!
+) {
+  _sendHTTPRequest(input: {
+    url: $url,
+    method: GET
+  }) {
+    body
+    translated: body @strTranslate(
+      from: $fromLang
+      to: $toLang
+    )
+  }
+}
+```
+
+It's been added as a predefined Persisted Query, and also to the Recipes section.
+
+## Fixed
+
+- In predefined persisted queries "Translate post" and "Translate posts", added `failIfNonExistingKeyOrPath: false` when selecting a block's `attributes.{something}` property (as it may sometimes not be defined)
+- In predefined persisted query "Import post from WordPress site", added status `any` to select the post

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -172,6 +172,7 @@ You can even synchronize content across a network of sites, such as from an upst
 
 = 1.2.0 =
 * Added recipe "Translating content from URL"
+* Added predefined Persisted Query "Translate content from URL"
 * In predefined persisted queries "Translate post" and "Translate posts", added `failIfNonExistingKeyOrPath: false` when selecting a block's `attributes.{something}` property (as it may sometimes not be defined)
 * In predefined persisted query "Import post from WordPress site", added status `any` to select the post
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-content-from-url.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-content-from-url.gql
@@ -6,8 +6,8 @@
 # 
 # URL params:
 #   - url: The URL with the content to translate
-#   - translateFrom: The language code to translate from, from Google Translate (https://cloud.google.com/translate/docs/languages)
-#   - translateTo: The language code to translate from, from Google Translate
+#   - fromLang: The language code to translate from, from Google Translate (https://cloud.google.com/translate/docs/languages)
+#   - toLang: The language code to translate from, from Google Translate
 #
 # *********************************************************************
 # 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-content-from-url.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-content-from-url.gql
@@ -1,0 +1,34 @@
+########################################################################
+#
+# This Persisted GraphQL query translates the content from the provided URL
+#
+# *********************************************************************
+# 
+# URL params:
+#   - url: The URL with the content to translate
+#   - translateFrom: The language code to translate from, from Google Translate (https://cloud.google.com/translate/docs/languages)
+#   - translateTo: The language code to translate from, from Google Translate
+#
+# *********************************************************************
+# 
+# More info:
+#   - https://gatographql.com/recipes/translating-content-from-url/
+#
+########################################################################
+
+query TranslateContent(
+  $url: URL!
+  $fromLang: String!
+  $toLang: String!
+) {
+  _sendHTTPRequest(input: {
+    url: $url,
+    method: GET
+  }) {
+    body
+    translated: body @strTranslate(
+      from: $fromLang
+      to: $toLang
+    )
+  }
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-content-from-url.json
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-content-from-url.json
@@ -1,0 +1,3 @@
+{
+  "fromLang": "en"
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -649,13 +649,8 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
          */
         /** @var EndpointSchemaConfigurationBlock */
         $endpointSchemaConfigurationBlock = $instanceManager->getInstance(EndpointSchemaConfigurationBlock::class);
-        /** @var CustomEndpointOptionsBlock */
-        $customEndpointOptionsBlock = $instanceManager->getInstance(CustomEndpointOptionsBlock::class);
-        /** @var EndpointGraphiQLBlock */
-        $endpointGraphiQLBlock = $instanceManager->getInstance(EndpointGraphiQLBlock::class);
-        /** @var EndpointVoyagerBlock */
-        $endpointVoyagerBlock = $instanceManager->getInstance(EndpointVoyagerBlock::class);
 
+        $defaultCustomEndpointBlocks = $this->getDefaultCustomEndpointBlocks();
         $adminCustomEndpointOptions = $this->getAdminCustomEndpointOptions();
         \wp_insert_post(array_merge(
             $adminCustomEndpointOptions,
@@ -669,15 +664,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             EndpointSchemaConfigurationBlock::ATTRIBUTE_NAME_SCHEMA_CONFIGURATION => $nestedMutationsSchemaConfigurationCustomPostID ?? EndpointSchemaConfigurationBlock::ATTRIBUTE_VALUE_SCHEMA_CONFIGURATION_DEFAULT,
                         ],
                     ],
-                    [
-                        'blockName' => $customEndpointOptionsBlock->getBlockFullName(),
-                    ],
-                    [
-                        'blockName' => $endpointGraphiQLBlock->getBlockFullName(),
-                    ],
-                    [
-                        'blockName' => $endpointVoyagerBlock->getBlockFullName(),
-                    ]
+                    ...$defaultCustomEndpointBlocks
                 ])),
             ]
         ));
@@ -1225,6 +1212,33 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
             'post_status' => 'private',
             'post_type' => $graphQLCustomEndpointCustomPostType->getCustomPostType(),
             'tax_input' => $adminEndpointTaxInputData,
+        ];
+    }
+
+    /**
+     * @return array<array<string,mixed>>
+     */
+    protected function getDefaultCustomEndpointBlocks(): array
+    {
+        $instanceManager = InstanceManagerFacade::getInstance();
+
+        /** @var CustomEndpointOptionsBlock */
+        $customEndpointOptionsBlock = $instanceManager->getInstance(CustomEndpointOptionsBlock::class);
+        /** @var EndpointGraphiQLBlock */
+        $endpointGraphiQLBlock = $instanceManager->getInstance(EndpointGraphiQLBlock::class);
+        /** @var EndpointVoyagerBlock */
+        $endpointVoyagerBlock = $instanceManager->getInstance(EndpointVoyagerBlock::class);
+
+        return [
+            [
+                'blockName' => $customEndpointOptionsBlock->getBlockFullName(),
+            ],
+            [
+                'blockName' => $endpointGraphiQLBlock->getBlockFullName(),
+            ],
+            [
+                'blockName' => $endpointVoyagerBlock->getBlockFullName(),
+            ]
         ];
     }
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -1046,6 +1046,27 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         \wp_insert_post(array_merge(
             $adminPersistedQueryOptions,
             [
+                'post_title' => \__('Translate content from URL', 'gatographql'),
+                'post_content' => serialize_blocks($this->addInnerContentToBlockAtts([
+                    [
+                        'blockName' => $persistedQueryEndpointGraphiQLBlock->getBlockFullName(),
+                        'attrs' => [
+                            AbstractGraphiQLBlock::ATTRIBUTE_NAME_QUERY => $this->readSetupGraphQLPersistedQueryAndEncodeForOutput(
+                                'admin/transform/translate-content-from-url',
+                                Recipes::TRANSLATING_CONTENT_FROM_URL,
+                            ),
+                            AbstractGraphiQLBlock::ATTRIBUTE_NAME_VARIABLES => $this->readSetupGraphQLVariablesJSONAndEncodeForOutput(
+                                'admin/transform/translate-content-from-url',
+                            ),
+                        ],
+                    ],
+                    ...$schemaConfigurationPersistedQueryBlocks,
+                ])),
+            ]
+        ));
+        \wp_insert_post(array_merge(
+            $adminPersistedQueryOptions,
+            [
                 'post_title' => \__('Import post from WordPress site', 'gatographql'),
                 'post_content' => serialize_blocks($this->addInnerContentToBlockAtts([
                     [

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -1276,7 +1276,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
 
         /** @var PersistedQueryEndpointGraphiQLBlock */
         $persistedQueryEndpointGraphiQLBlock = $instanceManager->getInstance(PersistedQueryEndpointGraphiQLBlock::class);
-        
+
         $adminPersistedQueryOptions = $this->getAdminPersistedQueryOptions();
         $defaultSchemaConfigurationPersistedQueryBlocks = $this->getDefaultSchemaConfigurationPersistedQueryBlocks();
         \wp_insert_post(array_merge(

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -644,13 +644,9 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
             $nestedMutationsPlusEntityAsPayloadTypeSchemaConfigurationCustomPostID = null;
         }
 
-        $adminEndpointTaxInputData = $this->getAdminEndpointTaxInputData();
-
         /**
          * Create custom endpoint
          */
-        /** @var GraphQLCustomEndpointCustomPostType */
-        $graphQLCustomEndpointCustomPostType = $instanceManager->getInstance(GraphQLCustomEndpointCustomPostType::class);
         /** @var EndpointSchemaConfigurationBlock */
         $endpointSchemaConfigurationBlock = $instanceManager->getInstance(EndpointSchemaConfigurationBlock::class);
         /** @var CustomEndpointOptionsBlock */
@@ -660,11 +656,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         /** @var EndpointVoyagerBlock */
         $endpointVoyagerBlock = $instanceManager->getInstance(EndpointVoyagerBlock::class);
 
-        $adminCustomEndpointOptions = [
-            'post_status' => 'private',
-            'post_type' => $graphQLCustomEndpointCustomPostType->getCustomPostType(),
-            'tax_input' => $adminEndpointTaxInputData,
-        ];
+        $adminCustomEndpointOptions = $this->getAdminCustomEndpointOptions();
         \wp_insert_post(array_merge(
             $adminCustomEndpointOptions,
             [
@@ -1215,6 +1207,24 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
             'post_status' => 'draft', // They are public => don't publish them!
             'post_type' => $graphQLPersistedQueryEndpointCustomPostType->getCustomPostType(),
             'tax_input' => $webhookEndpointTaxInputData,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getAdminCustomEndpointOptions(): array
+    {
+        $instanceManager = InstanceManagerFacade::getInstance();
+
+        $adminEndpointTaxInputData = $this->getAdminEndpointTaxInputData();
+
+        /** @var GraphQLCustomEndpointCustomPostType */
+        $graphQLCustomEndpointCustomPostType = $instanceManager->getInstance(GraphQLCustomEndpointCustomPostType::class);
+        return [
+            'post_status' => 'private',
+            'post_type' => $graphQLCustomEndpointCustomPostType->getCustomPostType(),
+            'tax_input' => $adminEndpointTaxInputData,
         ];
     }
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -614,7 +614,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         ];
         $nestedMutationsSchemaConfigurationCustomPostID = \wp_insert_post([
             'post_status' => 'publish',
-            // 'post_name' => 'nested-mutations', // Predefined slug to search/delete when installing .xml data in server
+            'post_name' => 'nested-mutations', // Predefine slug to retrieve this CPT's ID on future updates
             'post_type' => $graphQLSchemaConfigurationCustomPostType->getCustomPostType(),
             'post_title' => \__('Nested mutations', 'gatographql'),
             'post_content' => serialize_blocks($this->addInnerContentToBlockAtts([
@@ -632,7 +632,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         ];
         $nestedMutationsPlusEntityAsPayloadTypeSchemaConfigurationCustomPostID = \wp_insert_post([
             'post_status' => 'publish',
-            // 'post_name' => 'nested-mutations-entity-as-mutation-payload-type', // Predefined slug to search/delete when installing .xml data in server
+            'post_name' => 'nested-mutations-entity-as-mutation-payload-type', // Predefine slug to retrieve this CPT's ID on future updates
             'post_type' => $graphQLSchemaConfigurationCustomPostType->getCustomPostType(),
             'post_title' => \__('Nested mutations + Entity as mutation payload type', 'gatographql'),
             'post_content' => serialize_blocks($this->addInnerContentToBlockAtts([

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -704,11 +704,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         /** @var PersistedQueryEndpointAPIHierarchyBlock */
         $persistedQueryEndpointAPIHierarchyBlock = $instanceManager->getInstance(PersistedQueryEndpointAPIHierarchyBlock::class);
 
-        $adminPersistedQueryOptions = [
-            'post_status' => 'private',
-            'post_type' => $graphQLPersistedQueryEndpointCustomPostType->getCustomPostType(),
-            'tax_input' => $adminEndpointTaxInputData,
-        ];
+        $adminPersistedQueryOptions = $this->getAdminPersistedQueryOptions();
         $schemaConfigurationPersistedQueryBlocks = [
             [
                 'blockName' => $endpointSchemaConfigurationBlock->getBlockFullName(),
@@ -1203,11 +1199,27 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         return $webhookEndpointTaxInputData;
     }
 
-    protected function installPluginSetupDataForVersion1Dot2(): void
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getAdminPersistedQueryOptions(): array
     {
         $instanceManager = InstanceManagerFacade::getInstance();
 
         $adminEndpointTaxInputData = $this->getAdminEndpointTaxInputData();
+
+        /** @var GraphQLPersistedQueryEndpointCustomPostType */
+        $graphQLPersistedQueryEndpointCustomPostType = $instanceManager->getInstance(GraphQLPersistedQueryEndpointCustomPostType::class);
+        return [
+            'post_status' => 'private',
+            'post_type' => $graphQLPersistedQueryEndpointCustomPostType->getCustomPostType(),
+            'tax_input' => $adminEndpointTaxInputData,
+        ];
+    }
+
+    protected function installPluginSetupDataForVersion1Dot2(): void
+    {
+        $instanceManager = InstanceManagerFacade::getInstance();
 
         /** @var EndpointSchemaConfigurationBlock */
         $endpointSchemaConfigurationBlock = $instanceManager->getInstance(EndpointSchemaConfigurationBlock::class);
@@ -1215,8 +1227,6 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         /**
          * Create the ancestor Persisted Queries for organization
          */
-        /** @var GraphQLPersistedQueryEndpointCustomPostType */
-        $graphQLPersistedQueryEndpointCustomPostType = $instanceManager->getInstance(GraphQLPersistedQueryEndpointCustomPostType::class);
         /** @var PersistedQueryEndpointGraphiQLBlock */
         $persistedQueryEndpointGraphiQLBlock = $instanceManager->getInstance(PersistedQueryEndpointGraphiQLBlock::class);
         /** @var PersistedQueryEndpointOptionsBlock */
@@ -1224,11 +1234,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         /** @var PersistedQueryEndpointAPIHierarchyBlock */
         $persistedQueryEndpointAPIHierarchyBlock = $instanceManager->getInstance(PersistedQueryEndpointAPIHierarchyBlock::class);
 
-        $adminPersistedQueryOptions = [
-            'post_status' => 'private',
-            'post_type' => $graphQLPersistedQueryEndpointCustomPostType->getCustomPostType(),
-            'tax_input' => $adminEndpointTaxInputData,
-        ];
+        $adminPersistedQueryOptions = $this->getAdminPersistedQueryOptions();
         $schemaConfigurationPersistedQueryBlocks = [
             [
                 'blockName' => $endpointSchemaConfigurationBlock->getBlockFullName(),

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -705,17 +705,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         $persistedQueryEndpointAPIHierarchyBlock = $instanceManager->getInstance(PersistedQueryEndpointAPIHierarchyBlock::class);
 
         $adminPersistedQueryOptions = $this->getAdminPersistedQueryOptions();
-        $defaultSchemaConfigurationPersistedQueryBlocks = [
-            [
-                'blockName' => $endpointSchemaConfigurationBlock->getBlockFullName(),
-            ],
-            [
-                'blockName' => $persistedQueryEndpointOptionsBlock->getBlockFullName(),
-            ],
-            [
-                'blockName' => $persistedQueryEndpointAPIHierarchyBlock->getBlockFullName(),
-            ]
-        ];
+        $defaultSchemaConfigurationPersistedQueryBlocks = $this->getDefaultSchemaConfigurationPersistedQueryBlocks();
         $nestedMutationsSchemaConfigurationPersistedQueryBlocks = [
             [
                 'blockName' => $endpointSchemaConfigurationBlock->getBlockFullName(),
@@ -1217,25 +1207,22 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         ];
     }
 
-    protected function installPluginSetupDataForVersion1Dot2(): void
+    /**
+     * @return array<array<string,mixed>>
+     */
+    protected function getDefaultSchemaConfigurationPersistedQueryBlocks(): array
     {
         $instanceManager = InstanceManagerFacade::getInstance();
 
         /** @var EndpointSchemaConfigurationBlock */
         $endpointSchemaConfigurationBlock = $instanceManager->getInstance(EndpointSchemaConfigurationBlock::class);
 
-        /**
-         * Create the ancestor Persisted Queries for organization
-         */
-        /** @var PersistedQueryEndpointGraphiQLBlock */
-        $persistedQueryEndpointGraphiQLBlock = $instanceManager->getInstance(PersistedQueryEndpointGraphiQLBlock::class);
         /** @var PersistedQueryEndpointOptionsBlock */
         $persistedQueryEndpointOptionsBlock = $instanceManager->getInstance(PersistedQueryEndpointOptionsBlock::class);
         /** @var PersistedQueryEndpointAPIHierarchyBlock */
         $persistedQueryEndpointAPIHierarchyBlock = $instanceManager->getInstance(PersistedQueryEndpointAPIHierarchyBlock::class);
 
-        $adminPersistedQueryOptions = $this->getAdminPersistedQueryOptions();
-        $defaultSchemaConfigurationPersistedQueryBlocks = [
+        return [
             [
                 'blockName' => $endpointSchemaConfigurationBlock->getBlockFullName(),
             ],
@@ -1246,6 +1233,17 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                 'blockName' => $persistedQueryEndpointAPIHierarchyBlock->getBlockFullName(),
             ]
         ];
+    }
+
+    protected function installPluginSetupDataForVersion1Dot2(): void
+    {
+        $instanceManager = InstanceManagerFacade::getInstance();
+
+        /** @var PersistedQueryEndpointGraphiQLBlock */
+        $persistedQueryEndpointGraphiQLBlock = $instanceManager->getInstance(PersistedQueryEndpointGraphiQLBlock::class);
+        
+        $adminPersistedQueryOptions = $this->getAdminPersistedQueryOptions();
+        $defaultSchemaConfigurationPersistedQueryBlocks = $this->getDefaultSchemaConfigurationPersistedQueryBlocks();
         \wp_insert_post(array_merge(
             $adminPersistedQueryOptions,
             [

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -705,7 +705,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         $persistedQueryEndpointAPIHierarchyBlock = $instanceManager->getInstance(PersistedQueryEndpointAPIHierarchyBlock::class);
 
         $adminPersistedQueryOptions = $this->getAdminPersistedQueryOptions();
-        $schemaConfigurationPersistedQueryBlocks = [
+        $defaultSchemaConfigurationPersistedQueryBlocks = [
             [
                 'blockName' => $endpointSchemaConfigurationBlock->getBlockFullName(),
             ],
@@ -762,7 +762,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -804,7 +804,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -846,7 +846,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -885,7 +885,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -903,7 +903,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -996,7 +996,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -1032,7 +1032,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -1050,7 +1050,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -1068,7 +1068,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -1086,7 +1086,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -1104,7 +1104,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -1122,7 +1122,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -1147,7 +1147,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));
@@ -1235,7 +1235,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         $persistedQueryEndpointAPIHierarchyBlock = $instanceManager->getInstance(PersistedQueryEndpointAPIHierarchyBlock::class);
 
         $adminPersistedQueryOptions = $this->getAdminPersistedQueryOptions();
-        $schemaConfigurationPersistedQueryBlocks = [
+        $defaultSchemaConfigurationPersistedQueryBlocks = [
             [
                 'blockName' => $endpointSchemaConfigurationBlock->getBlockFullName(),
             ],
@@ -1263,7 +1263,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                             ),
                         ],
                     ],
-                    ...$schemaConfigurationPersistedQueryBlocks,
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
                 ])),
             ]
         ));

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -645,7 +645,6 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         }
 
         $adminEndpointTaxInputData = $this->getAdminEndpointTaxInputData();
-        $webhookEndpointTaxInputData = $this->getWebhookEndpointTaxInputData();
 
         /**
          * Create custom endpoint
@@ -695,8 +694,6 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         /**
          * Create the ancestor Persisted Queries for organization
          */
-        /** @var GraphQLPersistedQueryEndpointCustomPostType */
-        $graphQLPersistedQueryEndpointCustomPostType = $instanceManager->getInstance(GraphQLPersistedQueryEndpointCustomPostType::class);
         /** @var PersistedQueryEndpointGraphiQLBlock */
         $persistedQueryEndpointGraphiQLBlock = $instanceManager->getInstance(PersistedQueryEndpointGraphiQLBlock::class);
         /** @var PersistedQueryEndpointOptionsBlock */
@@ -1117,11 +1114,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
             ]
         ));
 
-        $webhookPersistedQueryOptions = [
-            'post_status' => 'draft', // They are public => don't publish them!
-            'post_type' => $graphQLPersistedQueryEndpointCustomPostType->getCustomPostType(),
-            'tax_input' => $webhookEndpointTaxInputData,
-        ];
+        $webhookPersistedQueryOptions = $this->getWebhookPersistedQueryOptions();
         \wp_insert_post(array_merge(
             $webhookPersistedQueryOptions,
             [
@@ -1204,6 +1197,24 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
             'post_status' => 'private',
             'post_type' => $graphQLPersistedQueryEndpointCustomPostType->getCustomPostType(),
             'tax_input' => $adminEndpointTaxInputData,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getWebhookPersistedQueryOptions(): array
+    {
+        $instanceManager = InstanceManagerFacade::getInstance();
+
+        $webhookEndpointTaxInputData = $this->getWebhookEndpointTaxInputData();
+
+        /** @var GraphQLPersistedQueryEndpointCustomPostType */
+        $graphQLPersistedQueryEndpointCustomPostType = $instanceManager->getInstance(GraphQLPersistedQueryEndpointCustomPostType::class);
+        return [
+            'post_status' => 'draft', // They are public => don't publish them!
+            'post_type' => $graphQLPersistedQueryEndpointCustomPostType->getCustomPostType(),
+            'tax_input' => $webhookEndpointTaxInputData,
         ];
     }
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -644,30 +644,8 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
             $nestedMutationsPlusEntityAsPayloadTypeSchemaConfigurationCustomPostID = null;
         }
 
-
-        /**
-         * Create Endpoint Categories
-         */
-        /** @var GraphQLEndpointCategoryTaxonomy */
-        $graphQLEndpointCategoryTaxonomy = $instanceManager->getInstance(GraphQLEndpointCategoryTaxonomy::class);
-
-        $endpointCategoryTaxonomy = $graphQLEndpointCategoryTaxonomy->getTaxonomy();
-
-        $adminEndpointTaxInputData = [
-            $endpointCategoryTaxonomy => [],
-        ];
-        $adminEndpointCategoryID = $this->getAdminEndpointCategoryID();
-        if ($adminEndpointCategoryID !== null) {
-            $adminEndpointTaxInputData[$endpointCategoryTaxonomy][] = $adminEndpointCategoryID;
-        }
-
-        $webhookEndpointTaxInputData = [
-            $endpointCategoryTaxonomy => [],
-        ];
-        $webhookEndpointCategoryID = $this->getWebhookEndpointCategoryID();
-        if ($webhookEndpointCategoryID !== null) {
-            $webhookEndpointTaxInputData[$endpointCategoryTaxonomy][] = $webhookEndpointCategoryID;
-        }
+        $adminEndpointTaxInputData = $this->getAdminEndpointTaxInputData();
+        $webhookEndpointTaxInputData = $this->getWebhookEndpointTaxInputData();
 
         /**
          * Create custom endpoint
@@ -1179,7 +1157,10 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         ));
     }
 
-    protected function installPluginSetupDataForVersion1Dot2(): void
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getAdminEndpointTaxInputData(): array
     {
         $instanceManager = InstanceManagerFacade::getInstance();
 
@@ -1195,6 +1176,38 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         if ($adminEndpointCategoryID !== null) {
             $adminEndpointTaxInputData[$endpointCategoryTaxonomy][] = $adminEndpointCategoryID;
         }
+
+        return $adminEndpointTaxInputData;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getWebhookEndpointTaxInputData(): array
+    {
+        $instanceManager = InstanceManagerFacade::getInstance();
+
+        /** @var GraphQLEndpointCategoryTaxonomy */
+        $graphQLEndpointCategoryTaxonomy = $instanceManager->getInstance(GraphQLEndpointCategoryTaxonomy::class);
+
+        $endpointCategoryTaxonomy = $graphQLEndpointCategoryTaxonomy->getTaxonomy();
+
+        $webhookEndpointTaxInputData = [
+            $endpointCategoryTaxonomy => [],
+        ];
+        $webhookEndpointCategoryID = $this->getWebhookEndpointCategoryID();
+        if ($webhookEndpointCategoryID !== null) {
+            $webhookEndpointTaxInputData[$endpointCategoryTaxonomy][] = $webhookEndpointCategoryID;
+        }
+
+        return $webhookEndpointTaxInputData;
+    }
+
+    protected function installPluginSetupDataForVersion1Dot2(): void
+    {
+        $instanceManager = InstanceManagerFacade::getInstance();
+
+        $adminEndpointTaxInputData = $this->getAdminEndpointTaxInputData();
 
         /** @var EndpointSchemaConfigurationBlock */
         $endpointSchemaConfigurationBlock = $instanceManager->getInstance(EndpointSchemaConfigurationBlock::class);


### PR DESCRIPTION
A new predefined Persisted Query has been added: "Translating content from URL".

Given a URL as input, its language, and what language to translate it to, fetches the content from the URL and performs the translation using Google Translate:

```graphql
query TranslateContent(
  $url: URL!
  $fromLang: String!
  $toLang: String!
) {
  _sendHTTPRequest(input: {
    url: $url,
    method: GET
  }) {
    body
    translated: body @strTranslate(
      from: $fromLang
      to: $toLang
    )
  }
}
```

For instance, passing the [URL of some Markdown file in a GitHub repo](https://raw.githubusercontent.com/GatoGraphQL/GatoGraphQL/c870d8906ae1aec3c81acc039c53acc7aab5dff0/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/single-endpoint/en.md), and language code `"es"`:

```json
{
  "url": "https://raw.githubusercontent.com/GatoGraphQL/GatoGraphQL/c870d8906ae1aec3c81acc039c53acc7aab5dff0/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/single-endpoint/en.md",
  "fromLang": "en",
  "toLang": "es"
}
```

...will translate the Markdown content to Spanish:

```json
{
  "data": {
    "_sendHTTPRequest": {
      "body": "# Single Endpoint\n\nExecute queries against the GraphQL server through the public single endpoint.\n\nBy default the endpoint is `/graphql/`, and the path can be configured through the Settings.\n\n![Single endpoint in Settings](../../images/settings-single-endpoint.png \"Single endpoint in Settings\")\n\nThe GraphQL single endpoint can be configured by assigning a Schema Configuration to it. To do this, on section \"Schema Configuration\" select the desired entry from the dropdown for \"Schema Configuration for the Single Endpoint\":\n\n<div class=\"img-width-1024\" markdown=1>\n\n![Settings for the Schema Configuration for the Single Endpoint](../../images/settings-schema-configuration-for-single-endpoint.png)\n\n</div>\n\n## Clients\n\nInteract with the single endpoint via the available clients.\n\n### GraphiQL\n\nIf module \"GraphiQL for Single Endpoint\" is enabled, then the single endpoint's GraphiQL client becomes publicly available.\n\nTo open it, click on link \"🟢 GraphiQL (public)\" on the plugin's menu:\n\n<div class=\"img-width-1024\" markdown=1>\n\n![Single endpoint's link to the GraphiQL client](../../images/single-endpoint-graphiql-link.png)\n\n</div>\n\nBy default, the client is exposed under `/graphiql/`. This path can be modified on the Settings, under tab \"GraphiQL for Single Endpoint\":\n\n<div class=\"img-width-1024\" markdown=1>\n\n![Path to GraphiQL client](../../images/settings-graphiql-for-single-endpoint.png)\n\n</div>\n\n### Interactive Schema (Voyager)\n\nIf module \"Interactive Schema for Single Endpoint\" is enabled, then the single endpoint's Voyager client becomes publicly available.\n\nTo open it, click on link \"🟢 Schema (public)\" on the plugin's menu:\n\n<div class=\"img-width-1024\" markdown=1>\n\n![Single endpoint's link to the Interactive Schema client](../../images/single-endpoint-interactive-schema-link.png)\n\n</div>\n\nBy default, the client is exposed under `/schema/`. This path can be modified on the Settings, under tab \"Interactive Schema for Single Endpoint\":\n\n<div class=\"img-width-1024\" markdown=1>\n\n![Path to Voyager client](../../images/settings-interactive-schema-for-single-endpoint.png)\n\n</div>\n",
      "translated": "# Punto final único\n\nEjecute consultas en el servidor GraphQL a través del punto final único público.\n\nDe forma predeterminada, el punto final es `/graphql/` y la ruta se puede configurar a través de Configuración.\n\n![Punto final único en Configuración](../../images/settings-single-endpoint.png \"Punto final único en Configuración\")\n\nEl punto final único GraphQL se puede configurar asignándole una configuración de esquema. Para hacer esto, en la sección \"Configuración del esquema\", seleccione la entrada deseada del menú desplegable para \"Configuración del esquema para el punto final único\":\n\n<div class=\"img-width-1024\" descuento=1>\n\n![Configuración del esquema para el punto final único](../../images/settings-schema-configuration-for-single-endpoint.png)\n\n</div>\n\n## Clientes\n\nInteractúe con el punto final único a través de los clientes disponibles.\n\n### GrafiQL\n\nSi el módulo \"GraphiQL para punto final único\" está habilitado, el cliente GraphiQL del punto final único estará disponible públicamente.\n\nPara abrirlo, haga clic en el enlace \"🟢 GraphiQL (público)\" en el menú del complemento:\n\n<div class=\"img-width-1024\" descuento=1>\n\n![Enlace del punto final único al cliente GraphiQL](../../images/single-endpoint-graphiql-link.png)\n\n</div>\n\nDe forma predeterminada, el cliente está expuesto en `/graphiql/`. Esta ruta se puede modificar en Configuración, en la pestaña \"GraphiQL para punto final único\":\n\n<div class=\"img-width-1024\" descuento=1>\n\n![Ruta al cliente GraphiQL](../../images/settings-graphiql-for-single-endpoint.png)\n\n</div>\n\n### Esquema interactivo (Voyager)\n\nSi el módulo \"Esquema interactivo para punto final único\" está habilitado, el cliente Voyager del punto final único estará disponible públicamente.\n\nPara abrirlo, haga clic en el enlace \"🟢 Esquema (público)\" en el menú del complemento:\n\n<div class=\"img-width-1024\" descuento=1>\n\n![Enlace del punto final único al cliente de esquema interactivo](../../images/single-endpoint-interactive-schema-link.png)\n\n</div>\n\nDe forma predeterminada, el cliente está expuesto en `/schema/`. Esta ruta se puede modificar en Configuración, en la pestaña \"Esquema interactivo para punto final único\":\n\n<div class=\"img-width-1024\" descuento=1>\n\n![Ruta al cliente Voyager](../../images/settings-interactive-schema-for-single-endpoint.png)\n\n</div>\n"
    }
  }
}
```
