### PR TITLE
Added predefined Persisted Query "Fetch post links"

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -13,6 +13,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Recipe "Translating content from URL"
 - Predefined Persisted Query "Translate content from URL"
 - Predefined Persisted Query "Import post from WordPress RSS feed"
+- Predefined Persisted Query "Fetch post links"
 
 ### Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.2/en.md
@@ -166,6 +166,44 @@ mutation ImportPostFromRSSFeed
 }
 ```
 
+## Added predefined Persisted Query "Fetch post links"
+
+The new predefined Persisted Query "Fetch post links" finds all `<a href="(...)">(...)</a>` strings in all posts, and lists them down in the response as `{ href: (...), text: (...) }`.
+
+For instance, it may produce this response:
+
+```json
+{
+  "data": {
+    "posts": [
+      {
+        "id": 1435,
+        "title": "Citations from famous authors",
+        "links": [
+          {
+            "href": "https://www.azquotes.com/author/4085-Fyodor_Dostoevsky",
+            "text": "Quote by Fyodor Dostoevsky"
+          },
+          {
+            "href": "https://www.azquotes.com/author/14706-Leo_Tolstoy",
+            "text": "Quote by Leon Tolstoi"
+          },
+          {
+            "href": "https://www.azquotes.com/author/15138-Voltaire",
+            "text": "Quote by Voltaire"
+          }
+        ]
+      },
+      {
+        "id": 1,
+        "title": "Hello world!",
+        "links": []
+      }
+    ]
+  }
+}
+```
+
 ## Added `XML` scalar type
 
 We can now input XML strings via the new `XML` scalar type, which will validate the correctness of the XML string.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.2/en.md
@@ -153,7 +153,6 @@ mutation ImportPostFromRSSFeed
       slug
       date
       status
-
       author {
         id
         username

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -176,6 +176,7 @@ You can even synchronize content across a network of sites, such as from an upst
 * Added recipe "Translating content from URL"
 * Added predefined Persisted Query "Translate content from URL"
 * Added predefined Persisted Query "Import post from WordPress RSS feed"
+* Added predefined Persisted Query "Fetch post links"
 * In predefined persisted queries "Translate post" and "Translate posts", added `failIfNonExistingKeyOrPath: false` when selecting a block's `attributes.{something}` property (as it may sometimes not be defined)
 * In predefined persisted query "Import post from WordPress site", added status `any` to select the post
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/report/post-links.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/report/post-links.gql
@@ -2,6 +2,9 @@
 #
 # This Persisted GraphQL query displays all links added to all posts.
 #
+# It finds all `<a href="(...)">(...)</a>` strings in all posts, and
+# lists them down in the response as `{ href: (...), text: (...) }`.
+#
 # *********************************************************************
 # 
 # URL params:
@@ -10,23 +13,89 @@
 #
 ########################################################################
 
-query FetchUsersByLocale(
-  $localeRegex: String!
-) {
-  usersByLocale: users(
-    filter: { metaQuery: {
-      key: "locale",
-      compareBy: {
-        stringValue: {
-          value: $localeRegex
-          operator: REGEXP
-        }
-      }
-    }},
-    pagination: { limit: -1 }
-  ) {
+query GetPostData {
+  posts(pagination: { limit: -1 }) {
     id
-    name
-    locale: metaValue(key: "locale")
+    title
+    
+    # Get the post content, and identify the links
+    rawContent
+      @remove
+    adaptedRawContent: _strRegexReplace(
+      searchRegex: "#<a.*(?=href=\"([^\"]*)\")[^>]*>([^<]*)<\/a>#i",
+      replaceWith: "*****|||||$1|||||$2*****",
+      in: $__rawContent
+    )
+      @remove
+    
+    # Extract the links into an object { href: ..., text: ...}
+    links: _strSplit(
+      string: $__adaptedRawContent,
+      separator: "*****"
+    )
+      @underEachArrayItem(
+        passValueOnwardsAs: "entry"
+        affectDirectivesUnderPos: [1, 2, 3]
+      )
+        @applyField(
+          name: "_strStartsWith"
+          arguments: {
+            search: "|||||"
+            in: $entry
+          }
+          passOnwardsAs: "isMatch"
+        )
+        @applyField(
+          name: "_not"
+          arguments: {
+            value: $isMatch
+          }
+          passOnwardsAs: "isNotMatch"
+        )
+        @if(
+          condition: $isNotMatch
+        )
+          @setNull
+    
+      @arrayFilter
+    
+      @underEachArrayItem(
+        passValueOnwardsAs: "match"
+        affectDirectivesUnderPos: [1, 2, 3, 4]
+      )
+        @applyField(
+          name: "_strSplit"
+          arguments: {
+            separator: "|||||"
+            string: $match
+          }
+          passOnwardsAs: "matchSplit"
+        )
+        @applyField(
+          name: "_arrayItem"
+          arguments: {
+            array: $matchSplit
+            position: 1
+          }
+          passOnwardsAs: "matchHref"
+        )
+        @applyField(
+          name: "_arrayItem"
+          arguments: {
+            array: $matchSplit
+            position: 2
+          }
+          passOnwardsAs: "matchText"
+        )
+        @applyField(
+          name: "_echo"
+          arguments: {
+            value: {
+              href: $matchHref
+              text: $matchText
+            }
+          }
+          setResultInResponse: true
+        )
   }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/report/post-links.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/report/post-links.gql
@@ -13,7 +13,7 @@
 #
 ########################################################################
 
-query GetPostData {
+query GetPostLinks {
   posts(pagination: { limit: -1 }) {
     id
     title

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/report/post-links.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/report/post-links.gql
@@ -1,0 +1,32 @@
+########################################################################
+#
+# This Persisted GraphQL query displays all links added to all posts.
+#
+# *********************************************************************
+# 
+# URL params:
+#   - localeRegex: The regex to identify the locale
+#       eg: "es_[A-Z]+" for the Spanish locale (es_AR for Argentina, es_ES for Spain, etc)
+#
+########################################################################
+
+query FetchUsersByLocale(
+  $localeRegex: String!
+) {
+  usersByLocale: users(
+    filter: { metaQuery: {
+      key: "locale",
+      compareBy: {
+        stringValue: {
+          value: $localeRegex
+          operator: REGEXP
+        }
+      }
+    }},
+    pagination: { limit: -1 }
+  ) {
+    id
+    name
+    locale: metaValue(key: "locale")
+  }
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/report/post-links.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/report/post-links.gql
@@ -5,12 +5,6 @@
 # It finds all `<a href="(...)">(...)</a>` strings in all posts, and
 # lists them down in the response as `{ href: (...), text: (...) }`.
 #
-# *********************************************************************
-# 
-# URL params:
-#   - localeRegex: The regex to identify the locale
-#       eg: "es_[A-Z]+" for the Spanish locale (es_AR for Argentina, es_ES for Spain, etc)
-#
 ########################################################################
 
 query GetPostLinks {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Constants/VirtualRecipes.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Constants/VirtualRecipes.php
@@ -10,5 +10,5 @@ namespace GatoGraphQL\GatoGraphQL\Constants;
 class VirtualRecipes
 {
     public const IMPORTING_A_POST_FROM_WORDPRESS_RSS_FEED = 'importing-a-post-from-wordpress-rss-feed';
-    public const RETRIEVE_POST_LINKS = 'retrieve-post-links';
+    public const FETCH_POST_LINKS = 'fetch-post-links';
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Constants/VirtualRecipes.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Constants/VirtualRecipes.php
@@ -10,4 +10,5 @@ namespace GatoGraphQL\GatoGraphQL\Constants;
 class VirtualRecipes
 {
     public const IMPORTING_A_POST_FROM_WORDPRESS_RSS_FEED = 'importing-a-post-from-wordpress-rss-feed';
+    public const RETRIEVE_POST_LINKS = 'retrieve-post-links';
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -1332,7 +1332,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                         'attrs' => [
                             AbstractGraphiQLBlock::ATTRIBUTE_NAME_QUERY => $this->readSetupGraphQLPersistedQueryAndEncodeForOutput(
                                 'admin/report/post-links',
-                                VirtualRecipes::RETRIEVE_POST_LINKS,
+                                VirtualRecipes::FETCH_POST_LINKS,
                             ),
                         ],
                     ],

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -1325,7 +1325,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         \wp_insert_post(array_merge(
             $adminPersistedQueryOptions,
             [
-                'post_title' => \__('Post links', 'gatographql'),
+                'post_title' => \__('Fetch post links', 'gatographql'),
                 'post_content' => serialize_blocks($this->addInnerContentToBlockAtts([
                     [
                         'blockName' => $persistedQueryEndpointGraphiQLBlock->getBlockFullName(),

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -1322,6 +1322,24 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                 ])),
             ]
         ));
+        \wp_insert_post(array_merge(
+            $adminPersistedQueryOptions,
+            [
+                'post_title' => \__('Post links', 'gatographql'),
+                'post_content' => serialize_blocks($this->addInnerContentToBlockAtts([
+                    [
+                        'blockName' => $persistedQueryEndpointGraphiQLBlock->getBlockFullName(),
+                        'attrs' => [
+                            AbstractGraphiQLBlock::ATTRIBUTE_NAME_QUERY => $this->readSetupGraphQLPersistedQueryAndEncodeForOutput(
+                                'admin/report/post-links',
+                                VirtualRecipes::RETRIEVE_POST_LINKS,
+                            ),
+                        ],
+                    ],
+                    ...$defaultSchemaConfigurationPersistedQueryBlocks,
+                ])),
+            ]
+        ));
     }
 
     protected function getAdminEndpointCategoryID(): ?int

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataProviders/VirtualRecipeDataProvider.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataProviders/VirtualRecipeDataProvider.php
@@ -29,7 +29,7 @@ class VirtualRecipeDataProvider
                     BundleExtensionModuleResolver::APPLICATION_GLUE_AND_AUTOMATOR,
                 ]
             ],
-            VirtualRecipes::RETRIEVE_POST_LINKS => [
+            VirtualRecipes::FETCH_POST_LINKS => [
                 \__('Retrieving post links', 'gatographql'),
                 [
                     ExtensionModuleResolver::CONDITIONAL_FIELD_MANIPULATION,

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataProviders/VirtualRecipeDataProvider.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataProviders/VirtualRecipeDataProvider.php
@@ -29,6 +29,19 @@ class VirtualRecipeDataProvider
                     BundleExtensionModuleResolver::APPLICATION_GLUE_AND_AUTOMATOR,
                 ]
             ],
+            VirtualRecipes::RETRIEVE_POST_LINKS => [
+                \__('Retrieving post links', 'gatographql'),
+                [
+                    ExtensionModuleResolver::FIELD_TO_INPUT,
+                    ExtensionModuleResolver::HELPER_FUNCTION_COLLECTION,
+                    ExtensionModuleResolver::HTTP_CLIENT,
+                    ExtensionModuleResolver::MULTIPLE_QUERY_EXECUTION,
+                    ExtensionModuleResolver::PHP_FUNCTIONS_VIA_SCHEMA,
+                ],
+                [
+                    BundleExtensionModuleResolver::APPLICATION_GLUE_AND_AUTOMATOR,
+                ]
+            ],
         ];
     }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataProviders/VirtualRecipeDataProvider.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataProviders/VirtualRecipeDataProvider.php
@@ -32,10 +32,11 @@ class VirtualRecipeDataProvider
             VirtualRecipes::RETRIEVE_POST_LINKS => [
                 \__('Retrieving post links', 'gatographql'),
                 [
+                    ExtensionModuleResolver::CONDITIONAL_FIELD_MANIPULATION,
+                    ExtensionModuleResolver::FIELD_ON_FIELD,
+                    ExtensionModuleResolver::FIELD_RESPONSE_REMOVAL,
                     ExtensionModuleResolver::FIELD_TO_INPUT,
-                    ExtensionModuleResolver::HELPER_FUNCTION_COLLECTION,
-                    ExtensionModuleResolver::HTTP_CLIENT,
-                    ExtensionModuleResolver::MULTIPLE_QUERY_EXECUTION,
+                    ExtensionModuleResolver::FIELD_VALUE_ITERATION_AND_MANIPULATION,
                     ExtensionModuleResolver::PHP_FUNCTIONS_VIA_SCHEMA,
                 ],
                 [


### PR DESCRIPTION
The new predefined Persisted Query "Fetch post links" finds all `<a href="(...)">(...)</a>` strings in all posts, and lists them down in the response as `{ href: (...), text: (...) }`.

For instance, it may produce this response:

```json
{
  "data": {
    "posts": [
      {
        "id": 1435,
        "title": "Citations from famous authors",
        "links": [
          {
            "href": "https://www.azquotes.com/author/4085-Fyodor_Dostoevsky",
            "text": "Quote by Fyodor Dostoevsky"
          },
          {
            "href": "https://www.azquotes.com/author/14706-Leo_Tolstoy",
            "text": "Quote by Leon Tolstoi"
          },
          {
            "href": "https://www.azquotes.com/author/15138-Voltaire",
            "text": "Quote by Voltaire"
          }
        ]
      },
      {
        "id": 1,
        "title": "Hello world!",
        "links": []
      }
    ]
  }
}
```