### PR TITLE
Added documentation for new field `_strParseCSV` (Helper Function Collection)

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -10,6 +10,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - `XML` scalar type
 - Documentation for new field `_strDecodeXMLAsJSON` from the Helper Function Collection extension
+- Documentation for new field `_strParseCSV` from the Helper Function Collection extension
 - Recipe "Translating content from URL"
 - Predefined Persisted Query "Translate content from URL"
 - Predefined Persisted Query "Import post from WordPress RSS feed"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.2/en.md
@@ -269,6 +269,12 @@ Whereas this query:
 }
 ```
 
+## Improved documentation
+
+- Added documentation for new fields from the [Helper Function Collection](https://gatographql.com/extensions/helper-function-collection/) extension:
+  - `_strDecodeXMLAsJSON`
+  - `_strParseCSV`
+
 ## Fixed
 
 - In predefined persisted queries "Translate post" and "Translate posts", added `failIfNonExistingKeyOrPath: false` when selecting a block's `attributes.{something}` property (as it may sometimes not be defined)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/helper-function-collection/docs/modules/helper-function-collection/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/helper-function-collection/docs/modules/helper-function-collection/en.md
@@ -182,6 +182,66 @@ This query:
 }
 ```
 
+### `_strParseCSV`
+
+Parse a CSV string into a list of JSON objects.
+
+This field will take a CSV as input, and convert it into a format that can be extracted, iterated and manipulated using other function fields.
+
+For instance, this query:
+
+```graphql
+{
+  _strParseCSV(
+    string: """Year,Make,Model,Description,Price
+1997,Ford,E350,"ac, abs, moon",3000.00
+1999,Chevy,"Venture ""Extended Edition"" (2008)","",4900.00
+1999,Chevy,"Venture ""Extended Edition, Very Large"" (2008)","",5000.00
+1996,Jeep,Grand Cherokee,"MUST SELL!
+air, moon roof, loaded",4799.00"""
+  )
+}
+```
+
+...will produce:
+
+```json
+{
+  "data": {
+    "_strParseCSV": [
+      {
+        "Year": "1997",
+        "Make": "Ford",
+        "Model": "E350",
+        "Description": "ac, abs, moon",
+        "Price": "3000.00"
+      },
+      {
+        "Year": "1999",
+        "Make": "Chevy",
+        "Model": "Venture \"Extended Edition\" (2008)",
+        "Description": "",
+        "Price": "4900.00"
+      },
+      {
+        "Year": "1999",
+        "Make": "Chevy",
+        "Model": "Venture \"Extended Edition, Very Large\" (2008)",
+        "Description": "",
+        "Price": "5000.00"
+      },
+      {
+        "Year": "1996",
+        "Make": "Jeep",
+        "Model": "Grand Cherokee",
+        "Description": "MUST SELL!\nair, moon roof, loaded",
+        "Price": "4799.00"
+      }
+    ]
+  }
+}
+```
+
 ### `_urlAddParams`
 
 Adds params to a URL.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -173,6 +173,7 @@ You can even synchronize content across a network of sites, such as from an upst
 = 1.2.0 =
 * Added `XML` scalar type
 * Added documentation for new field `_strDecodeXMLAsJSON` from the Helper Function Collection extension
+* Added documentation for new field `_strParseCSV` from the Helper Function Collection extension
 * Added recipe "Translating content from URL"
 * Added predefined Persisted Query "Translate content from URL"
 * Added predefined Persisted Query "Import post from WordPress RSS feed"


### PR DESCRIPTION
This field will take a CSV as input, and convert it into a format that can be extracted, iterated and manipulated using other function fields.

For instance, this query:

```graphql
{
  _strParseCSV(
    string: """Year,Make,Model,Description,Price
1997,Ford,E350,"ac, abs, moon",3000.00
1999,Chevy,"Venture ""Extended Edition"" (2008)","",4900.00
1999,Chevy,"Venture ""Extended Edition, Very Large"" (2008)","",5000.00
1996,Jeep,Grand Cherokee,"MUST SELL!
air, moon roof, loaded",4799.00"""
  )
}
```

...will produce:

```json
{
  "data": {
    "_strParseCSV": [
      {
        "Year": "1997",
        "Make": "Ford",
        "Model": "E350",
        "Description": "ac, abs, moon",
        "Price": "3000.00"
      },
      {
        "Year": "1999",
        "Make": "Chevy",
        "Model": "Venture \"Extended Edition\" (2008)",
        "Description": "",
        "Price": "4900.00"
      },
      {
        "Year": "1999",
        "Make": "Chevy",
        "Model": "Venture \"Extended Edition, Very Large\" (2008)",
        "Description": "",
        "Price": "5000.00"
      },
      {
        "Year": "1996",
        "Make": "Jeep",
        "Model": "Grand Cherokee",
        "Description": "MUST SELL!\nair, moon roof, loaded",
        "Price": "4799.00"
      }
    ]
  }
}
```