### PR TITLE
Added predefined custom endpoint "Nested mutations + Entity as mutation payload type"

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 1.4.0 - DATE
 
+### Added
+
+- Predefined custom endpoint "Nested mutations + Entity as mutation payload type"
+
 ### Improvements
 
 - Added "Request headers" to GraphiQL clients on single public/private endpoint, and custom endpoints

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.4/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.4/en.md
@@ -21,3 +21,7 @@ Same for custom endpoints:
 </div>
 
 (GraphiQL clients on Persisted queries do not have this addition.)
+
+## Fixed
+
+- HTML codes were printed in select inputs in the WordPress editor, they have now been removed

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.4/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.4/en.md
@@ -2,6 +2,12 @@
 
 Here's a description of all the changes.
 
+## Added predefined custom endpoint "Nested mutations + Entity as mutation payload type"
+
+The new predefined custom endpoint "Nested mutations + Entity as mutation payload type", installed as `private`, is useful for executing queries that create resources in bulk.
+
+For instance, the "Import posts from CSV" persisted query would need to be run on that client.
+
 ## Added "Request headers" to GraphiQL clients on single public/private endpoint, and custom endpoints
 
 The GraphiQL client on the single public and private GraphQL endpoints now have the "Request headers" input:

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -171,6 +171,7 @@ You can even synchronize content across a network of sites, such as from an upst
 == Changelog ==
 
 = 1.4.0 =
+* Added predefined custom endpoint "Nested mutations + Entity as mutation payload type"
 * Added "Request headers" to GraphiQL clients on single public/private endpoint, and custom endpoints
 * Fixed HTML codes were printed in select inputs in the WordPress editor, now removed
 


### PR DESCRIPTION
The new predefined custom endpoint "Nested mutations + Entity as mutation payload type", installed as `private`, is useful for executing queries that create resources in bulk.

For instance, the "Import posts from CSV" persisted query would need to be run on that client.