### PR TITLE
Fix bug: Extension version must be empty

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,6 +6,12 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 1.6.0 - DATE
 
+## 1.5.2 - 08/01/2024
+
+### Fixed
+
+- Active bundle or extension, with different version than main plugin, did not show "Active" button in Extensions page
+
 ## 1.5.1 - 08/01/2024
 
 ### Improvements

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -169,6 +169,9 @@ You can even synchronize content across a network of sites, such as from an upst
 
 == Changelog ==
 
+= 1.5.2 =
+* Active bundle or extension, with different version than main plugin, did not show "Active" button in Extensions page
+
 = 1.5.1 =
 * Improved description on readme.txt (for the WordPress plugin directory)
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Admin/Tables/AbstractExtensionListTable.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Admin/Tables/AbstractExtensionListTable.php
@@ -123,7 +123,24 @@ abstract class AbstractExtensionListTable extends WP_Plugin_Install_List_Table i
     protected function getCommonPluginData(): array
     {
         $mainPlugin = PluginApp::getMainPlugin();
-        $mainPluginVersion = $mainPlugin->getPluginVersion();
+
+        /**
+         * Watch out! Cannot assign the main plugin version because
+         * it produces a bug:
+         *
+         * If Gato GraphQL v1.5 is installed, and a bundle v1.4
+         * is installed, then page Extensions will not show the
+         * bundle as having the "Active" button, and also all
+         * included extensions as being "Active (via Bundle)".
+         *
+         * This happens because `install_plugin_install_status`
+         * keeps `$status` as `"install"`, and it must be
+         * `"newer_installed"` to add the expected button
+         * to Install/Activate the extension.
+         */
+        // $mainPluginVersion = $mainPlugin->getPluginVersion();
+        // $extensionPluginVersion = $mainPluginVersion;
+        $extensionPluginVersion = '';
 
         /**
          * @see https://developer.wordpress.org/reference/functions/get_plugin_data/
@@ -131,7 +148,7 @@ abstract class AbstractExtensionListTable extends WP_Plugin_Install_List_Table i
         $gatoGraphQLPluginData = get_plugin_data($mainPlugin->getPluginFile());
 
         return [
-            'version' => $mainPluginVersion,
+            'version' => $extensionPluginVersion,
             'author' => sprintf(
                 '<a href="%s">%s</a>',
                 $gatoGraphQLPluginData['AuthorURI'],


### PR DESCRIPTION
Fixed bug: Active bundle or extension, with different version than main plugin, did not show "Active" button in Extensions page