### PR TITLE
Fix bug with syntax error with variables

### DIFF
--- a/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
+++ b/layers/Engine/packages/graphql-parser/src/Spec/Parser/Parser.php
@@ -275,8 +275,12 @@ class Parser extends Tokenizer implements ParserInterface
         while (!$this->match(Token::TYPE_RPAREN) && !$this->end()) {
             $this->eat(Token::TYPE_COMMA);
 
-            /** @var Token */
+            /** @var Token|null */
             $variableToken = $this->eat(Token::TYPE_VARIABLE);
+            if ($variableToken === null) {
+                // If the variable doesn't start with "$" => syntax error
+                throw $this->createUnexpectedException($this->peek());
+            }
             $nameToken     = $this->eatIdentifierToken();
             $this->eat(Token::TYPE_COLON);
 

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -2199,4 +2199,16 @@ GRAPHQL;
           }
         ');
     }
+
+    public function testVariableNameMissing(): void
+    {
+        $this->expectException(SyntaxErrorParserException::class);
+        $this->expectExceptionMessage((new FeedbackItemResolution(GraphQLParserErrorFeedbackItemProvider::class, GraphQLParserErrorFeedbackItemProvider::E_6, ['COLON']))->getMessage());
+        $parser = $this->getParser();
+        $parser->parse('
+          query($: Int) {
+            id
+          }
+        ');
+    }
 }

--- a/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
+++ b/layers/Engine/packages/graphql-parser/tests/Spec/Parser/ParserTest.php
@@ -2187,4 +2187,16 @@ GRAPHQL;
         $parser = $this->getParser();
         $parser->parse('query ($variable: [[[String]]]){ query ( teas: $variable ) { alias: name } }');
     }
+
+    public function testVariableSyntaxIncorrect(): void
+    {
+        $this->expectException(SyntaxErrorParserException::class);
+        $this->expectExceptionMessage((new FeedbackItemResolution(GraphQLParserErrorFeedbackItemProvider::class, GraphQLParserErrorFeedbackItemProvider::E_6, ['IDENTIFIER']))->getMessage());
+        $parser = $this->getParser();
+        $parser->parse('
+          query(variable: Int) {
+            id
+          }
+        ');
+    }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -198,6 +198,10 @@ fragment MediaItemData on Media {
 - Validate the license keys when updating the plugin
 - Simplified the Tutorial section
 
+### Fixed
+
+- Bug where a syntax error on a variable definition in the GraphQL query was not validated
+
 ## 1.5.4 - 11/01/2024
 
 ### Fixed

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.6/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.6/en.md
@@ -191,3 +191,7 @@ fragment MediaItemData on Media {
 
 - Validate the license keys when updating the plugin
 - Simplified the Tutorial section
+
+## Fixed
+
+- Bug where a syntax error on a variable definition in the GraphQL query was not validated

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -175,6 +175,7 @@ You can even synchronize content across a network of sites, such as from an upst
 * Added fields `myMediaItemCount`, `myMediaItems` and `myMediaItem`
 * Validate the license keys when updating the plugin
 * Simplified the Tutorial section
+* Fixed bug where a syntax error on a variable definition in the GraphQL query was not validated
 
 = 1.5.4 =
 * Fixed bug in resolver where innerBlocks is not set


### PR DESCRIPTION
This query was producing an error:

```graphql
query(variable: Int) { # The "$" is missing: It should be $variable
  id
}
```

Now it's validated and fixed.