### PR TITLE
Added field `_dataMatrixOutputAsCSV`

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -193,6 +193,39 @@ fragment MediaItemData on Media {
 }
 ```
 
+#### Documentation for new field `_dataMatrixOutputAsCSV` from the Helper Function Collection extension
+
+Field `_dataMatrixOutputAsCSV` has been added to the documentation for the Helper Function Collection extension.
+
+This field takes a matrix of data, and produces a CSV string. For instance, this query:
+
+```graphql
+csv: _dataMatrixOutputAsCSV(
+  fields: 
+    ["Name", "Surname", "Year"]
+  data: [
+    ["John", "Smith", 2003],
+    ["Pedro", "Gonzales", 2012],
+    ["Manuel", "Perez", 2008],
+    ["Jose", "Pereyra", 1999],
+    ["Jacinto", "Bloomberg", 1998],
+    ["Jun-E", "Song", 1983],
+    ["Juan David", "Santamaria", 1943],
+    ["Luis Miguel", null, 1966],
+  ]
+)
+```
+
+...will produce:
+
+```json
+{
+  "data": {
+    "csv": "Name,Surname,Year\nJohn,Smith,2003\nPedro,Gonzales,2012\nManuel,Perez,2008\nJose,Pereyra,1999\nJacinto,Bloomberg,1998\nJun-E,Song,1983\nJuan David,Santamaria,1943\nLuis Miguel,,1966\n"
+  }
+}
+```
+
 ### Improvements
 
 - Validate the license keys when updating the plugin

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.6/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.6/en.md
@@ -187,6 +187,39 @@ fragment MediaItemData on Media {
 }
 ```
 
+### Documentation for new field `_dataMatrixOutputAsCSV` from the Helper Function Collection extension
+
+Field `_dataMatrixOutputAsCSV` has been added to the documentation for the Helper Function Collection extension.
+
+This field takes a matrix of data, and produces a CSV string. For instance, this query:
+
+```graphql
+csv: _dataMatrixOutputAsCSV(
+  fields: 
+    ["Name", "Surname", "Year"]
+  data: [
+    ["John", "Smith", 2003],
+    ["Pedro", "Gonzales", 2012],
+    ["Manuel", "Perez", 2008],
+    ["Jose", "Pereyra", 1999],
+    ["Jacinto", "Bloomberg", 1998],
+    ["Jun-E", "Song", 1983],
+    ["Juan David", "Santamaria", 1943],
+    ["Luis Miguel", null, 1966],
+  ]
+)
+```
+
+...will produce:
+
+```json
+{
+  "data": {
+    "csv": "Name,Surname,Year\nJohn,Smith,2003\nPedro,Gonzales,2012\nManuel,Perez,2008\nJose,Pereyra,1999\nJacinto,Bloomberg,1998\nJun-E,Song,1983\nJuan David,Santamaria,1943\nLuis Miguel,,1966\n"
+  }
+}
+```
+
 ## Improvements
 
 - Validate the license keys when updating the plugin

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/helper-function-collection/docs/modules/helper-function-collection/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/helper-function-collection/docs/modules/helper-function-collection/en.md
@@ -242,6 +242,41 @@ air, moon roof, loaded",4799.00"""
 }
 ```
 
+### `_dataMatrixOutputAsCSV`
+
+Output data as a CSV.
+
+This field will take a matrix of data, and produce a CSV string. This string can then be uploaded to the Media Library, or uploaded to an S3 bucket or FileStack, or other.
+
+For instance, this query:
+
+```graphql
+csv: _dataMatrixOutputAsCSV(
+  fields: 
+    ["Name", "Surname", "Year"]
+  data: [
+    ["John", "Smith", 2003],
+    ["Pedro", "Gonzales", 2012],
+    ["Manuel", "Perez", 2008],
+    ["Jose", "Pereyra", 1999],
+    ["Jacinto", "Bloomberg", 1998],
+    ["Jun-E", "Song", 1983],
+    ["Juan David", "Santamaria", 1943],
+    ["Luis Miguel", null, 1966],
+  ]
+)
+```
+
+...will produce:
+
+```json
+{
+  "data": {
+    "csv": "Name,Surname,Year\nJohn,Smith,2003\nPedro,Gonzales,2012\nManuel,Perez,2008\nJose,Pereyra,1999\nJacinto,Bloomberg,1998\nJun-E,Song,1983\nJuan David,Santamaria,1943\nLuis Miguel,,1966\n"
+  }
+}
+```
+
 ### `_urlAddParams`
 
 Adds params to a URL.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -173,6 +173,7 @@ You can even synchronize content across a network of sites, such as from an upst
 * Added new module Media Mutations
 * Added mutation `createMediaItem`
 * Added fields `myMediaItemCount`, `myMediaItems` and `myMediaItem`
+* Added documentation for new field `_dataMatrixOutputAsCSV` from the Helper Function Collection extension
 * Validate the license keys when updating the plugin
 * Simplified the Tutorial section
 * Fixed bug where a syntax error on a variable definition in the GraphQL query was not validated


### PR DESCRIPTION
Field `_dataMatrixOutputAsCSV` has been added to the documentation for the Helper Function Collection extension.

This field takes a matrix of data, and produces a CSV string. For instance, this query:

```graphql
csv: _dataMatrixOutputAsCSV(
  fields: 
    ["Name", "Surname", "Year"]
  data: [
    ["John", "Smith", 2003],
    ["Pedro", "Gonzales", 2012],
    ["Manuel", "Perez", 2008],
    ["Jose", "Pereyra", 1999],
    ["Jacinto", "Bloomberg", 1998],
    ["Jun-E", "Song", 1983],
    ["Juan David", "Santamaria", 1943],
    ["Luis Miguel", null, 1966],
  ]
)
```

...will produce:

```json
{
  "data": {
    "csv": "Name,Surname,Year\nJohn,Smith,2003\nPedro,Gonzales,2012\nManuel,Perez,2008\nJose,Pereyra,1999\nJacinto,Bloomberg,1998\nJun-E,Song,1983\nJuan David,Santamaria,1943\nLuis Miguel,,1966\n"
  }
}
```