### PR TITLE
Upgrade to node.js v20 in GitHub actions

### DIFF
--- a/.github/workflows/coding_standards.yml
+++ b/.github/workflows/coding_standards.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
@@ -41,7 +41,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -12,7 +12,7 @@ jobs:
         name: Provide list of source packages
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
@@ -50,7 +50,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 

--- a/.github/workflows/downgrade_php_tests.yml
+++ b/.github/workflows/downgrade_php_tests.yml
@@ -123,7 +123,7 @@ jobs:
                 run: zip -X -r build/downgraded-code.zip . -x *.git* build/\* php-parallel-lint/\*
                 if: ${{ needs.provide_data.outputs.generate_artifact }}
             -   name: Upload artifact
-                uses: actions/upload-artifact@v3
+                uses: actions/upload-artifact@v4
                 if: ${{ needs.provide_data.outputs.generate_artifact }}
                 with:
                     name: downgraded-code

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -229,7 +229,7 @@ jobs:
                     args: unzip -qq build/${{ matrix.pluginConfig.zip_file }}.zip -d build/dist-plugin/${{ matrix.pluginConfig.plugin_slug }}
 
             -   name: Upload plugin zip as artifact
-                uses: actions/upload-artifact@v3
+                uses: actions/upload-artifact@v4
                 with:
                     name: ${{ matrix.pluginConfig.zip_file }}
                     path: build/dist-plugin/

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -39,7 +39,7 @@ jobs:
         name: Provide configuration to generate plugins
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
@@ -79,7 +79,7 @@ jobs:
                 pluginConfig: ${{ fromJson(needs.provide_data.outputs.plugin_config_entries) }}
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -160,7 +160,7 @@ jobs:
                 working-directory: ${{ matrix.pluginConfig.path }}
 
             -   name: Check if readme.txt exists
-                uses: andstor/file-existence-action@v2
+                uses: andstor/file-existence-action@v3
                 id: check_readme_exists
                 with:
                     files: "${{ matrix.pluginConfig.path }}/readme.txt"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -13,7 +13,7 @@ jobs:
         name: Retrieve the GitHub Action artifact URLs to install in InstaWP
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
@@ -73,7 +73,7 @@ jobs:
             matrix:
                 instaWPConfig: ${{ fromJson(needs.provide_data.outputs.instawp_config_entries) }}
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 

--- a/.github/workflows/monorepo_validation.yml
+++ b/.github/workflows/monorepo_validation.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 

--- a/.github/workflows/scoping_tests.yml
+++ b/.github/workflows/scoping_tests.yml
@@ -19,7 +19,7 @@ jobs:
         name: Provide configuration of scoped releases
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
@@ -51,7 +51,7 @@ jobs:
                 pluginConfig: ${{ fromJson(needs.provide_data.outputs.plugin_config_entries) }}
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 

--- a/.github/workflows/split_monorepo.yml
+++ b/.github/workflows/split_monorepo.yml
@@ -17,7 +17,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
@@ -76,7 +76,7 @@ jobs:
         name: Monorepo Split of ${{ matrix.package.name }} (${{ matrix.package.path }})
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 

--- a/.github/workflows/split_monorepo_tagged.yml
+++ b/.github/workflows/split_monorepo_tagged.yml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 
@@ -58,7 +58,7 @@ jobs:
         name: Split with tag - ${{ matrix.package.name }} (${{ matrix.package.path }})
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
                     # this is required for "WyriHaximus/github-action-get-previous-tag" workflow

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     submodules: ${{ env.CHECKOUT_SUBMODULES }}
 


### PR DESCRIPTION
Fix warnings in GitHub Actions:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3, andstor/file-existence-action@v2, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/