### PR TITLE
Added predefined persisted query "Insert block in post"

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Added
 
 - Support passing the Schema Configuration to apply when invoking the Internal GraphQL Server
+- Predefined persisted query "Insert block in post"
 
 ### Improvements
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.1/en.md
@@ -41,6 +41,12 @@ class GraphQLServer {
   }
 ```
 
+### Predefined persisted query "Insert block in post"
+
+The newly-added persisted GraphQL query "Insert block in post" allows to inject a block in a post. It identifies the nth block of a given type (`wp:paragraph` by default) in a post, and places the provided custom block's HTML content right after it.
+
+Used with the [Automation](https://gatographql.com/extensions/automation/) extension, this persisted query can be used to automatically inject mandatory blocks to a newly-published post (eg: a CTA block to promote an ongoing campaign).
+
 ## Improvements
 
 - If initializing the service container from the cache fails, fallback to initializing PHP object from memory (#2638)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -171,6 +171,7 @@ You can even synchronize content across a network of sites, such as from an upst
 
 = 2.1.0 =
 * Support passing the Schema Configuration to apply when invoking the Internal GraphQL Server
+* Added predefined persisted query "Insert block in post"
 * If initializing the service container from the cache fails, fallback to initializing PHP object from memory (#2638)
 * Give unique operationName to all predefined persisted queries (#2644)
 * Improved error message when fetching blocks from a post, and the block content has errors

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/insert-block-in-post.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/insert-block-in-post.gql
@@ -57,7 +57,7 @@ query CreateRegex(
     @remove
 }
 
-mutation InsertBlockInPosts($postId: ID!)
+mutation InsertBlockInPost($postId: ID!)
   @depends(on: "CreateRegex")
 {
   post(by: { id : $postId }) {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/insert-block-in-post.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/insert-block-in-post.gql
@@ -1,0 +1,87 @@
+########################################################################
+# 
+# Variables:
+#   - postId: ID of the post to modify
+#   - searchBlockType: After what block type to insert the new block ("wp:paragraph" by default)
+#   - injectAfterBlockCount: After how many occurrences of the block to search will the new block be placed
+#   - injectBlockMarkup: The HTML for the block to insert
+#       eg: <!-- mycompany:black-friday-campaign-video --><figure class=\"wp-block-video\"><video controls src=\"https://mysite.com/videos/BlackFriday2023.mp4\"></video></figure><!-- /mycompany:black-friday-campaign-video -->
+#
+# *********************************************************************
+#
+# === Description ===
+#
+# This Persisted GraphQL query identifies the nth block of a given type
+# ("wp:paragraph" by default) in a post, and places the provided
+# custom block's HTML content right after it.
+#
+# *********************************************************************
+# 
+# More info:
+#   - https://gatographql.com/tutorial/inserting-removing-a-gutenberg-block-in-bulk/#heading-inserting-the-block-with-more-options
+#
+########################################################################
+
+query CreateRegex(
+  $searchBlockType: String! = "wp:paragraph"
+  $injectAfterBlockCount: Int = 1
+  $injectBlockMarkup: String!
+) {
+  endingBlockMarkup: _sprintf(
+    string: "<!-- /%s -->",
+    values: [$searchBlockType]
+  )
+    @remove
+  endingBlockMarkupArray: _arrayPad(
+    array: [],
+    length: $injectAfterBlockCount,
+    value: $__endingBlockMarkup
+  )
+    @remove
+  regexString: _arrayJoin(
+    array: $__endingBlockMarkupArray,
+    separator: "[\\s\\S]+"
+  )
+    @remove
+  regex: _sprintf(
+    string: "#(%s)#U",
+    values: [$__regexString]
+  )
+    @export(as: "regex")
+    @remove
+  replaceWith: _sprintf(
+    string: "$1%s",
+    values: [$injectBlockMarkup]
+  )
+    @export(as: "replaceWith")
+    @remove
+}
+
+mutation InsertBlockInPosts($postId: ID!)
+  @depends(on: "CreateRegex")
+{
+  post(by: { id : $postId }) {
+    rawContent
+    adaptedRawContent: _strRegexReplace(
+      in: $__rawContent,
+      searchRegex: $regex,
+      replaceWith: $replaceWith,
+      limit: 1
+    )
+    update(input: {
+      contentAs: { html: $__adaptedRawContent },
+    }) {
+      status
+      errors {
+        __typename
+        ...on ErrorPayload {
+          message
+        }
+      }
+      post {
+        id
+        rawContent
+      }
+    }
+  }
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Constants/PluginSetupDataEntrySlugs.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Constants/PluginSetupDataEntrySlugs.php
@@ -32,6 +32,7 @@ class PluginSetupDataEntrySlugs
     public final const PERSISTED_QUERY_IMPORT_POST_FROM_WORDPRESS_RSS_FEED = 'import-post-from-wordpress-rss-feed';
     public final const PERSISTED_QUERY_IMPORT_POST_FROM_WORDPRESS_SITE = 'import-post-from-wordpress-site';
     public final const PERSISTED_QUERY_IMPORT_POSTS_FROM_CSV = 'import-posts-from-csv';
+    public final const PERSISTED_QUERY_INSERT_BLOCK_IN_POST = 'insert-block-in-post';
     public final const PERSISTED_QUERY_INSERT_BLOCK_IN_POSTS = 'insert-block-in-posts';
     public final const PERSISTED_QUERY_REGEX_REPLACE_STRINGS_IN_POST = 'regex-replace-strings-in-post';
     public final const PERSISTED_QUERY_REGEX_REPLACE_STRINGS_IN_POSTS = 'regex-replace-strings-in-posts';

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Plugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Plugin.php
@@ -256,6 +256,7 @@ class Plugin extends AbstractMainPlugin
             '1.4' => [$this->installPluginSetupDataForVersion1Dot4(...)],
             '1.5' => [$this->installPluginSetupDataForVersion1Dot5(...)],
             '1.6' => [$this->installPluginSetupDataForVersion1Dot6(...)],
+            '2.1' => [$this->installPluginSetupDataForVersion2Dot1(...)],
         ];
     }
 
@@ -1463,6 +1464,40 @@ class Plugin extends AbstractMainPlugin
                             ],
                         ],
                         ...$defaultSchemaConfigurationPersistedQueryBlocks,
+                    ])),
+                ]
+            ));
+        }
+    }
+
+    protected function installPluginSetupDataForVersion2Dot1(): void
+    {
+        $instanceManager = InstanceManagerFacade::getInstance();
+
+        /** @var PersistedQueryEndpointGraphiQLBlock */
+        $persistedQueryEndpointGraphiQLBlock = $instanceManager->getInstance(PersistedQueryEndpointGraphiQLBlock::class);
+
+        $adminPersistedQueryOptions = $this->getAdminPersistedQueryOptions();
+        $nestedMutationsSchemaConfigurationPersistedQueryBlocks = $this->getNestedMutationsSchemaConfigurationPersistedQueryBlocks();
+
+        $slug = PluginSetupDataEntrySlugs::PERSISTED_QUERY_INSERT_BLOCK_IN_POST;
+        if (PluginSetupDataHelpers::getPersistedQueryEndpointID($slug, 'any') === null) {
+            \wp_insert_post(array_merge(
+                $adminPersistedQueryOptions,
+                [
+                    'post_name' => $slug,
+                    'post_title' => \__('Insert block in post', 'gatographql'),
+                    'post_content' => serialize_blocks($this->addInnerContentToBlockAtts([
+                        [
+                            'blockName' => $persistedQueryEndpointGraphiQLBlock->getBlockFullName(),
+                            'attrs' => [
+                                AbstractGraphiQLBlock::ATTRIBUTE_NAME_QUERY => $this->readSetupGraphQLPersistedQueryAndEncodeForOutput(
+                                    'admin/transform/insert-block-in-post',
+                                    TutorialLessons::INSERTING_REMOVING_A_GUTENBERG_BLOCK_IN_BULK,
+                                ),
+                            ],
+                        ],
+                        ...$nestedMutationsSchemaConfigurationPersistedQueryBlocks,
                     ])),
                 ]
             ));

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataComposers/GraphQLDocumentDataComposer.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataComposers/GraphQLDocumentDataComposer.php
@@ -218,5 +218,14 @@ class GraphQLDocumentDataComposer
     public function encodeGraphQLVariablesJSONForOutput(string $graphQLVariablesJSON): string
     {
         return $this->encodeGraphQLDocumentForOutput($graphQLVariablesJSON);
+        // return str_replace(
+        //     [
+        //         '\\n',
+        //     ],
+        //     [
+        //         '\\\\n',
+        //     ],
+        //     $this->encodeGraphQLDocumentForOutput($graphQLVariablesJSON)
+        // );
     }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataComposers/GraphQLDocumentDataComposer.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataComposers/GraphQLDocumentDataComposer.php
@@ -217,26 +217,6 @@ class GraphQLDocumentDataComposer
      */
     public function encodeGraphQLVariablesJSONForOutput(string $graphQLVariablesJSON): string
     {
-        return str_replace(
-            [
-                '\\',
-                PHP_EOL,
-                '"',
-                '&',
-                '-',
-                '<',
-                '>',
-            ],
-            [
-                '\\\\',
-                '\\n',
-                '\"',
-                '\&',
-                '\u002d',
-                '\<',
-                '\>',
-            ],
-            $graphQLVariablesJSON
-        );
+        return $this->encodeGraphQLDocumentForOutput($graphQLVariablesJSON);
     }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataComposers/GraphQLDocumentDataComposer.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataComposers/GraphQLDocumentDataComposer.php
@@ -217,16 +217,6 @@ class GraphQLDocumentDataComposer
      */
     public function encodeGraphQLVariablesJSONForOutput(string $graphQLVariablesJSON): string
     {
-        return str_replace(
-            [
-                PHP_EOL,
-                '"',
-            ],
-            [
-                '\\n',
-                '\"',
-            ],
-            $graphQLVariablesJSON
-        );
+        return $this->encodeGraphQLDocumentForOutput($graphQLVariablesJSON);
     }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataComposers/GraphQLDocumentDataComposer.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataComposers/GraphQLDocumentDataComposer.php
@@ -219,6 +219,7 @@ class GraphQLDocumentDataComposer
     {
         return str_replace(
             [
+                '\\',
                 PHP_EOL,
                 '"',
                 '&',
@@ -227,6 +228,7 @@ class GraphQLDocumentDataComposer
                 '>',
             ],
             [
+                '\\\\',
                 '\\n',
                 '\"',
                 '\&',

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataComposers/GraphQLDocumentDataComposer.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/DataComposers/GraphQLDocumentDataComposer.php
@@ -217,15 +217,24 @@ class GraphQLDocumentDataComposer
      */
     public function encodeGraphQLVariablesJSONForOutput(string $graphQLVariablesJSON): string
     {
-        return $this->encodeGraphQLDocumentForOutput($graphQLVariablesJSON);
-        // return str_replace(
-        //     [
-        //         '\\n',
-        //     ],
-        //     [
-        //         '\\\\n',
-        //     ],
-        //     $this->encodeGraphQLDocumentForOutput($graphQLVariablesJSON)
-        // );
+        return str_replace(
+            [
+                PHP_EOL,
+                '"',
+                '&',
+                '-',
+                '<',
+                '>',
+            ],
+            [
+                '\\n',
+                '\"',
+                '\&',
+                '\u002d',
+                '\<',
+                '\>',
+            ],
+            $graphQLVariablesJSON
+        );
     }
 }

--- a/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
+++ b/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
@@ -273,7 +273,7 @@ class BlockContentParser implements BlockContentParserInterface
         }
 
         if ($parsing_error) {
-        $error_message = sprintf('Error parsing post ID %d: %s', $post_id, /*$parsing_error->getMessage()*/\__('This post either does not contain block content, or its block content has errors. (Edit the post within the WordPress editor, fix the errors, save, and try again.)', 'gatographql'));
+            $error_message = sprintf('Error parsing post ID %d: %s', $post_id, /*$parsing_error->getMessage()*/\__('This post either does not contain block content, or its block content has errors. (Edit the post within the WordPress editor, fix the errors, save, and try again.)', 'gatographql'));
             return new WP_Error('vip-block-data-api-parser-error', $error_message, [
                 'status'  => 500,
                 'details' => $parsing_error->__toString(),


### PR DESCRIPTION
The newly-added persisted GraphQL query "Insert block in post" allows to inject a block in a post. It identifies the nth block of a given type (`wp:paragraph` by default) in a post, and places the provided custom block's HTML content right after it.

Used with the [Automation](https://gatographql.com/extensions/automation/) extension, this persisted query can be used to automatically inject mandatory blocks to a newly-published post (eg: a CTA block to promote an ongoing campaign).