### PR TITLE
Handle error from passing WP_Post as GraphQL variable to Internal GraphQL Server

### DIFF
--- a/layers/Engine/packages/component-model/src/FeedbackItemProviders/InputValueCoercionGraphQLSpecErrorFeedbackItemProvider.php
+++ b/layers/Engine/packages/component-model/src/FeedbackItemProviders/InputValueCoercionGraphQLSpecErrorFeedbackItemProvider.php
@@ -27,6 +27,7 @@ class InputValueCoercionGraphQLSpecErrorFeedbackItemProvider extends AbstractFee
     public final const E_5_6_1_17 = '5.6.1[17]';
     public final const E_5_6_1_18 = '5.6.1[18]';
     public final const E_5_6_1_19 = '5.6.1[19]';
+    public final const E_5_6_1_20 = '5.6.1[20]';
 
     protected function getNamespace(): string
     {
@@ -57,6 +58,7 @@ class InputValueCoercionGraphQLSpecErrorFeedbackItemProvider extends AbstractFee
             self::E_5_6_1_17,
             self::E_5_6_1_18,
             self::E_5_6_1_19,
+            self::E_5_6_1_20,
         ];
     }
 
@@ -81,6 +83,7 @@ class InputValueCoercionGraphQLSpecErrorFeedbackItemProvider extends AbstractFee
             self::E_5_6_1_17 => $this->__('Only strings or integers are allowed for type \'%s\'', 'component-model'),
             self::E_5_6_1_18 => $this->__('Enum values can only be strings, value \'%s\' for type \'%s\' is not allowed', 'component-model'),
             self::E_5_6_1_19 => $this->__('Property \'%s\' in oneof input object \'%s\' cannot receive `null`', 'component-model'),
+            self::E_5_6_1_20 => $this->__('Argument \'%s\' of type \'%s\' cannot be an object', 'component-model'),
             default => parent::getMessagePlaceholder($code),
         };
     }

--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
@@ -323,7 +323,7 @@ class InputCoercingService implements InputCoercingServiceInterface
             return array_map(
                 // If it contains a null value, return it as is
                 fn (array|ValueResolutionPromiseInterface|null $arrayArgValueElem) => ($arrayArgValueElem === null || $arrayArgValueElem instanceof ValueResolutionPromiseInterface) ? $arrayArgValueElem : array_map(
-                    fn (mixed $arrayOfArraysArgValueElem) => ($arrayOfArraysArgValueElem === null || $arrayOfArraysArgValueElem instanceof ValueResolutionPromiseInterface) ? $arrayOfArraysArgValueElem : $this->validateAndCoerceInputValue($inputTypeResolver, $arrayOfArraysArgValueElem, $astNode, $objectTypeFieldResolutionFeedbackStore),
+                    fn (mixed $arrayOfArraysArgValueElem) => ($arrayOfArraysArgValueElem === null || $arrayOfArraysArgValueElem instanceof ValueResolutionPromiseInterface) ? $arrayOfArraysArgValueElem : $this->validateAndCoerceInputValue($inputTypeResolver, $arrayOfArraysArgValueElem, $inputName, $astNode, $objectTypeFieldResolutionFeedbackStore),
                     $arrayArgValueElem
                 ),
                 $inputValue
@@ -333,12 +333,12 @@ class InputCoercingService implements InputCoercingServiceInterface
             /** @var mixed[] $inputValue */
             // If the value is an array, then cast each element to the item type
             return array_map(
-                fn (mixed $arrayArgValueElem) => ($arrayArgValueElem === null || $arrayArgValueElem instanceof ValueResolutionPromiseInterface) ? $arrayArgValueElem : $this->validateAndCoerceInputValue($inputTypeResolver, $arrayArgValueElem, $astNode, $objectTypeFieldResolutionFeedbackStore),
+                fn (mixed $arrayArgValueElem) => ($arrayArgValueElem === null || $arrayArgValueElem instanceof ValueResolutionPromiseInterface) ? $arrayArgValueElem : $this->validateAndCoerceInputValue($inputTypeResolver, $arrayArgValueElem, $inputName, $astNode, $objectTypeFieldResolutionFeedbackStore),
                 $inputValue
             );
         }
         // Otherwise, simply cast the given value directly
-        return $this->validateAndCoerceInputValue($inputTypeResolver, $inputValue, $astNode, $objectTypeFieldResolutionFeedbackStore);
+        return $this->validateAndCoerceInputValue($inputTypeResolver, $inputValue, $inputName, $astNode, $objectTypeFieldResolutionFeedbackStore);
     }
 
     /**
@@ -350,11 +350,25 @@ class InputCoercingService implements InputCoercingServiceInterface
     protected function validateAndCoerceInputValue(
         InputTypeResolverInterface $inputTypeResolver,
         string|int|float|bool|object $inputValue,
+        string $inputName,
         AstInterface $astNode,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): string|int|float|bool|object|null {
         if (is_object($inputValue) && !($inputValue instanceof stdClass)) {
-
+            $objectTypeFieldResolutionFeedbackStore->addError(
+                new ObjectTypeFieldResolutionFeedback(
+                    new FeedbackItemResolution(
+                        InputValueCoercionGraphQLSpecErrorFeedbackItemProvider::class,
+                        InputValueCoercionGraphQLSpecErrorFeedbackItemProvider::E_5_6_1_20,
+                        [
+                            $inputName,
+                            $inputTypeResolver->getMaybeNamespacedTypeName(),
+                        ]
+                    ),
+                    $astNode,
+                ),
+            );
+            return null;
         }
         return $inputTypeResolver->coerceValue(
             $inputValue,

--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
@@ -342,10 +342,10 @@ class InputCoercingService implements InputCoercingServiceInterface
     }
 
     /**
-     * Handle error from passing WP_Post as GraphQL variable,
-     * which is possible when executing a query via the
-     * Internal GraphQL Server, as variables are passed
-     * as a JSON.
+     * Handle error from passing WP_Post (or any object)
+     * as GraphQL variable, which is possible when executing
+     * a query via the Internal GraphQL Server, as variables
+     * are passed as a PHP array.
      */
     protected function validateAndCoerceInputValue(
         InputTypeResolverInterface $inputTypeResolver,

--- a/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
+++ b/layers/Engine/packages/component-model/src/Schema/InputCoercingService.php
@@ -323,7 +323,7 @@ class InputCoercingService implements InputCoercingServiceInterface
             return array_map(
                 // If it contains a null value, return it as is
                 fn (array|ValueResolutionPromiseInterface|null $arrayArgValueElem) => ($arrayArgValueElem === null || $arrayArgValueElem instanceof ValueResolutionPromiseInterface) ? $arrayArgValueElem : array_map(
-                    fn (mixed $arrayOfArraysArgValueElem) => ($arrayOfArraysArgValueElem === null || $arrayOfArraysArgValueElem instanceof ValueResolutionPromiseInterface) ? $arrayOfArraysArgValueElem : $this->validateAndCoerceValue($inputTypeResolver, $arrayOfArraysArgValueElem, $astNode, $objectTypeFieldResolutionFeedbackStore),
+                    fn (mixed $arrayOfArraysArgValueElem) => ($arrayOfArraysArgValueElem === null || $arrayOfArraysArgValueElem instanceof ValueResolutionPromiseInterface) ? $arrayOfArraysArgValueElem : $this->validateAndCoerceInputValue($inputTypeResolver, $arrayOfArraysArgValueElem, $astNode, $objectTypeFieldResolutionFeedbackStore),
                     $arrayArgValueElem
                 ),
                 $inputValue
@@ -333,12 +333,12 @@ class InputCoercingService implements InputCoercingServiceInterface
             /** @var mixed[] $inputValue */
             // If the value is an array, then cast each element to the item type
             return array_map(
-                fn (mixed $arrayArgValueElem) => ($arrayArgValueElem === null || $arrayArgValueElem instanceof ValueResolutionPromiseInterface) ? $arrayArgValueElem : $this->validateAndCoerceValue($inputTypeResolver, $arrayArgValueElem, $astNode, $objectTypeFieldResolutionFeedbackStore),
+                fn (mixed $arrayArgValueElem) => ($arrayArgValueElem === null || $arrayArgValueElem instanceof ValueResolutionPromiseInterface) ? $arrayArgValueElem : $this->validateAndCoerceInputValue($inputTypeResolver, $arrayArgValueElem, $astNode, $objectTypeFieldResolutionFeedbackStore),
                 $inputValue
             );
         }
         // Otherwise, simply cast the given value directly
-        return $this->validateAndCoerceValue($inputTypeResolver, $inputValue, $astNode, $objectTypeFieldResolutionFeedbackStore);
+        return $this->validateAndCoerceInputValue($inputTypeResolver, $inputValue, $astNode, $objectTypeFieldResolutionFeedbackStore);
     }
 
     /**
@@ -347,12 +347,15 @@ class InputCoercingService implements InputCoercingServiceInterface
      * Internal GraphQL Server, as variables are passed
      * as a JSON.
      */
-    protected function validateAndCoerceValue(
+    protected function validateAndCoerceInputValue(
         InputTypeResolverInterface $inputTypeResolver,
-        string|int|float|bool|stdClass $inputValue,
+        string|int|float|bool|object $inputValue,
         AstInterface $astNode,
         ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
     ): string|int|float|bool|object|null {
+        if (is_object($inputValue) && !($inputValue instanceof stdClass)) {
+
+        }
         return $inputTypeResolver->coerceValue(
             $inputValue,
             $astNode,

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -24,7 +24,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Bug in multi-control JS component used by extensions (Access Control, Cache Control, and Field Deprecation) showing "undefined" on the block on the Schema Configuration (#2639)
 - Bug in regex replacements in predefined persisted queries (#2649)
 - Avoid reinstalling plugin setup data if deactivating/reactivating the plugin (#2641)
-- Handle error from passing WP_Post as GraphQL variable
+- Handle error from passing WP_Post as GraphQL variable to the Internal GraphQL Server (#2652)
 
 ## 2.0.0 - 29/01/2014
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -24,6 +24,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Bug in multi-control JS component used by extensions (Access Control, Cache Control, and Field Deprecation) showing "undefined" on the block on the Schema Configuration (#2639)
 - Bug in regex replacements in predefined persisted queries (#2649)
 - Avoid reinstalling plugin setup data if deactivating/reactivating the plugin (#2641)
+- Handle error from passing WP_Post as GraphQL variable
 
 ## 2.0.0 - 29/01/2014
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.1/en.md
@@ -80,3 +80,4 @@ Used with the [Automation](https://gatographql.com/extensions/automation/) exten
 - Bug in multi-control JS component used by extensions (Access Control, Cache Control, and Field Deprecation) showing "undefined" on the block on the Schema Configuration (#2639)
 - Bug in regex replacements in predefined persisted queries (#2649)
 - Avoid reinstalling plugin setup data if deactivating/reactivating the plugin (#2641)
+- Handle error from passing WP_Post as GraphQL variable

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.1/en.md
@@ -80,4 +80,4 @@ Used with the [Automation](https://gatographql.com/extensions/automation/) exten
 - Bug in multi-control JS component used by extensions (Access Control, Cache Control, and Field Deprecation) showing "undefined" on the block on the Schema Configuration (#2639)
 - Bug in regex replacements in predefined persisted queries (#2649)
 - Avoid reinstalling plugin setup data if deactivating/reactivating the plugin (#2641)
-- Handle error from passing WP_Post as GraphQL variable
+- Handle error from passing WP_Post as GraphQL variable to the Internal GraphQL Server (#2652)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -180,7 +180,7 @@ You can even synchronize content across a network of sites, such as from an upst
 * Fixed bug in multi-control JS component used by extensions (Access Control, Cache Control, and Field Deprecation) showing "undefined" on the block on the Schema Configuration (#2639)
 * Fixed bug in regex replacements in predefined persisted queries (#2649)
 * Avoid reinstalling plugin setup data if deactivating/reactivating the plugin (#2641)
-* Handle error from passing WP_Post as GraphQL variable
+* Handle error from passing WP_Post as GraphQL variable to the Internal GraphQL Server (#2652)
 
 = 2.0.0 =
 * Added new module Media Mutations

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -180,6 +180,7 @@ You can even synchronize content across a network of sites, such as from an upst
 * Fixed bug in multi-control JS component used by extensions (Access Control, Cache Control, and Field Deprecation) showing "undefined" on the block on the Schema Configuration (#2639)
 * Fixed bug in regex replacements in predefined persisted queries (#2649)
 * Avoid reinstalling plugin setup data if deactivating/reactivating the plugin (#2641)
+* Handle error from passing WP_Post as GraphQL variable
 
 = 2.0.0 =
 * Added new module Media Mutations

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/Upstream/ComponentModel/InputValueCoercionQueryExecutionGraphQLServerTest.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/Upstream/ComponentModel/InputValueCoercionQueryExecutionGraphQLServerTest.php
@@ -56,7 +56,6 @@ class InputValueCoercionQueryExecutionGraphQLServerTest extends AbstractGraphQLS
             ],
         ];
         foreach ($items as $item) {
-            $item[2] ??= [];
             [$query, $expectedResponse, $variables] = $item;
             $this->assertGraphQLQueryExecution($query, $expectedResponse, $variables);
         }

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/Upstream/ComponentModel/InputValueCoercionQueryExecutionGraphQLServerTest.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/Upstream/ComponentModel/InputValueCoercionQueryExecutionGraphQLServerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GraphQLByPoP\GraphQLServer\Unit\Upstream\ComponentModel;
+
+use GraphQLByPoP\GraphQLServer\Unit\AbstractGraphQLServerTestCase;
+
+/**
+ * Test: Handle error from passing WP_Post as GraphQL variable
+ */
+class InputValueCoercionQueryExecutionGraphQLServerTest extends AbstractGraphQLServerTestCase
+{
+    public function testQueries(): void
+    {
+        $items = [
+            'var-object-not-supported' => [
+                '
+                query Echo($include: Boolean!) {
+                    id @include(if: $include)
+                }
+                ',
+                [
+                    "errors" => [
+                        [
+                            "message" => "Argument 'if' of type 'Boolean' cannot be an object",
+                            "locations" => [
+                                [
+                                    "line" => 3,
+                                    "column" => 37
+                                ]
+                            ],
+                            "extensions" => [
+                                "path" => [
+                                    "\$include",
+                                    "(if: \$include)",
+                                    "@include(if: \$include)",
+                                    "id @include(if: \$include)",
+                                    "query Echo(\$include: Boolean!) { ... }"
+                                ],
+                                "type" => "QueryRoot",
+                                "field" => "id @include(if: \$include)",
+                                "code" => "gql@5.6.1[20]",
+                                "specifiedBy" => "https://spec.graphql.org/draft/#sec-Values-of-Correct-Type"
+                            ]
+                        ]
+                    ],
+                    "data" => [
+                        "id" => null
+                    ]
+                ],
+                // Pass any non-stdClass object here
+                [
+                    'include' => static::getGraphQLServer(),
+                ]
+            ],
+        ];
+        foreach ($items as $item) {
+            $item[2] ??= [];
+            [$query, $expectedResponse, $variables] = $item;
+            $this->assertGraphQLQueryExecution($query, $expectedResponse, $variables);
+        }
+    }
+}

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/Upstream/ComponentModel/VariablesQueryExecutionGraphQLServerTest.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/Upstream/ComponentModel/VariablesQueryExecutionGraphQLServerTest.php
@@ -60,46 +60,6 @@ class VariablesQueryExecutionGraphQLServerTest extends AbstractGraphQLServerTest
                     ],
                 ],
             ],
-            'var-object-not-supported' => [
-                '
-                query Echo($include: Boolean!) {
-                    id @include(if: $include)
-                }
-                ',
-                [
-                    "errors" => [
-                        [
-                            "message" => "Argument 'if' of type 'Boolean' cannot be an object",
-                            "locations" => [
-                                [
-                                    "line" => 3,
-                                    "column" => 37
-                                ]
-                            ],
-                            "extensions" => [
-                                "path" => [
-                                    "\$include",
-                                    "(if: \$include)",
-                                    "@include(if: \$include)",
-                                    "id @include(if: \$include)",
-                                    "query Echo(\$include: Boolean!) { ... }"
-                                ],
-                                "type" => "QueryRoot",
-                                "field" => "id @include(if: \$include)",
-                                "code" => "gql@5.6.1[20]",
-                                "specifiedBy" => "https://spec.graphql.org/draft/#sec-Values-of-Correct-Type"
-                            ]
-                        ]
-                    ],
-                    "data" => [
-                        "id" => null
-                    ]
-                ],
-                // Pass any non-stdClass object here
-                [
-                    'include' => static::getGraphQLServer(),
-                ]
-            ],
         ];
         foreach ($items as $item) {
             $item[2] ??= [];

--- a/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/Upstream/ComponentModel/VariablesQueryExecutionGraphQLServerTest.php
+++ b/layers/GraphQLByPoP/packages/graphql-server/tests/Unit/Upstream/ComponentModel/VariablesQueryExecutionGraphQLServerTest.php
@@ -60,6 +60,46 @@ class VariablesQueryExecutionGraphQLServerTest extends AbstractGraphQLServerTest
                     ],
                 ],
             ],
+            'var-object-not-supported' => [
+                '
+                query Echo($include: Boolean!) {
+                    id @include(if: $include)
+                }
+                ',
+                [
+                    "errors" => [
+                        [
+                            "message" => "Argument 'if' of type 'Boolean' cannot be an object",
+                            "locations" => [
+                                [
+                                    "line" => 3,
+                                    "column" => 37
+                                ]
+                            ],
+                            "extensions" => [
+                                "path" => [
+                                    "\$include",
+                                    "(if: \$include)",
+                                    "@include(if: \$include)",
+                                    "id @include(if: \$include)",
+                                    "query Echo(\$include: Boolean!) { ... }"
+                                ],
+                                "type" => "QueryRoot",
+                                "field" => "id @include(if: \$include)",
+                                "code" => "gql@5.6.1[20]",
+                                "specifiedBy" => "https://spec.graphql.org/draft/#sec-Values-of-Correct-Type"
+                            ]
+                        ]
+                    ],
+                    "data" => [
+                        "id" => null
+                    ]
+                ],
+                // Pass any non-stdClass object here
+                [
+                    'include' => static::getGraphQLServer(),
+                ]
+            ],
         ];
         foreach ($items as $item) {
             $item[2] ??= [];


### PR DESCRIPTION
Handle error from passing `WP_Post` (or any object) as a GraphQL variable, which is possible when executing a query via the Internal GraphQL Server, as variables are passed as a PHP array.