### PR TITLE
"html" source was adapted to "rich-text" on WP 6.5

### DIFF
--- a/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
+++ b/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
@@ -410,7 +410,7 @@ class BlockContentParser implements BlockContentParserInterface
             // https://github.com/WordPress/gutenberg/pull/8276
 
             $attribute_value = $this->source_block_attribute($crawler, $block_attribute_definition);
-        } elseif ('html' === $attribute_source) {
+        } elseif ('html' === $attribute_source || 'rich-text' === $attribute_source) {
             $attribute_value = $this->source_block_html($crawler, $block_attribute_definition);
         } elseif ('text' === $attribute_source) {
             $attribute_value = $this->source_block_text($crawler, $block_attribute_definition);

--- a/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
+++ b/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
@@ -411,6 +411,9 @@ class BlockContentParser implements BlockContentParserInterface
 
             $attribute_value = $this->source_block_attribute($crawler, $block_attribute_definition);
         } elseif ('html' === $attribute_source || 'rich-text' === $attribute_source) {
+            // 'html' source was converted to 'rich-text' in WordPress 6.5.
+            // https://github.com/WordPress/gutenberg/commit/6a42225124e69276a2deec4597a855bb504b37cc
+
             $attribute_value = $this->source_block_html($crawler, $block_attribute_definition);
         } elseif ('text' === $attribute_source) {
             $attribute_value = $this->source_block_text($crawler, $block_attribute_definition);


### PR DESCRIPTION
Starting from WordPress 6.5, `core/table` (and several other) blocks have the `source` attribute as `rich-text` instead of `html`, so adapt it:

- https://github.com/WordPress/gutenberg/commit/6a42225124e69276a2deec4597a855bb504b37cc