### PR TITLE
Point Support form to Netlify v5 runtime URL

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -10,7 +10,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Fixed
 
-- Updated the Support form's action URL
+- Updated the Support form's action URL (#2662)
 
 ## 2.2.3 - 26/04/2024
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,6 +6,12 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 2.3.0 - DATE
 
+## 2.2.4 - DATE
+
+### Fixed
+
+- Updated the Support form's action URL
+
 ## 2.2.3 - 26/04/2024
 
 ### Fixed

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/general/about/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/general/about/en.md
@@ -36,7 +36,7 @@ _Support is provided to customers of any Gato GraphQL product (bundles or extens
 
 Send your message to the Gato GraphQL Support team:
 
-<form action="https://gatographql.com/support/success" method="POST" name="support" target="_blank">
+<form action="https://gatographql.com/__forms/support.html" method="POST" name="support" target="_blank">
   <input type="hidden" name="form-name" value="support" />
 
   <label for="field-name">Your name:</label>

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.2/en.md
@@ -7,6 +7,7 @@
 - Tested up WordPress 6.5 (`v2.2.2`)
 - Renamed "Tutorial" to "Schema tutorial" (`v2.2.2`)
 - Bug parsing `@export(as: $someVar)` ([#2661](https://github.com/GatoGraphQL/GatoGraphQL/pull/2661)) (`v2.2.3`)
+- Updated the Support form's action URL
 
 ### Do not include bundles in the Extensions page
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.2/en.md
@@ -7,7 +7,7 @@
 - Tested up WordPress 6.5 (`v2.2.2`)
 - Renamed "Tutorial" to "Schema tutorial" (`v2.2.2`)
 - Bug parsing `@export(as: $someVar)` ([#2661](https://github.com/GatoGraphQL/GatoGraphQL/pull/2661)) (`v2.2.3`)
-- Updated the Support form's action URL
+- Updated the Support form's action URL ([#2662](https://github.com/GatoGraphQL/GatoGraphQL/pull/2662)) (`v2.2.4`)
 
 ### Do not include bundles in the Extensions page
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -257,7 +257,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 == Changelog ==
 
 = 2.2.4 =
-* Updated the Support form's action URL
+* Updated the Support form's action URL (#2662)
 
 = 2.2.3 =
 * Bug parsing `@export(as: $someVar)` (#2661)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -256,6 +256,9 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 
 == Changelog ==
 
+= 2.2.4 =
+* Updated the Support form's action URL
+
 = 2.2.3 =
 * Bug parsing `@export(as: $someVar)` (#2661)
 


### PR DESCRIPTION
After changing Netlify's Nextjs runtime to v5 on gatographql.com, there are [breaking changes](https://docs.netlify.com/frameworks/next-js/overview/#breaking-changes), so this PR updates the Support form to the new URL