### PR TITLE
Support alternative filenames from 3rd-party plugins for extensions

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -17,6 +17,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - [PRO] Translate posts for Polylang (Classic editor) (#2667)
   - [PRO] Sync featured image for Polylang (#2669)
   - [PRO] Sync tags and categories for Polylang (#2670)
+- Support alternative filenames from 3rd-party plugins for extensions
 
 ### Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -17,7 +17,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - [PRO] Translate posts for Polylang (Classic editor) (#2667)
   - [PRO] Sync featured image for Polylang (#2669)
   - [PRO] Sync tags and categories for Polylang (#2670)
-- Support alternative filenames from 3rd-party plugins for extensions
+- Support alternative filenames from 3rd-party plugins for extensions (#2671)
 
 ### Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.3/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.3/en.md
@@ -54,7 +54,7 @@ For instance, to work with WooCommerce, we can currently use field `Root.updateC
 
 However, we cannot create an WooCommerce product. For that, we must wait until the "WooCommerce for Gato GraphQL" extension is available.
 
-## Support alternative filenames from 3rd-party plugins for extensions
+## Support alternative filenames from 3rd-party plugins for extensions ([#2671](https://github.com/GatoGraphQL/GatoGraphQL/pull/2671))
 
 Gato GraphQL extensions with 3rd-party plugins now support alternative filenames from the plugin, where any of them being active will make the extension be enabled.
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.3/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.3/en.md
@@ -54,6 +54,12 @@ For instance, to work with WooCommerce, we can currently use field `Root.updateC
 
 However, we cannot create an WooCommerce product. For that, we must wait until the "WooCommerce for Gato GraphQL" extension is available.
 
+## Support alternative filenames from 3rd-party plugins for extensions
+
+Gato GraphQL extensions with 3rd-party plugins now support alternative filenames from the plugin, where any of them being active will make the extension be enabled.
+
+For instance, the Polylang extension in Gato GraphQL PRO will be enabled if either `polylang/polylang.php` or `polylang-pro/polylang.php` is active.
+
 ## [PRO] Improvements
 
 - Added automation rules:

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -263,6 +263,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 * Return an EnumString type on `GenericCategory.taxonomy` and `GenericTag.taxonomy` (#2666)
 * Fix bug: Updated the Support form's action URL (#2662)
 * Added predefined persisted queries: "[PRO] Translate posts for Polylang (Gutenberg)" (#2667), "[PRO] Translate posts for Polylang (Classic editor)" (#2667), "[PRO] Sync featured image for Polylang" (#2669) and "[PRO] Sync tags and categories for Polylang" (#2670)
+* Support alternative filenames from 3rd-party plugins for extensions
 * [PRO] Added integration with Polylang
 * [PRO] Added automation rules: "Polylang: When publishing a post, translate it to all languages (Gutenberg)", "Polylang: When publishing a post, translate it to all languages (Classic editor)", "Polylang: When publishing a post, set the featured image for each language on all translation posts" and "Polylang: When publishing a post, set the tags and categories for each language on all translation posts"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -263,7 +263,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 * Return an EnumString type on `GenericCategory.taxonomy` and `GenericTag.taxonomy` (#2666)
 * Fix bug: Updated the Support form's action URL (#2662)
 * Added predefined persisted queries: "[PRO] Translate posts for Polylang (Gutenberg)" (#2667), "[PRO] Translate posts for Polylang (Classic editor)" (#2667), "[PRO] Sync featured image for Polylang" (#2669) and "[PRO] Sync tags and categories for Polylang" (#2670)
-* Support alternative filenames from 3rd-party plugins for extensions
+* Support alternative filenames from 3rd-party plugins for extensions (#2671)
 * [PRO] Added integration with Polylang
 * [PRO] Added automation rules: "Polylang: When publishing a post, translate it to all languages (Gutenberg)", "Polylang: When publishing a post, translate it to all languages (Classic editor)", "Polylang: When publishing a post, set the featured image for each language on all translation posts" and "Polylang: When publishing a post, set the tags and categories for each language on all translation posts"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/ObjectModels/AbstractDependedOnWordPressPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/ObjectModels/AbstractDependedOnWordPressPlugin.php
@@ -15,8 +15,8 @@ abstract class AbstractDependedOnWordPressPlugin
     public function __construct(
         public readonly string $name,
         public readonly string $file,
-        ?string $url = null,
         public readonly array $alternativeFiles = [],
+        ?string $url = null,
     ) {
         $this->slug = $this->extractSlugFromPluginFile($file);
         $this->url = $this->calculateURL($url, $this->slug);

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/ObjectModels/AbstractDependedOnWordPressPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/ObjectModels/AbstractDependedOnWordPressPlugin.php
@@ -9,10 +9,14 @@ abstract class AbstractDependedOnWordPressPlugin
     public readonly string $slug;
     public readonly string $url;
 
+    /**
+     * @param string[] $alternativeFiles
+     */
     public function __construct(
         public readonly string $name,
         public readonly string $file,
         ?string $url = null,
+        public readonly array $alternativeFiles = [],
     ) {
         $this->slug = $this->extractSlugFromPluginFile($file);
         $this->url = $this->calculateURL($url, $this->slug);

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/ObjectModels/DependedOnActiveWordPressPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/ObjectModels/DependedOnActiveWordPressPlugin.php
@@ -6,16 +6,21 @@ namespace GatoGraphQL\GatoGraphQL\ObjectModels;
 
 final class DependedOnActiveWordPressPlugin extends AbstractDependedOnWordPressPlugin
 {
+    /**
+     * @param string[] $alternativeFiles
+     */
     public function __construct(
         string $name,
         string $file,
         public readonly ?string $versionConstraint = null,
         ?string $url = null,
+        array $alternativeFiles = [],
     ) {
         parent::__construct(
             $name,
             $file,
             $url,
+            $alternativeFiles,
         );
     }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/ObjectModels/DependedOnActiveWordPressPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/ObjectModels/DependedOnActiveWordPressPlugin.php
@@ -13,14 +13,14 @@ final class DependedOnActiveWordPressPlugin extends AbstractDependedOnWordPressP
         string $name,
         string $file,
         public readonly ?string $versionConstraint = null,
-        ?string $url = null,
         array $alternativeFiles = [],
+        ?string $url = null,
     ) {
         parent::__construct(
             $name,
             $file,
-            $url,
             $alternativeFiles,
+            $url,
         );
     }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Registries/ModuleRegistry.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Registries/ModuleRegistry.php
@@ -234,7 +234,18 @@ class ModuleRegistry implements ModuleRegistryInterface
          */
         foreach ($moduleResolver->getDependentOnActiveWordPressPlugins($module) as $dependedActivePlugin) {
             // Check that all required plugins are active
-            if (!PluginStaticHelpers::isWordPressPluginActive($dependedActivePlugin->file)) {
+            $activeFile = null;
+            if (PluginStaticHelpers::isWordPressPluginActive($dependedActivePlugin->file)) {
+                $activeFile = $dependedActivePlugin->file;
+            } else {
+                foreach ($dependedActivePlugin->alternativeFiles as $alternativeFile) {
+                    if (PluginStaticHelpers::isWordPressPluginActive($alternativeFile)) {
+                        $activeFile = $alternativeFile;
+                        break;
+                    }
+                }
+            }
+            if ($activeFile === null) {
                 return false;
             }
 
@@ -245,7 +256,7 @@ class ModuleRegistry implements ModuleRegistryInterface
 
             if (
                 !PluginStaticHelpers::doesActivePluginSatisfyVersionConstraint(
-                    $dependedActivePlugin->file,
+                    $activeFile,
                     $dependedActivePlugin->versionConstraint
                 )
             ) {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Registries/ModuleRegistry.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Registries/ModuleRegistry.php
@@ -272,6 +272,11 @@ class ModuleRegistry implements ModuleRegistryInterface
             if (PluginStaticHelpers::isWordPressPluginActive($dependedInactivePlugin->file)) {
                 return false;
             }
+            foreach ($dependedInactivePlugin->alternativeFiles as $alternativeFile) {
+                if (PluginStaticHelpers::isWordPressPluginActive($alternativeFile)) {
+                    return false;
+                }
+            }
         }
 
         return true;


### PR DESCRIPTION
Gato GraphQL extensions with 3rd-party plugins now support alternative filenames from the plugin, where any of them being active will make the extension be enabled.

For instance, the Polylang extension in Gato GraphQL PRO will be enabled if either `polylang/polylang.php` or `polylang-pro/polylang.php` is active.