### PR TITLE
Append full path to endpoint in GraphiQL client because of Multisite

### DIFF
--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/WPClientTrait.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/WPClientTrait.php
@@ -10,6 +10,8 @@ use GraphQLByPoP\GraphQLEndpointForWP\Module as GraphQLEndpointForWPModule;
 use GraphQLByPoP\GraphQLEndpointForWP\ModuleConfiguration as GraphQLEndpointForWPModuleConfiguration;
 use PoP\Root\App;
 
+use function get_site_url;
+
 trait WPClientTrait
 {
     /**

--- a/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/WPClientTrait.php
+++ b/layers/GraphQLByPoP/packages/graphql-clients-for-wp/src/Clients/WPClientTrait.php
@@ -36,6 +36,13 @@ trait WPClientTrait
     {
         /** @var GraphQLEndpointForWPModuleConfiguration */
         $moduleConfiguration = App::getModule(GraphQLEndpointForWPModule::class)->getConfiguration();
-        return $moduleConfiguration->getGraphQLAPIEndpoint();
+        $endpoint = $moduleConfiguration->getGraphQLAPIEndpoint();
+
+        /**
+         * Because of the Multisite network based on subfolders,
+         * which has the path embedded within the domain,
+         * we must pass the full path
+         */
+        return untrailingslashit(get_site_url()) . $endpoint;
     }
 }


### PR DESCRIPTION
Continuation of #2677 to fix loading the endpoint in the GraphiQL client