### PR TITLE
GraphiQL client (for LocalWP) now uses site URL as endpoint

### DIFF
--- a/layers/Engine/packages/component-model/src/Misc/GeneralUtils.php
+++ b/layers/Engine/packages/component-model/src/Misc/GeneralUtils.php
@@ -122,7 +122,7 @@ class GeneralUtils
         return rtrim($text, '/\\') . '/';
     }
 
-    public static function getDomain(string $url): string
+    public static function getDomain(string $url, bool $withPort = false): string
     {
         $url_parts = parse_url($url);
         if (!is_array($url_parts)) {
@@ -130,7 +130,14 @@ class GeneralUtils
         }
         $scheme = isset($url_parts['scheme']) ? $url_parts['scheme'] . '://' : '';
         $host = $url_parts['host'] ?? '';
-        return $scheme . $host;
+        $port = '';
+        if ($withPort) {
+            $port = $url_parts['port'] ?? '';
+            if ($port) {
+                $port = ':' . $port;
+            }
+        }
+        return $scheme . $host . $port;
     }
 
     public static function getHost(string $url): string
@@ -144,7 +151,7 @@ class GeneralUtils
 
     public static function removeDomain(string $url): string
     {
-        return substr($url, strlen(self::getDomain($url)));
+        return substr($url, strlen(self::getDomain($url, true)));
     }
 
     public static function getPath(string $url): string

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -21,6 +21,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Fixed
 
 - Highlight extensions and enable link to visit in website (#2674)
+- GraphiQL client (for LocalWP) now uses site URL as endpoint (#2686)
 
 ## 2.3.0 - 08/05/2024
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.4/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.4/en.md
@@ -162,3 +162,4 @@ query GetDataFromExternalWPSite(
 ## Fixed
 
 - Highlight extensions and enable link to visit in website ([#2674](https://github.com/GatoGraphQL/GatoGraphQL/pull/2674))
+- GraphiQL client (for LocalWP) now uses site URL as endpoint ([#2686](https://github.com/GatoGraphQL/GatoGraphQL/pull/2686))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -281,6 +281,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 * Link extensions to the Extensions Reference in gatographql.com (#2675)
 * Added YouTube channel link to About page (#2676)
 * Fixed: Highlight extensions and enable link to visit in website (#2674)
+* Fixed: GraphiQL client (for LocalWP) now uses site URL as endpoint (#2686)
 
 = 2.3.0 =
 * Added fields `GenericCustomPost.update`, `Root.updateCustomPost` and `Root.createCustomPost` (#2663)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Clients/CustomEndpointClientTrait.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Clients/CustomEndpointClientTrait.php
@@ -8,6 +8,7 @@ use GatoGraphQL\GatoGraphQL\AppHelpers;
 use GatoGraphQL\GatoGraphQL\Constants\RequestParams;
 use GatoGraphQL\GatoGraphQL\Services\CustomPostTypes\GraphQLCustomEndpointCustomPostType;
 use PoP\ComponentModel\HelperServices\RequestHelperServiceInterface;
+use PoP\ComponentModel\Misc\GeneralUtils;
 
 trait CustomEndpointClientTrait
 {
@@ -41,6 +42,17 @@ trait CustomEndpointClientTrait
 
         // Remove the ?view=...
         $endpointURL = \remove_query_arg(RequestParams::VIEW, $fullURL);
+
+        /**
+         * When using LocalWP, the port "10003" is somehow added to the URL,
+         * and it doesn't work anymore.
+         *
+         * Then, simply use the path from the current URL, and retrieve the
+         * domain from the WP site
+         */
+        $endpointPath = GeneralUtils::removeDomain($endpointURL);
+        $endpointURL = untrailingslashit(get_site_url()) . $endpointPath;
+        
         // // Maybe add ?use_namespace=true
         // /** @var ComponentModelModuleConfiguration */
         // $moduleConfiguration = \PoP\Root\App::getModule(ComponentModelModule::class)->getConfiguration();

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Clients/CustomEndpointClientTrait.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Clients/CustomEndpointClientTrait.php
@@ -52,7 +52,7 @@ trait CustomEndpointClientTrait
          */
         $endpointPath = GeneralUtils::removeDomain($endpointURL);
         $endpointURL = untrailingslashit(get_site_url()) . $endpointPath;
-        
+
         // // Maybe add ?use_namespace=true
         // /** @var ComponentModelModuleConfiguration */
         // $moduleConfiguration = \PoP\Root\App::getModule(ComponentModelModule::class)->getConfiguration();


### PR DESCRIPTION
When using LocalWP, the port "10003" is somehow added to the URL, and retrieving data from the GraphQL server doesn't work anymore.

As solution, use the path from the current URL, but retrieve the domain from the WP site (using `get_site_url()`)