### PR TITLE
GraphiQL client (for LocalWP) now uses site URL as endpoint (continuation)

### DIFF
--- a/layers/Engine/packages/component-model/src/HelperServices/RequestHelperService.php
+++ b/layers/Engine/packages/component-model/src/HelperServices/RequestHelperService.php
@@ -29,27 +29,7 @@ class RequestHelperService implements RequestHelperServiceInterface
             return null;
         }
 
-        $s = App::server("HTTPS") === "on" ? "s" : "";
-        $sp = strtolower(App::server("SERVER_PROTOCOL"));
-        $pos = strpos($sp, "/");
-        if ($pos === false) {
-            $pos = null;
-        }
-        $protocol = substr($sp, 0, $pos) . $s;
-        /**
-         * The default ports (80 for HTTP and 443 for HTTPS) must be ignored
-         */
-        $isDefaultPort = $s ? in_array(App::server("SERVER_PORT"), ["443", "80"]) : App::server("SERVER_PORT") == "80";
-        $port = $isDefaultPort ? "" : (":" . App::server("SERVER_PORT"));
-        /**
-         * If accessing from Nginx, the server_name might point to localhost
-         * instead of the actual server domain. So provide the change to use
-         * the user-requested host
-         *
-         * @see https://stackoverflow.com/questions/2297403/what-is-the-difference-between-http-host-and-server-name-in-php
-         */
-        $host = $useHostRequestedByClient ? App::server('HTTP_HOST') : App::server('SERVER_NAME');
-        return $protocol . "://" . $host . $port . App::server('REQUEST_URI');
+        return App::getRequest()->getRequestUri();
     }
 
     public function getComponentModelCurrentURL(): ?string

--- a/layers/Engine/packages/component-model/src/HelperServices/RequestHelperService.php
+++ b/layers/Engine/packages/component-model/src/HelperServices/RequestHelperService.php
@@ -23,7 +23,7 @@ class RequestHelperService implements RequestHelperServiceInterface
      *
      * @param bool $useHostRequestedByClient If true, get the host from user-provided HTTP_HOST, otherwise from the server-defined SERVER_NAME
      */
-    public function getRequestedFullURL(bool $useHostRequestedByClient = false): ?string
+    public function getRequestedFullURL(): ?string
     {
         if (!App::isHTTPRequest()) {
             return null;

--- a/layers/Engine/packages/component-model/src/HelperServices/RequestHelperService.php
+++ b/layers/Engine/packages/component-model/src/HelperServices/RequestHelperService.php
@@ -20,8 +20,6 @@ class RequestHelperService implements RequestHelperServiceInterface
 
     /**
      * Return the requested full URL
-     *
-     * @param bool $useHostRequestedByClient If true, get the host from user-provided HTTP_HOST, otherwise from the server-defined SERVER_NAME
      */
     public function getRequestedFullURL(): ?string
     {
@@ -29,7 +27,7 @@ class RequestHelperService implements RequestHelperServiceInterface
             return null;
         }
 
-        return App::getRequest()->getRequestUri();
+        return App::getRequest()->getSchemeAndHttpHost() . App::getRequest()->getRequestUri();
     }
 
     public function getComponentModelCurrentURL(): ?string

--- a/layers/Engine/packages/component-model/src/HelperServices/RequestHelperServiceInterface.php
+++ b/layers/Engine/packages/component-model/src/HelperServices/RequestHelperServiceInterface.php
@@ -8,10 +8,8 @@ interface RequestHelperServiceInterface
 {
     /**
      * Return the requested full URL
-     *
-     * @param boolean $useHostRequestedByClient If true, get the host from user-provided HTTP_HOST, otherwise from the server-defined SERVER_NAME
      */
-    public function getRequestedFullURL(bool $useHostRequestedByClient = false): ?string;
+    public function getRequestedFullURL(): ?string;
 
     /**
      * Return the URL that is useful to the component model:

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Clients/CustomEndpointClientTrait.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Clients/CustomEndpointClientTrait.php
@@ -34,7 +34,7 @@ trait CustomEndpointClientTrait
          * If accessing from Nginx, the server_name might point to localhost
          * instead of the actual server domain. So use the user-requested host
          */
-        $fullURL = $this->getRequestHelperService()->getRequestedFullURL(true);
+        $fullURL = $this->getRequestHelperService()->getRequestedFullURL();
         if ($fullURL === null) {
             return null;
         }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Clients/CustomEndpointClientTrait.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Clients/CustomEndpointClientTrait.php
@@ -8,7 +8,6 @@ use GatoGraphQL\GatoGraphQL\AppHelpers;
 use GatoGraphQL\GatoGraphQL\Constants\RequestParams;
 use GatoGraphQL\GatoGraphQL\Services\CustomPostTypes\GraphQLCustomEndpointCustomPostType;
 use PoP\ComponentModel\HelperServices\RequestHelperServiceInterface;
-use PoP\ComponentModel\Misc\GeneralUtils;
 
 trait CustomEndpointClientTrait
 {
@@ -42,16 +41,6 @@ trait CustomEndpointClientTrait
 
         // Remove the ?view=...
         $endpointURL = \remove_query_arg(RequestParams::VIEW, $fullURL);
-
-        /**
-         * When using LocalWP, the port "10003" is somehow added to the URL,
-         * and it doesn't work anymore.
-         *
-         * Then, simply use the path from the current URL, and retrieve the
-         * domain from the WP site
-         */
-        $endpointPath = GeneralUtils::removeDomain($endpointURL);
-        $endpointURL = untrailingslashit(get_site_url()) . $endpointPath;
 
         // // Maybe add ?use_namespace=true
         // /** @var ComponentModelModuleConfiguration */


### PR DESCRIPTION
Continuation of #2686 to fix bug: Directly use Symfony's `getRequestUri()` method