### PR TITLE
Added documentation for "WordPress hook mapping" for the [PRO] Automation extension

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 2.5.0 - DATE
 
+### Improvements
+
+- Added documentation for "WordPress hook mapping" for the [PRO] Automation extension
+
 ## 2.4.0 - 23/05/2024
 
 ### Improvements

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -8,7 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Improvements
 
-- Added documentation for "WordPress hook mapping" for the [PRO] Automation extension
+- Added documentation for "WordPress hook mapping" for the [PRO] Automation extension (#2691)
 
 ## 2.4.0 - 23/05/2024
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.5/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.5/en.md
@@ -2,7 +2,7 @@
 
 ## Improvements
 
-### Added documentation for "WordPress hook mapping" for the [PRO] Automation extension
+### Added documentation for "WordPress hook mapping" for the [PRO] Automation extension ([#2691](https://github.com/GatoGraphQL/GatoGraphQL/pull/2691))
 
 There are WordPress hooks which cannot be directly used in the Automation Configurator, because they provide a PHP object via the hook, which can't be input as a GraphQL variable.
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.5/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.5/en.md
@@ -2,3 +2,10 @@
 
 ## Improvements
 
+### Added documentation for "WordPress hook mapping" for the [PRO] Automation extension
+
+There are WordPress hooks which cannot be directly used in the Automation Configurator, because they provide a PHP object via the hook, which can't be input as a GraphQL variable.
+
+Starting from `v2.5` of Gato GraphQL PRO, several of these hooks have been mapped, by triggering a new hook prepended with `gatographql:` and the same hook name, and passing the corresponding object ID as a variable, which can be input as a GraphQL variable.
+
+For instance, WordPress hook `draft_to_publish` passes the `$post` as variable (of type `WP_Post`). Gato GraphQL PRO maps this hook as `gatographql:draft_to_publish`, and passes the `$postId` (of type `int`) as variable.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/automation/docs/modules/automation/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/automation/docs/modules/automation/en.md
@@ -87,6 +87,20 @@ If the same key is used for the "dynamic" and "static" GraphQL variables (see **
 
 </div>
 
+### WordPress hook mapping
+
+There are WordPress hooks which cannot be directly used in the Automation Configurator, because they provide a PHP object via the hook, which can't be input as a GraphQL variable.
+
+Several of these hooks have been mapped by Gato GraphQL, by triggering a new hook prepended with `gatographql:` and the same hook name, and passing the corresponding object ID as a variable, which can be input as a GraphQL variable.
+
+For instance, WordPress hook `draft_to_publish` passes the `$post` as variable (of type `WP_Post`). Gato GraphQL maps this hook as `gatographql:draft_to_publish`, and passes the `$postId` (of type `int`) as variable.
+
+The following table lists down the mapped WordPress hooks:
+
+| WordPress hook | Mapped hook by Gato GraphQL |
+| --- | --- |
+| `do_action( “{$old_status}_to_{$new_status}”, WP_Post $post )` | `do_action( “gatographql:{$old_status}_to_{$new_status}”, int $postId )` (eg: `gatographql:draft_to_publish`) |
+
 ### Debugging issues
 
 If the automation hasn't been executed, there could be an error with the configuration of the automation, or execution of the persisted query.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/automation/docs/modules/automation/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/automation/docs/modules/automation/en.md
@@ -99,7 +99,7 @@ The following table lists down the mapped WordPress hooks:
 
 | WordPress hook | Mapped hook by Gato GraphQL |
 | --- | --- |
-| `do_action( “{$old_status}_to_{$new_status}”, WP_Post $post )` | `do_action( “gatographql:{$old_status}_to_{$new_status}”, int $postId )` (eg: `gatographql:draft_to_publish`) |
+| [`{$old_status}_to_{$new_status}`](https://developer.wordpress.org/reference/hooks/old_status_to_new_status/) (passing `WP_Post $post`) | `gatographql:{$old_status}_to_{$new_status}` (passing `int $postId`) |
 
 ### Debugging issues
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -270,6 +270,9 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 
 == Changelog ==
 
+= 2.5.0 =
+* Added documentation for "WordPress hook mapping" for the [PRO] Automation extension
+
 = 2.4.1 =
 * Fixed bug: Internal server error from passing string when expected int 
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -271,7 +271,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 == Changelog ==
 
 = 2.5.0 =
-* Added documentation for "WordPress hook mapping" for the [PRO] Automation extension
+* Added documentation for "WordPress hook mapping" for the [PRO] Automation extension (#2691)
 
 = 2.4.1 =
 * Fixed bug: Internal server error from passing string when expected int 


### PR DESCRIPTION
There are WordPress hooks which cannot be directly used in the Automation Configurator, because they provide a PHP object via the hook, which can't be input as a GraphQL variable.

Starting from `v2.5` of Gato GraphQL PRO, several of these hooks have been mapped, by triggering a new hook prepended with `gatographql:` and the same hook name, and passing the corresponding object ID as a variable, which can be input as a GraphQL variable.

For instance, WordPress hook `draft_to_publish` passes the `$post` as variable (of type `WP_Post`). Gato GraphQL PRO maps this hook as `gatographql:draft_to_publish`, and passes the `$postId` (of type `int`) as variable.

This PR adds documentation for the Automation extension, listing down the mapped WordPress hooks:

| WordPress hook | Mapped hook by Gato GraphQL |
| --- | --- |
| [`{$old_status}_to_{$new_status}`](https://developer.wordpress.org/reference/hooks/old_status_to_new_status/) (passing `WP_Post $post`) | `gatographql:{$old_status}_to_{$new_status}` (passing `int $postId`) |