### PR TITLE
Add `siteURL` field

### DIFF
--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/site.gql
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/site.gql
@@ -1,4 +1,5 @@
 {
+  siteURL
   siteLocale
   siteLanguage
 }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/site.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/site.json
@@ -1,5 +1,6 @@
 {
     "data": {
+        "siteURL": "https://gatographql.lndo.site",
         "siteLocale": "en_US",
         "siteLanguage": "en"
     }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -8,6 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Improvements
 
+- Added `siteURL` field (#2697)
 - Added GraphQL variable `$translateFromLanguage` to persisted query "[PRO] Translate posts for Polylang (Gutenberg)"
 
 ## 2.5.2 - 06/06/2024

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/schema-settings/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/schema-settings/en.md
@@ -16,7 +16,7 @@ For instance, this query retrieves the site's URL:
 
 ```graphql
 {
-  homeURL: optionValue(name: "home")
+  siteURL: optionValue(name: "siteurl")
 }
 ```
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.6/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.6/en.md
@@ -2,4 +2,28 @@
 
 ## Improvements
 
+### Added `siteURL` field ([#2697](https://github.com/GatoGraphQL/GatoGraphQL/pull/2697))
+
+Added the following field to the GraphQL schema, via the "Site" module:
+
+- `Root.siteURL`
+
+For instance, executing the following query:
+
+```graphql
+{
+  siteURL
+}
+```
+
+...might produce:
+
+```json
+{
+  "data": {
+    "siteURL": "https://mysite.com"
+  }
+}
+```
+
 - Added GraphQL variable `$translateFromLanguage` to persisted query "[PRO] Translate posts for Polylang (Gutenberg)" ([#2694](https://github.com/GatoGraphQL/GatoGraphQL/pull/2694))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.6/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.6/en.md
@@ -2,6 +2,8 @@
 
 ## Improvements
 
+- Added GraphQL variable `$translateFromLanguage` to persisted query "[PRO] Translate posts for Polylang (Gutenberg)" ([#2694](https://github.com/GatoGraphQL/GatoGraphQL/pull/2694))
+
 ### Added `siteURL` field ([#2697](https://github.com/GatoGraphQL/GatoGraphQL/pull/2697))
 
 Added the following field to the GraphQL schema, via the "Site" module:
@@ -16,7 +18,7 @@ For instance, executing the following query:
 }
 ```
 
-...might produce:
+...will produce:
 
 ```json
 {
@@ -25,5 +27,3 @@ For instance, executing the following query:
   }
 }
 ```
-
-- Added GraphQL variable `$translateFromLanguage` to persisted query "[PRO] Translate posts for Polylang (Gutenberg)" ([#2694](https://github.com/GatoGraphQL/GatoGraphQL/pull/2694))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -271,6 +271,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 == Changelog ==
 
 = 2.6.0 =
+* Added `siteURL` field (#2697)
 * Added GraphQL variable `$translateFromLanguage` to persisted query "[PRO] Translate posts for Polylang (Gutenberg)" (#2694)
 
 = 2.5.2 =


### PR DESCRIPTION
Added the following field to the GraphQL schema, via the "Site" module:

- `Root.siteURL`

For instance, executing the following query:

```graphql
{
  siteURL
}
```

...will produce:

```json
{
  "data": {
    "siteURL": "https://mysite.com"
  }
}
```
