### PR TITLE
Filter languages to translate to in Polylang persisted queries

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -11,7 +11,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Added `siteURL` field (#2697)
 - Added fields to fetch multisite data (#2698)
 - Added documentation for integration with MultilingualPress (#2699)
-- Added GraphQL variable `$translateFromLanguage` to persisted query "[PRO] Translate posts for Polylang (Gutenberg)"
+- Added GraphQL variables `$translateFromLanguage`, `$includeLanguagesToTranslate` and `$excludeLanguagesToTranslate` to persisted queries (#2694 / #2700):
+  - [PRO] Translate posts for Polylang (Gutenberg)
+  - [PRO] Translate posts for Polylang (Classic editor)
 - [PRO] Added integration with MultilingualPress
 
 ## 2.5.2 - 06/06/2024

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.6/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.6/en.md
@@ -3,7 +3,9 @@
 ## Improvements
 
 - Added documentation for integration with MultilingualPress ([#2699](https://github.com/GatoGraphQL/GatoGraphQL/pull/2699))
-- Added GraphQL variable `$translateFromLanguage` to persisted query "[PRO] Translate posts for Polylang (Gutenberg)" ([#2694](https://github.com/GatoGraphQL/GatoGraphQL/pull/2694))
+- Added GraphQL variables `$translateFromLanguage`, `$includeLanguagesToTranslate` and `$excludeLanguagesToTranslate` to persisted queries ([#2694](https://github.com/GatoGraphQL/GatoGraphQL/pull/2694) / [#2700](https://github.com/GatoGraphQL/GatoGraphQL/pull/2700)):
+  - [PRO] Translate posts for Polylang (Gutenberg)
+  - [PRO] Translate posts for Polylang (Classic editor)
 
 ### Added `siteURL` field ([#2697](https://github.com/GatoGraphQL/GatoGraphQL/pull/2697))
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -274,7 +274,9 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 * Added `siteURL` field (#2697)
 * Added fields to fetch multisite data (#2698)
 * Added documentation for integration with MultilingualPress (#2699)
-* Added GraphQL variable `$translateFromLanguage` to persisted query "[PRO] Translate posts for Polylang (Gutenberg)" (#2694)
+* Added GraphQL variables `$translateFromLanguage`, `$includeLanguagesToTranslate` and `$excludeLanguagesToTranslate` to persisted queries (#2694 / #2700):
+  * [PRO] Translate posts for Polylang (Gutenberg)
+  * [PRO] Translate posts for Polylang (Classic editor)
 * [PRO] Added integration with MultilingualPress
 
 = 2.5.2 =

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
@@ -63,7 +63,11 @@ query InitializeVariables
     @export(as: "translationPostIds")
 }
 
-query ExportOriginPost($postId: ID!)
+query ExportOriginPost(
+  $postId: ID!
+  $includeLanguagesToTranslate: [String!]
+  $excludeLanguagesToTranslate: [String!]
+)
   @depends(on: "InitializeVariables")
 {
   defaultLanguage: polylangDefaultLanguage
@@ -77,7 +81,10 @@ query ExportOriginPost($postId: ID!)
       @export(as: "fromLanguage")
     
 
-    polylangTranslationLanguageIDs
+    polylangTranslationLanguageIDs(filter: {
+      includeLanguagues: $includeLanguagesToTranslate
+      excludeLanguagues: $excludeLanguagesToTranslate
+    })
     translationPostIds: _objectValues(object: $__polylangTranslationLanguageIDs)
       @export(as: "translationPostIds")
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
@@ -82,8 +82,8 @@ query ExportOriginPost(
     
 
     polylangTranslationLanguageIDs(filter: {
-      includeLanguagues: $includeLanguagesToTranslate
-      excludeLanguagues: $excludeLanguagesToTranslate
+      includeLanguages: $includeLanguagesToTranslate
+      excludeLanguages: $excludeLanguagesToTranslate
     })
     translationPostIds: _objectValues(object: $__polylangTranslationLanguageIDs)
       @export(as: "translationPostIds")

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
@@ -6,6 +6,7 @@
 #   - updateSlug: Indicate if to update the post slug, using the translated title. It is `true` by default.
 #   - translateDefaultLanguageOnly: Indicate if only execute the translation when the origin post has the default language of the site. It is `true` by default.
 #   - translateFromLanguage: Only execute the translation when the origin post has some provided language. It applies only when `translateDefaultLanguageOnly` is `false`
+#   - languagesToTranslate: Specify for what languages to execute the translation. If empty, it's all languages
 #
 # *********************************************************************
 #
@@ -34,6 +35,10 @@
 # providing `$translateFromLanguage` with the language code
 # (for instance, `"en"`). It applies only when
 # `$translateDefaultLanguageOnly` is `false`.
+#
+# To limit for what languages to execute the translation, pass
+# variable `$languagesToTranslate`. If empty, all languages
+# will be included.
 #
 # By default it also translates the post slug. To disable, pass
 # variable `updateSlug` with `false`.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
@@ -58,6 +58,11 @@ query InitializeVariables
 {
   emptyString: _echo(value: null)
     @export(as: "fromLanguage")
+
+  emptyBool: _echo(value: false)
+    @export(as: "hasTranslationPosts")
+    @export(as: "executeTranslation")
+    @remove
   
   emptyArray: _echo(value: [])
     @export(as: "translationPostIds")
@@ -88,6 +93,9 @@ query ExportOriginPost(
     translationPostIds: _objectValues(object: $__polylangTranslationLanguageIDs)
       @export(as: "translationPostIds")
 
+    hasTranslationPosts: _notEmpty(value: $__translationPostIds)
+      @export(as: "hasTranslationPosts")
+
 
     title
       @export(as: "originTitle")
@@ -108,6 +116,7 @@ query FetchData(
 )
   @depends(on: "ExportOriginPost")
   @include(if: $hasOriginPost)
+  @include(if: $hasTranslationPosts)
 {
   translationPosts: posts(filter: { ids: $translationPostIds, status: $statusToUpdate } ) {
     id
@@ -128,8 +137,6 @@ query FetchData(
       )
   }
 
-  hasTranslationPosts: _notEmpty(value: $__translationPosts)
-
   originPostHasDefaultLanguage: _equals(
     value1: $defaultLanguage,
     value2: $fromLanguage
@@ -148,16 +155,11 @@ query FetchData(
     else: true
   )
 
-  canTranslateOriginPost: _if(
+  executeTranslation: _if(
     condition: $translateDefaultLanguageOnly,
     then: $__originPostHasDefaultLanguage,
     else: $__canTranslateOriginPostFromSpecificLanguage
   )
-
-  executeTranslation: _and(values: [
-    $__hasTranslationPosts,
-    $__canTranslateOriginPost
-  ])
     @export(as: "executeTranslation")
 }
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
@@ -6,7 +6,8 @@
 #   - updateSlug: Indicate if to update the post slug, using the translated title. It is `true` by default.
 #   - translateDefaultLanguageOnly: Indicate if only execute the translation when the origin post has the default language of the site. It is `true` by default.
 #   - translateFromLanguage: Only execute the translation when the origin post has some provided language. It applies only when `translateDefaultLanguageOnly` is `false`
-#   - languagesToTranslate: Specify for what languages to execute the translation. If empty, it's all languages
+#   - includeLanguagesToTranslate: Limit languages to execute the translation for. If empty, all languages are included
+#   - excludeLanguagesToTranslate: Exclude languages from executing the translation
 #
 # *********************************************************************
 #
@@ -37,8 +38,8 @@
 # `$translateDefaultLanguageOnly` is `false`.
 #
 # To limit for what languages to execute the translation, pass
-# variable `$languagesToTranslate`. If empty, all languages
-# will be included.
+# variables `$includeLanguagesToTranslate` (if empty, all languages
+# will be included) and `$excludeLanguagesToTranslate`.
 #
 # By default it also translates the post slug. To disable, pass
 # variable `updateSlug` with `false`.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
@@ -157,8 +157,8 @@ query ExportOriginPost(
     
 
     polylangTranslationLanguageIDs(filter: {
-      includeLanguagues: $includeLanguagesToTranslate
-      excludeLanguagues: $excludeLanguagesToTranslate
+      includeLanguages: $includeLanguagesToTranslate
+      excludeLanguages: $excludeLanguagesToTranslate
     })
     translationPostIds: _objectValues(object: $__polylangTranslationLanguageIDs)
       @export(as: "translationPostIds")

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
@@ -6,6 +6,7 @@
 #   - updateSlug: Indicate if to update the post slug, using the translated title. It is `true` by default.
 #   - translateDefaultLanguageOnly: Indicate if only execute the translation when the origin post has the default language of the site. It is `true` by default.
 #   - translateFromLanguage: Only execute the translation when the origin post has some provided language. It applies only when `translateDefaultLanguageOnly` is `false`
+#   - languagesToTranslate: Specify for what languages to execute the translation. If empty, it's all languages
 #
 # *********************************************************************
 #
@@ -34,6 +35,10 @@
 # providing `$translateFromLanguage` with the language code
 # (for instance, `"en"`). It applies only when
 # `$translateDefaultLanguageOnly` is `false`.
+#
+# To limit for what languages to execute the translation, pass
+# variable `$languagesToTranslate`. If empty, all languages
+# will be included.
 #
 # By default it also translates the post slug. To disable, pass
 # variable `updateSlug` with `false`.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
@@ -59,6 +59,11 @@ query InitializeVariables
   emptyString: _echo(value: null)
     @export(as: "fromLanguage")
     @remove
+
+  emptyBool: _echo(value: false)
+    @export(as: "hasTranslationPosts")
+    @export(as: "executeTranslation")
+    @remove
   
   emptyArray: _echo(value: [])
     @export(as: "translationPostIds")
@@ -162,6 +167,9 @@ query ExportOriginPost(
     })
     translationPostIds: _objectValues(object: $__polylangTranslationLanguageIDs)
       @export(as: "translationPostIds")
+
+    hasTranslationPosts: _notEmpty(value: $__translationPostIds)
+      @export(as: "hasTranslationPosts")
 
 
     title
@@ -422,6 +430,7 @@ query InitializeTranslationVariables(
 )
   @depends(on: "ExportOriginPost")
   @include(if: $hasOriginPost)
+  @include(if: $hasTranslationPosts)
 {
   emptyTranslationPostVars: posts(filter: { ids: $translationPostIds, status: $statusToUpdate } ) {
     emptyArray: _echo(value: [])
@@ -678,8 +687,6 @@ query InitializeTranslationVariables(
       )
   }
 
-  hasTranslationPosts: _notEmpty(value: $__emptyTranslationPostVars)
-
   originPostHasDefaultLanguage: _equals(
     value1: $defaultLanguage,
     value2: $fromLanguage
@@ -698,16 +705,11 @@ query InitializeTranslationVariables(
     else: true
   )
 
-  canTranslateOriginPost: _if(
+  executeTranslation: _if(
     condition: $translateDefaultLanguageOnly,
     then: $__originPostHasDefaultLanguage,
     else: $__canTranslateOriginPostFromSpecificLanguage
   )
-
-  executeTranslation: _and(values: [
-    $__hasTranslationPosts,
-    $__canTranslateOriginPost
-  ])
     @export(as: "executeTranslation")
 }
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
@@ -152,7 +152,7 @@ query ExportOriginPost($postId: ID!)
       @export(as: "fromLanguage")
     
 
-    polylangTranslationLanguageIDs(filter: { includeLanguagues: ["en"] })
+    polylangTranslationLanguageIDs
     translationPostIds: _objectValues(object: $__polylangTranslationLanguageIDs)
       @export(as: "translationPostIds")
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
@@ -138,7 +138,11 @@ query InitializeVariables
     @remove
 }
 
-query ExportOriginPost($postId: ID!)
+query ExportOriginPost(
+  $postId: ID!
+  $includeLanguagesToTranslate: [String!]
+  $excludeLanguagesToTranslate: [String!]
+)
   @depends(on: "InitializeVariables")
 {
   defaultLanguage: polylangDefaultLanguage
@@ -152,7 +156,10 @@ query ExportOriginPost($postId: ID!)
       @export(as: "fromLanguage")
     
 
-    polylangTranslationLanguageIDs
+    polylangTranslationLanguageIDs(filter: {
+      includeLanguagues: $includeLanguagesToTranslate
+      excludeLanguagues: $excludeLanguagesToTranslate
+    })
     translationPostIds: _objectValues(object: $__polylangTranslationLanguageIDs)
       @export(as: "translationPostIds")
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
@@ -6,7 +6,8 @@
 #   - updateSlug: Indicate if to update the post slug, using the translated title. It is `true` by default.
 #   - translateDefaultLanguageOnly: Indicate if only execute the translation when the origin post has the default language of the site. It is `true` by default.
 #   - translateFromLanguage: Only execute the translation when the origin post has some provided language. It applies only when `translateDefaultLanguageOnly` is `false`
-#   - languagesToTranslate: Specify for what languages to execute the translation. If empty, it's all languages
+#   - includeLanguagesToTranslate: Limit languages to execute the translation for. If empty, all languages are included
+#   - excludeLanguagesToTranslate: Exclude languages from executing the translation
 #
 # *********************************************************************
 #
@@ -37,8 +38,8 @@
 # `$translateDefaultLanguageOnly` is `false`.
 #
 # To limit for what languages to execute the translation, pass
-# variable `$languagesToTranslate`. If empty, all languages
-# will be included.
+# variables `$includeLanguagesToTranslate` (if empty, all languages
+# will be included) and `$excludeLanguagesToTranslate`.
 #
 # By default it also translates the post slug. To disable, pass
 # variable `updateSlug` with `false`.
@@ -151,7 +152,7 @@ query ExportOriginPost($postId: ID!)
       @export(as: "fromLanguage")
     
 
-    polylangTranslationLanguageIDs
+    polylangTranslationLanguageIDs(filter: { includeLanguagues: ["en"] })
     translationPostIds: _objectValues(object: $__polylangTranslationLanguageIDs)
       @export(as: "translationPostIds")
 


### PR DESCRIPTION
Added GraphQL variables `$includeLanguagesToTranslate` and `$excludeLanguagesToTranslate` to persisted queries:

- [PRO] Translate posts for Polylang (Gutenberg)
- [PRO] Translate posts for Polylang (Classic editor)