### PR TITLE
Add field `_strRegexFindMatches`

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -10,7 +10,8 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - Added `siteURL` field (#2697)
 - Added fields to fetch multisite data (#2698)
-- Added documentation for integration with MultilingualPress (#2699)
+- Added documentation for PRO integration with MultilingualPress (#2699)
+- Added documentation for new PRO field `_strRegexFindMatches`
 - Added GraphQL variables `$translateFromLanguage`, `$includeLanguagesToTranslate` and `$excludeLanguagesToTranslate` to persisted queries (#2694 / #2700):
   - [PRO] Translate posts for Polylang (Gutenberg)
   - [PRO] Translate posts for Polylang (Classic editor)
@@ -30,6 +31,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Added automation rules:
   - MultilingualPress: When publishing a post, translate it to all languages (Gutenberg)
   - MultilingualPress: When publishing a post, translate it to all languages (Classic editor)
+- Added field `_strRegexFindMatches`
 
 ## 2.5.2 - 06/06/2024
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -11,7 +11,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Added `siteURL` field (#2697)
 - Added fields to fetch multisite data (#2698)
 - Added documentation for PRO integration with MultilingualPress (#2699)
-- Added documentation for new PRO field `_strRegexFindMatches`
+- Added documentation for new PRO field `_strRegexFindMatches` (#2708)
 - Added GraphQL variables `$translateFromLanguage`, `$includeLanguagesToTranslate` and `$excludeLanguagesToTranslate` to persisted queries (#2694 / #2700):
   - [PRO] Translate posts for Polylang (Gutenberg)
   - [PRO] Translate posts for Polylang (Classic editor)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.6/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.6/en.md
@@ -3,7 +3,7 @@
 ## Improvements
 
 - Added documentation for PRO integration with MultilingualPress ([#2699](https://github.com/GatoGraphQL/GatoGraphQL/pull/2699))
-- Added documentation for new PRO field `_strRegexFindMatches`
+- Added documentation for new PRO field `_strRegexFindMatches` ([#2708](https://github.com/GatoGraphQL/GatoGraphQL/pull/2708))
 - Added GraphQL variables `$translateFromLanguage`, `$includeLanguagesToTranslate` and `$excludeLanguagesToTranslate` to persisted queries ([#2694](https://github.com/GatoGraphQL/GatoGraphQL/pull/2694) / [#2700](https://github.com/GatoGraphQL/GatoGraphQL/pull/2700)):
   - [PRO] Translate posts for Polylang (Gutenberg)
 - Added scalar types to the GraphQL schema:

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.6/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.6/en.md
@@ -2,7 +2,8 @@
 
 ## Improvements
 
-- Added documentation for integration with MultilingualPress ([#2699](https://github.com/GatoGraphQL/GatoGraphQL/pull/2699))
+- Added documentation for PRO integration with MultilingualPress ([#2699](https://github.com/GatoGraphQL/GatoGraphQL/pull/2699))
+- Added documentation for new PRO field `_strRegexFindMatches`
 - Added GraphQL variables `$translateFromLanguage`, `$includeLanguagesToTranslate` and `$excludeLanguagesToTranslate` to persisted queries ([#2694](https://github.com/GatoGraphQL/GatoGraphQL/pull/2694) / [#2700](https://github.com/GatoGraphQL/GatoGraphQL/pull/2700)):
   - [PRO] Translate posts for Polylang (Gutenberg)
 - Added scalar types to the GraphQL schema:
@@ -219,6 +220,35 @@ For instance, you can now run this query:
         }
       }
     }
+  }
+}
+```
+
+### Added field `_strRegexFindMatches`
+
+Field `_strRegexFindMatches` has been added to the **Helper Function Collection** module. This field executes a regular expression to extract all matches from a string.
+
+For instance, running this query:
+
+```graphql
+{
+  _strRegexFindMatches(regex: "/https?:\\/\\/([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,})/", string: "In website https://gatographql.com there is more information")
+}
+```
+
+...will produce:
+
+```json
+{
+  "data": {
+    "_strRegexFindMatches": [
+      [
+        "https:\/\/gatographql.com"
+      ],
+      [
+        "gatographql.com"
+      ]
+    ]
   }
 }
 ```

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/php-functions-via-schema/docs/modules/php-functions-via-schema/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/php-functions-via-schema/docs/modules/php-functions-via-schema/en.md
@@ -26,7 +26,7 @@ This query, containing a variety of function fields and directives:
 
   _strReplace(search: "https://", replaceWith: "http://", in: "https://gatographql.com")
   _strReplaceMultiple(search: ["https://", "gato"], replaceWith: ["http://", "dog"], in: "https://gatographql.com")
-  _strRegexFindMatches(regex: "/^(https?:\\/\\//)([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,})", string: "In website https://gatographql.com there is more information")
+  _strRegexFindMatches(regex: "/https?:\\/\\/([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,})/", string: "In website https://gatographql.com there is more information")
   _strRegexReplaceMultiple(searchRegex: ["/^https?:\\/\\//", "/([a-z]*)/"], replaceWith: ["", "$1$1"], in: "https://gatographql.com")
   
   _strStartsWith(search: "orld", in: "Hello world")

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/php-functions-via-schema/docs/modules/php-functions-via-schema/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/php-functions-via-schema/docs/modules/php-functions-via-schema/en.md
@@ -26,7 +26,7 @@ This query, containing a variety of function fields and directives:
 
   _strReplace(search: "https://", replaceWith: "http://", in: "https://gatographql.com")
   _strReplaceMultiple(search: ["https://", "gato"], replaceWith: ["http://", "dog"], in: "https://gatographql.com")
-  _strRegexFindMatches(regex: "/^(https?:\\/\\//)([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})", string: "In website https://gatographql.com there is more information")
+  _strRegexFindMatches(regex: "/^(https?:\\/\\//)([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,})", string: "In website https://gatographql.com there is more information")
   _strRegexReplaceMultiple(searchRegex: ["/^https?:\\/\\//", "/([a-z]*)/"], replaceWith: ["", "$1$1"], in: "https://gatographql.com")
   
   _strStartsWith(search: "orld", in: "Hello world")

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/php-functions-via-schema/docs/modules/php-functions-via-schema/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/php-functions-via-schema/docs/modules/php-functions-via-schema/en.md
@@ -115,6 +115,14 @@ This query, containing a variety of function fields and directives:
       2
     ],
     "_arrayLength": 3,
+    "_strRegexFindMatches": [
+      [
+        "https:\/\/gatographql.com"
+      ],
+      [
+        "gatographql.com"
+      ]
+    ],
     "_strReplace": "http://gatographql.com",
     "_strReplaceMultiple": "http://doggraphql.com",
     "_strRegexReplace": "gatographql.com",

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/php-functions-via-schema/docs/modules/php-functions-via-schema/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/php-functions-via-schema/docs/modules/php-functions-via-schema/en.md
@@ -26,7 +26,7 @@ This query, containing a variety of function fields and directives:
 
   _strReplace(search: "https://", replaceWith: "http://", in: "https://gatographql.com")
   _strReplaceMultiple(search: ["https://", "gato"], replaceWith: ["http://", "dog"], in: "https://gatographql.com")
-  _strRegexReplace(searchRegex: "/^https?:\\/\\//", replaceWith: "", in: "https://gatographql.com")
+  _strRegexFindMatches(regex: "/^(https?:\\/\\//)([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})", string: "In website https://gatographql.com there is more information")
   _strRegexReplaceMultiple(searchRegex: ["/^https?:\\/\\//", "/([a-z]*)/"], replaceWith: ["", "$1$1"], in: "https://gatographql.com")
   
   _strStartsWith(search: "orld", in: "Hello world")
@@ -465,7 +465,7 @@ Indicates if a string ends with another string.
 
 ### `_strLength`
 
-Length of the string
+Length of the string.
 
 ### `_strLowerCase`
 
@@ -473,11 +473,15 @@ Transform a string to lower case.
 
 ### `_strPad`
 
-Pad a string to a certain length with another string
+Pad a string to a certain length with another string.
 
 ### `_strPos`
 
-Position of a substring within the string, or `null` if not found
+Position of a substring within the string, or `null` if not found.
+
+### `_strRegexFindMatches`
+
+Execute a regular expression to extract all matches from a string.
 
 ### `_strRegexReplace`
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/php-functions-via-schema/docs/modules/php-functions-via-schema/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/php-functions-via-schema/docs/modules/php-functions-via-schema/en.md
@@ -24,9 +24,11 @@ This query, containing a variety of function fields and directives:
   _arrayKeys(array: ["uno", "dos", "tres"])
   _arrayLength(array: ["uno", "dos", "tres"])
 
+  _strRegexFindMatches(regex: "/https?:\\/\\/([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,})/", string: "In website https://gatographql.com there is more information")
+  
   _strReplace(search: "https://", replaceWith: "http://", in: "https://gatographql.com")
   _strReplaceMultiple(search: ["https://", "gato"], replaceWith: ["http://", "dog"], in: "https://gatographql.com")
-  _strRegexFindMatches(regex: "/https?:\\/\\/([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,})/", string: "In website https://gatographql.com there is more information")
+  _strRegexReplace(searchRegex: "/^https?:\\/\\//", replaceWith: "", in: "https://gatographql.com")
   _strRegexReplaceMultiple(searchRegex: ["/^https?:\\/\\//", "/([a-z]*)/"], replaceWith: ["", "$1$1"], in: "https://gatographql.com")
   
   _strStartsWith(search: "orld", in: "Hello world")

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -290,7 +290,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 * Added `siteURL` field (#2697)
 * Added fields to fetch multisite data (#2698)
 * Added documentation for PRO integration with MultilingualPress (#2699)
-* Added documentation for new PRO field `_strRegexFindMatches`
+* Added documentation for new PRO field `_strRegexFindMatches` (#2708)
 * Added GraphQL variables `$translateFromLanguage`, `$includeLanguagesToTranslate` and `$excludeLanguagesToTranslate` to persisted queries (#2694 / #2700):
   * [PRO] Translate posts for Polylang (Gutenberg)
   * [PRO] Translate posts for Polylang (Classic editor)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -289,7 +289,8 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 = 2.6.0 =
 * Added `siteURL` field (#2697)
 * Added fields to fetch multisite data (#2698)
-* Added documentation for integration with MultilingualPress (#2699)
+* Added documentation for PRO integration with MultilingualPress (#2699)
+* Added documentation for new PRO field `_strRegexFindMatches`
 * Added GraphQL variables `$translateFromLanguage`, `$includeLanguagesToTranslate` and `$excludeLanguagesToTranslate` to persisted queries (#2694 / #2700):
   * [PRO] Translate posts for Polylang (Gutenberg)
   * [PRO] Translate posts for Polylang (Classic editor)


### PR DESCRIPTION
Added documentation for the new PRO field `_strRegexFindMatches` (from the **Helper Function Collection** module).

This field executes a regular expression to extract all matches from a string.

For instance, running this query:

```graphql
{
  _strRegexFindMatches(regex: "/https?:\\/\\/([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\\.[a-zA-Z]{2,})/", string: "In website https://gatographql.com there is more information")
}
```

...will produce:

```json
{
  "data": {
    "_strRegexFindMatches": [
      [
        "https:\/\/gatographql.com"
      ],
      [
        "gatographql.com"
      ]
    ]
  }
}
```
