### PR TITLE
Update min WP version to 6.0

### DIFF
--- a/layers/GatoGraphQLForWP/phpunit-plugins/gatographql-testing/gatographql-testing.php
+++ b/layers/GatoGraphQLForWP/phpunit-plugins/gatographql-testing/gatographql-testing.php
@@ -3,7 +3,7 @@
 Plugin Name: Gato GraphQL - PHPUnit & Testing Utilities
 Description: Utilities for testing Gato GraphQL
 Version: 2.7.0-dev
-Requires at least: 5.4
+Requires at least: 6.0
 Requires PHP: 8.1
 Author: Gato GraphQL
 License: GPLv2 or later

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 3.0.0 - DATE
 
+### Breaking changes
+
+- Require at least WordPress v6.0 (#2719)
+
 ### Improvements
 
 - Added compatibility with WordPress 6.6 (#2717)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/3.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/3.0/en.md
@@ -1,5 +1,15 @@
 # Release Notes: 3.0
 
+## Breaking changes
+
+### Require at least WordPress v6.0 ([#2719](https://github.com/GatoGraphQL/GatoGraphQL/pull/2719))
+
+When using Gato GraphQL with WordPress v6.6 (just ahead of its release), [blocks in the plugin stopped working](https://github.com/WordPress/gutenberg/issues/63009).
+
+As a solution, blocks were adapted and re-compiled, and the new [compiled files only work only with WordPress `v6.0`+](https://github.com/WordPress/gutenberg/issues/63135#issuecomment-2211631051).
+
+That's why, from now on, Gato GraphQL requires at least WordPress `v6.0`.
+
 ## Improvements
 
 - Added compatibility with WordPress 6.6 ([#2717](https://github.com/GatoGraphQL/GatoGraphQL/pull/2717))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/3.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/3.0/en.md
@@ -4,7 +4,7 @@
 
 ### Require at least WordPress v6.0 ([#2719](https://github.com/GatoGraphQL/GatoGraphQL/pull/2719))
 
-When using Gato GraphQL with WordPress v6.6 (just ahead of its release), [blocks in the plugin stopped working](https://github.com/WordPress/gutenberg/issues/63009).
+When using Gato GraphQL with WordPress `v6.6` (just ahead of its release), [blocks in the plugin stopped working](https://github.com/WordPress/gutenberg/issues/63009).
 
 As a solution, blocks were adapted and re-compiled, and the new [compiled files only work only with WordPress `v6.0`+](https://github.com/WordPress/gutenberg/issues/63135#issuecomment-2211631051).
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/3.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/3.0/en.md
@@ -4,7 +4,7 @@
 
 ### Require at least WordPress v6.0 ([#2719](https://github.com/GatoGraphQL/GatoGraphQL/pull/2719))
 
-When using Gato GraphQL with WordPress `v6.6` (just ahead of its release), [blocks in the plugin stopped working](https://github.com/WordPress/gutenberg/issues/63009).
+When using Gato GraphQL with WordPress `v6.6` (just [ahead of its release](https://wordpress.org/news/2024/07/wordpress-6-6-rc2/)), [blocks in the plugin stopped working](https://github.com/WordPress/gutenberg/issues/63009).
 
 As a solution, blocks were adapted and re-compiled, and the new [compiled files only work only with WordPress `v6.0`+](https://github.com/WordPress/gutenberg/issues/63135#issuecomment-2211631051).
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/gatographql.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/gatographql.php
@@ -5,7 +5,7 @@ Plugin URI: https://gatographql.com
 GitHub Plugin URI: https://github.com/GatoGraphQL/GatoGraphQL
 Description: The most powerful GraphQL server for WordPress.
 Version: 2.7.0-dev
-Requires at least: 5.4
+Requires at least: 6.0
 Requires PHP: 8.1
 Author: Gato GraphQL
 Author URI: https://gatographql.com

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -287,6 +287,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 == Changelog ==
 
 = 3.0.0 =
+* Breaking changes: Require at least WordPress v6.0 (#2719)
 * Added compatibility with WordPress 6.6 (#2717)
 * Fixed bug: Catch exception if dependency version is not semver (#2712)
 * Fixed bug: Convert entries in JSON dictionary of variables in persisted query from array to object (#2715)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -1,7 +1,7 @@
 === Gato GraphQL ===
 Contributors: gatographql, leoloso
 Tags: graphql, headless, webhook, api, automator, import export, search replace, google translate, wp-cli, external api, wpgraphql, code snippets
-Requires at least: 5.4
+Requires at least: 6.0
 Tested up to: 6.6
 Stable tag: 2.6.1
 Requires PHP: 8.1

--- a/layers/GatoGraphQLForWP/plugins/testing-schema/gatographql-testing-schema.php
+++ b/layers/GatoGraphQLForWP/plugins/testing-schema/gatographql-testing-schema.php
@@ -4,7 +4,7 @@ Plugin Name: Gato GraphQL - Testing Schema
 Plugin URI: https://github.com/GatoGraphQL/GatoGraphQL
 Description: Addition of elements to the GraphQL schema to test the Gato GraphQL plugin
 Version: 2.7.0-dev
-Requires at least: 5.4
+Requires at least: 6.0
 Requires PHP: 8.1
 Author: Gato GraphQL
 License: GPLv2 or later


### PR DESCRIPTION
When using Gato GraphQL with WordPress `v6.6` (just [ahead of its release](https://wordpress.org/news/2024/07/wordpress-6-6-rc2/)), [blocks in the plugin stopped working](https://github.com/WordPress/gutenberg/issues/63009).

As a solution, blocks were adapted and re-compiled, and the new [compiled files only work only with WordPress `v6.0`+](https://github.com/WordPress/gutenberg/issues/63135#issuecomment-2211631051).

That's why, from now on, Gato GraphQL requires at least WordPress `v6.0`.