### PR TITLE
Add mutations to create the translation posts for Polylang

### DIFF
--- a/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTermTypeAPI.php
+++ b/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTermTypeAPI.php
@@ -7,6 +7,7 @@ namespace PoPCMSSchema\TaxonomiesWP\TypeAPIs;
 use PoPCMSSchema\Taxonomies\TypeAPIs\TaxonomyTermTypeAPIInterface;
 use PoP\Root\Services\BasicServiceTrait;
 use WP_Term;
+use WP_Error;
 
 class TaxonomyTermTypeAPI implements TaxonomyTermTypeAPIInterface
 {
@@ -19,5 +20,10 @@ class TaxonomyTermTypeAPI implements TaxonomyTermTypeAPIInterface
     {
         /** @var WP_Term $taxonomyTerm */
         return $taxonomyTerm->taxonomy;
+    }
+    public function taxonomyTermExists(int|string $id): bool
+    {
+        $taxonomyTermExists = term_exists($id);
+        return $taxonomyTermExists !==  null;
     }
 }

--- a/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTermTypeAPI.php
+++ b/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/TaxonomyTermTypeAPI.php
@@ -7,7 +7,6 @@ namespace PoPCMSSchema\TaxonomiesWP\TypeAPIs;
 use PoPCMSSchema\Taxonomies\TypeAPIs\TaxonomyTermTypeAPIInterface;
 use PoP\Root\Services\BasicServiceTrait;
 use WP_Term;
-use WP_Error;
 
 class TaxonomyTermTypeAPI implements TaxonomyTermTypeAPIInterface
 {

--- a/layers/CMSSchema/packages/taxonomies/src/TypeAPIs/TaxonomyTermTypeAPIInterface.php
+++ b/layers/CMSSchema/packages/taxonomies/src/TypeAPIs/TaxonomyTermTypeAPIInterface.php
@@ -13,4 +13,5 @@ interface TaxonomyTermTypeAPIInterface
      * Retrieves the taxonomy name of the object ("post_tag", "category", etc)
      */
     public function getTermTaxonomyName(object $taxonomyTerm): string;
+    public function taxonomyTermExists(int|string $id): bool;
 }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/FixtureEndpointWebserverRequestTestCaseTrait.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/FixtureEndpointWebserverRequestTestCaseTrait.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace PHPUnitForGatoGraphQL\GatoGraphQL\Integration;
 
 use GraphQLByPoP\GraphQLServer\Unit\FixtureQueryExecutionGraphQLServerTestCaseTrait;
-use RuntimeException;
-use stdClass;
 
 use function file_exists;
 use function file_get_contents;
-use function json_decode;
 
 trait FixtureEndpointWebserverRequestTestCaseTrait
 {
     use FixtureQueryExecutionGraphQLServerTestCaseTrait;
+    use FixtureWebserverRequestTestCaseTrait;
 
     /**
      * Retrieve all GraphQL query files and their expected
@@ -118,36 +116,6 @@ trait FixtureEndpointWebserverRequestTestCaseTrait
             }
         }
         return static::customizeProviderEndpointEntries($providerItems);
-    }
-
-    /**
-     * @return array<string,mixed>
-     */
-    protected static function getGraphQLVariables(string $graphQLVariablesFile): array
-    {
-        if (!file_exists($graphQLVariablesFile)) {
-            return [];
-        }
-
-        $fileContents = file_get_contents($graphQLVariablesFile);
-        if ($fileContents === false) {
-            throw new RuntimeException(
-                sprintf(
-                    'File "%s" cannot be read',
-                    $graphQLVariablesFile
-                )
-            );
-        }
-        $variables = json_decode($fileContents);
-        if (!is_array($variables) && !($variables instanceof stdClass)) {
-            throw new RuntimeException(
-                sprintf(
-                    'Decoding the JSON inside file "%s" failed',
-                    $graphQLVariablesFile
-                )
-            );
-        }
-        return (array) $variables;
     }
 
     protected static function getMainFixtureOperationName(string $dataName): ?string

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/FixtureWebserverRequestTestCaseTrait.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/FixtureWebserverRequestTestCaseTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGatoGraphQL\GatoGraphQL\Integration;
+
+use RuntimeException;
+use stdClass;
+
+use function file_exists;
+use function file_get_contents;
+use function json_decode;
+
+trait FixtureWebserverRequestTestCaseTrait
+{
+    /**
+     * @return array<string,mixed>
+     */
+    protected static function getGraphQLVariables(string $graphQLVariablesFile): array
+    {
+        if (!file_exists($graphQLVariablesFile)) {
+            return [];
+        }
+
+        $fileContents = file_get_contents($graphQLVariablesFile);
+        if ($fileContents === false) {
+            throw new RuntimeException(
+                sprintf(
+                    'File "%s" cannot be read',
+                    $graphQLVariablesFile
+                )
+            );
+        }
+        $variables = json_decode($fileContents);
+        if (!is_array($variables) && !($variables instanceof stdClass)) {
+            throw new RuntimeException(
+                sprintf(
+                    'Decoding the JSON inside file "%s" failed',
+                    $graphQLVariablesFile
+                )
+            );
+        }
+        return (array) $variables;
+    }
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -55,11 +55,7 @@ abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUs
             if (!\file_exists($pluginDisabledGraphQLResponseFile)) {
                 static::throwFileNotExistsException($pluginDisabledGraphQLResponseFile);
             }
-            $pluginOnlyOneEnabledGraphQLResponse = null;
             $pluginOnlyOneEnabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':only-one-enabled.json';
-            if (\file_exists($pluginOnlyOneEnabledGraphQLResponseFile)) {
-                $pluginOnlyOneEnabledGraphQLResponse = file_get_contents($pluginOnlyOneEnabledGraphQLResponseFile);
-            }
             $pluginGraphQLVariablesFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . '.var.json';
             
             // The plugin name is created by the folder (plugin vendor) + fileName (plugin name)
@@ -70,8 +66,8 @@ abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUs
                 'response-enabled' => file_get_contents($pluginEnabledGraphQLResponseFile),
                 'response-disabled' => file_get_contents($pluginDisabledGraphQLResponseFile),
             ];
-            if ($pluginOnlyOneEnabledGraphQLResponse !== null) {
-                $pluginEntries[$pluginName]['response-only-one-enabled'] = $pluginOnlyOneEnabledGraphQLResponse;
+            if (\file_exists($pluginOnlyOneEnabledGraphQLResponseFile)) {
+                $pluginEntries[$pluginName]['response-only-one-enabled'] = file_get_contents($pluginOnlyOneEnabledGraphQLResponseFile);
             }
             if (\file_exists($pluginGraphQLVariablesFile)) {
                 $pluginEntries[$pluginName]['variables'] = static::getGraphQLVariables($pluginGraphQLVariablesFile);
@@ -100,21 +96,22 @@ abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUs
                     if (!\file_exists($additionalPluginDisabledGraphQLResponseFile)) {
                         static::throwFileNotExistsException($additionalPluginDisabledGraphQLResponseFile);
                     }
-                    $additionalPluginOnlyOneEnabledGraphQLResponse = null;
                     $additionalPluginOnlyOneEnabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':only-one-enabled.json';
-                    if (\file_exists($additionalPluginOnlyOneEnabledGraphQLResponseFile)) {
-                        $additionalPluginOnlyOneEnabledGraphQLResponse = file_get_contents($additionalPluginOnlyOneEnabledGraphQLResponseFile);
-                    }
                     $additionalPluginName = $pluginName . ':' . $additionalFileNumber;
                     $pluginEntries[$additionalPluginName] = [
                         'query' => $query,
-                        'response-enabled' => file_get_contents($additionalPluginEnabledGraphQLResponseFile),
-                        'response-disabled' => file_get_contents($additionalPluginDisabledGraphQLResponseFile),
+                        'variables' => static::getGraphQLVariables($additionalPluginGraphQLVariablesFile->getRealPath()),
                     ];
-                    if ($additionalPluginOnlyOneEnabledGraphQLResponse !== null) {
-                        $pluginEntries[$additionalPluginName]['response-only-one-enabled'] = $additionalPluginOnlyOneEnabledGraphQLResponse;
+                    // For the variations, make the "enable" and "disable" responses optional
+                    if (\file_exists($additionalPluginEnabledGraphQLResponseFile)) {
+                        $pluginEntries[$additionalPluginName]['response-enabled'] = file_get_contents($additionalPluginEnabledGraphQLResponseFile);
                     }
-                    $pluginEntries[$additionalPluginName]['variables'] = static::getGraphQLVariables($additionalPluginGraphQLVariablesFile->getRealPath());
+                    if (\file_exists($additionalPluginDisabledGraphQLResponseFile)) {
+                        $pluginEntries[$additionalPluginName]['response-disabled'] = file_get_contents($additionalPluginDisabledGraphQLResponseFile);
+                    }                    
+                    if (\file_exists($additionalPluginOnlyOneEnabledGraphQLResponseFile)) {
+                        $pluginEntries[$additionalPluginName]['response-only-one-enabled'] = file_get_contents($additionalPluginOnlyOneEnabledGraphQLResponseFile);
+                    }
                 }
             }
         }

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -85,7 +85,9 @@ abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUs
                 foreach ($additionalPluginGraphQLVariablesFiles as $additionalPluginGraphQLVariablesFile) {
                     $additionalFileName = $additionalPluginGraphQLVariablesFile->getFilenameWithoutExtension();
                     $additionalFileNumberWithSuffix = substr($additionalFileName, strpos($additionalFileName, ':') + 1);
-                    $additionalFileNumber = substr($additionalFileNumberWithSuffix, 0, strpos($additionalFileNumberWithSuffix, '.var'));
+                    /** @var int */
+                    $dotVarPos = strpos($additionalFileNumberWithSuffix, '.var');
+                    $additionalFileNumber = substr($additionalFileNumberWithSuffix, 0, $dotVarPos);
                     if (!is_numeric($additionalFileNumber)) {
                         continue;
                     }

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -88,27 +88,21 @@ abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUs
                     if (!is_numeric($additionalFileNumber)) {
                         continue;
                     }
-                    $additionalPluginEnabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':' . $additionalFileNumber . ':enabled.json';
-                    if (!\file_exists($additionalPluginEnabledGraphQLResponseFile)) {
-                        static::throwFileNotExistsException($additionalPluginEnabledGraphQLResponseFile);
-                    }
-                    $additionalPluginDisabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':' . $additionalFileNumber . ':disabled.json';
-                    if (!\file_exists($additionalPluginDisabledGraphQLResponseFile)) {
-                        static::throwFileNotExistsException($additionalPluginDisabledGraphQLResponseFile);
-                    }
-                    $additionalPluginOnlyOneEnabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':only-one-enabled.json';
                     $additionalPluginName = $pluginName . ':' . $additionalFileNumber;
                     $pluginEntries[$additionalPluginName] = [
                         'query' => $query,
                         'variables' => static::getGraphQLVariables($additionalPluginGraphQLVariablesFile->getRealPath()),
                     ];
                     // For the variations, make the "enable" and "disable" responses optional
+                    $additionalPluginEnabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':' . $additionalFileNumber . ':enabled.json';
                     if (\file_exists($additionalPluginEnabledGraphQLResponseFile)) {
                         $pluginEntries[$additionalPluginName]['response-enabled'] = file_get_contents($additionalPluginEnabledGraphQLResponseFile);
                     }
+                    $additionalPluginDisabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':' . $additionalFileNumber . ':disabled.json';
                     if (\file_exists($additionalPluginDisabledGraphQLResponseFile)) {
                         $pluginEntries[$additionalPluginName]['response-disabled'] = file_get_contents($additionalPluginDisabledGraphQLResponseFile);
                     }                    
+                    $additionalPluginOnlyOneEnabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':only-one-enabled.json';
                     if (\file_exists($additionalPluginOnlyOneEnabledGraphQLResponseFile)) {
                         $pluginEntries[$additionalPluginName]['response-only-one-enabled'] = file_get_contents($additionalPluginOnlyOneEnabledGraphQLResponseFile);
                     }

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -80,6 +80,7 @@ abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUs
                 $additionalPluginGraphQLVariablesFiles = static::findFilesInDirectory(
                     $filePath,
                     [$fileName . ':*.var.json'],
+                    ['*.disabled.var.json']
                 );
                 foreach ($additionalPluginGraphQLVariablesFiles as $additionalPluginGraphQLVariablesFile) {
                     $additionalFileName = $additionalPluginGraphQLVariablesFile->getFilenameWithoutExtension();

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -6,6 +6,7 @@ namespace PHPUnitForGatoGraphQL\WebserverRequests;
 
 use GraphQLByPoP\GraphQLServer\Unit\FixtureTestCaseTrait;
 
+use PHPUnitForGatoGraphQL\GatoGraphQL\Integration\FixtureWebserverRequestTestCaseTrait;
 use function file_get_contents;
 
 /**
@@ -14,6 +15,7 @@ use function file_get_contents;
 abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase extends AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase
 {
     use FixtureTestCaseTrait;
+    use FixtureWebserverRequestTestCaseTrait;
 
     /**
      * Since PHPUnit v10, this is not possible anymore!
@@ -58,7 +60,8 @@ abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUs
             if (\file_exists($pluginOnlyOneEnabledGraphQLResponseFile)) {
                 $pluginOnlyOneEnabledGraphQLResponse = file_get_contents($pluginOnlyOneEnabledGraphQLResponseFile);
             }
-
+            $pluginGraphQLVariablesFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . '.var.json';
+            
             // The plugin name is created by the folder (plugin vendor) + fileName (plugin name)
             $pluginVendor = substr($filePath, strlen($fixtureFolder . '/'));
             $pluginName = $pluginVendor . '/' . $fileName;
@@ -69,6 +72,9 @@ abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUs
             ];
             if ($pluginOnlyOneEnabledGraphQLResponse !== null) {
                 $pluginEntries[$pluginName]['response-only-one-enabled'] = $pluginOnlyOneEnabledGraphQLResponse;
+            }
+            if (\file_exists($pluginGraphQLVariablesFile)) {
+                $pluginEntries[$pluginName]['variables'] = static::getGraphQLVariables($pluginGraphQLVariablesFile);
             }
         }
         return static::customizePluginNameEntries($pluginEntries);

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace PHPUnitForGatoGraphQL\WebserverRequests;
 
 use GraphQLByPoP\GraphQLServer\Unit\FixtureTestCaseTrait;
-
 use PHPUnitForGatoGraphQL\GatoGraphQL\Integration\FixtureWebserverRequestTestCaseTrait;
+
 use function file_get_contents;
 
 /**
@@ -57,7 +57,7 @@ abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUs
             }
             $pluginOnlyOneEnabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':only-one-enabled.json';
             $pluginGraphQLVariablesFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . '.var.json';
-            
+
             // The plugin name is created by the folder (plugin vendor) + fileName (plugin name)
             $pluginVendor = substr($filePath, strlen($fixtureFolder . '/'));
             $pluginName = $pluginVendor . '/' . $fileName;
@@ -104,7 +104,7 @@ abstract class AbstractFixtureThirdPartyPluginDependencyWordPressAuthenticatedUs
                     $additionalPluginDisabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':' . $additionalFileNumber . ':disabled.json';
                     if (\file_exists($additionalPluginDisabledGraphQLResponseFile)) {
                         $pluginEntries[$additionalPluginName]['response-disabled'] = file_get_contents($additionalPluginDisabledGraphQLResponseFile);
-                    }                    
+                    }
                     $additionalPluginOnlyOneEnabledGraphQLResponseFile = $filePath . \DIRECTORY_SEPARATOR . $fileName . ':only-one-enabled.json';
                     if (\file_exists($additionalPluginOnlyOneEnabledGraphQLResponseFile)) {
                         $pluginEntries[$additionalPluginName]['response-only-one-enabled'] = file_get_contents($additionalPluginOnlyOneEnabledGraphQLResponseFile);

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -90,6 +90,7 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
                 $endpoint,
                 [],
                 $pluginEntry['query'],
+                $pluginEntry['variables'] ?? [],
             ];
             $providerEntries[$pluginName . ':disabled'] = [
                 'application/json',
@@ -97,6 +98,7 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
                 $endpoint,
                 [],
                 $pluginEntry['query'],
+                $pluginEntry['variables'] ?? [],
             ];
             if (isset($pluginEntry['response-only-one-enabled'])) {
                 $providerEntries[$pluginName . ':only-one-enabled'] = [
@@ -105,6 +107,7 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
                     $endpoint,
                     [],
                     $pluginEntry['query'],
+                    $pluginEntry['variables'] ?? [],
                 ];
             }
         }

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -150,14 +150,14 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
 
     /**
      * Support executing many enable/disable plugin tests:
-     * If the $dataName ends with "@{number}" (such as "@1",
-     * or "@2" or etc), strip them off, as they are
+     * If the $dataName ends with "__{number}" (such as "__1",
+     * or "__2" or etc), strip them off, as they are
      * "this is another test of the same plugin".
      *
      * Also, each of those tests can have variations via
      * additional .var.json files. In that case, the name
      * will end with ":{number}", like "test:1.var.json"
-     * or "test+1:1.var.json"
+     * or "test__1:1.var.json"
      */
     protected function getPluginNameFromDataName(string $dataName): string
     {
@@ -171,7 +171,7 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
             break;
         }
         $matches = [];
-        if (preg_match('/(.*)@\d+(\:\d+)?/', $pluginName, $matches)) {
+        if (preg_match('/(.*)__\d+(\:\d+)?/', $pluginName, $matches)) {
             return $matches[1];
         }
         return $pluginName;

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -84,6 +84,7 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
         $endpoint = static::getEndpoint();
         $providerEntries = [];
         foreach (static::getPluginNameEntries() as $pluginName => $pluginEntry) {
+            // Only for the variations, the "enable" and "disable" responses are optional
             if (isset($pluginEntry['response-enabled'])) {
                 $providerEntries[$pluginName . ':enabled'] = [
                     'application/json',

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -150,8 +150,8 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
 
     /**
      * Support executing many enable/disable plugin tests:
-     * If the $dataName ends with "+{number}" (such as "+1",
-     * or "+2" or etc), strip them off, as they are
+     * If the $dataName ends with "@{number}" (such as "@1",
+     * or "@2" or etc), strip them off, as they are
      * "this is another test of the same plugin".
      *
      * Also, each of those tests can have variations via
@@ -171,7 +171,7 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
             break;
         }
         $matches = [];
-        if (preg_match('/(.*)\+\d+(\:\d+)?/', $pluginName, $matches)) {
+        if (preg_match('/(.*)@\d+(\:\d+)?/', $pluginName, $matches)) {
             return $matches[1];
         }
         return $pluginName;

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -150,14 +150,14 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
 
     /**
      * Support executing many enable/disable plugin tests:
-     * If the $dataName ends with "|1" or "|2" or etc, strip
-     * them off, as they are "this is another test of the
-     * same plugin".
+     * If the $dataName ends with "+{number}" (such as "+1",
+     * or "+2" or etc), strip them off, as they are
+     * "this is another test of the same plugin".
      *
      * Also, each of those tests can have variations via
      * additional .var.json files. In that case, the name
      * will end with ":{number}", like "test:1.var.json"
-     * or "test|1:1.var.json"
+     * or "test+1:1.var.json"
      */
     protected function getPluginNameFromDataName(string $dataName): string
     {
@@ -171,7 +171,7 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
             break;
         }
         $matches = [];
-        if (preg_match('/(.*)\|\d+(\:\d+)?/', $pluginName, $matches)) {
+        if (preg_match('/(.*)\+\d+(\:\d+)?/', $pluginName, $matches)) {
             return $matches[1];
         }
         return $pluginName;

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -145,9 +145,14 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
 
     /**
      * Support executing many enable/disable plugin tests:
-     * If the $dataName ends with ":1" or ":2" or etc, strip
+     * If the $dataName ends with "|1" or "|2" or etc, strip
      * them off, as they are "this is another test of the
-     * same plugin"
+     * same plugin".
+     *
+     * Also, each of those tests can have variations via
+     * additional .var.json files. In that case, the name
+     * will end with ":{number}", like "test:1.var.json"
+     * or "test|1:1.var.json"
      */
     protected function getPluginNameFromDataName(string $dataName): string
     {
@@ -161,7 +166,7 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
             break;
         }
         $matches = [];
-        if (preg_match('/(.*)\:\d+/', $pluginName, $matches)) {
+        if (preg_match('/(.*)\|\d+(\:\d+)?/', $pluginName, $matches)) {
             return $matches[1];
         }
         return $pluginName;

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -84,22 +84,26 @@ abstract class AbstractThirdPartyPluginDependencyWordPressAuthenticatedUserWebse
         $endpoint = static::getEndpoint();
         $providerEntries = [];
         foreach (static::getPluginNameEntries() as $pluginName => $pluginEntry) {
-            $providerEntries[$pluginName . ':enabled'] = [
-                'application/json',
-                $pluginEntry['response-enabled'],
-                $endpoint,
-                [],
-                $pluginEntry['query'],
-                $pluginEntry['variables'] ?? [],
-            ];
-            $providerEntries[$pluginName . ':disabled'] = [
-                'application/json',
-                $pluginEntry['response-disabled'],
-                $endpoint,
-                [],
-                $pluginEntry['query'],
-                $pluginEntry['variables'] ?? [],
-            ];
+            if (isset($pluginEntry['response-enabled'])) {
+                $providerEntries[$pluginName . ':enabled'] = [
+                    'application/json',
+                    $pluginEntry['response-enabled'],
+                    $endpoint,
+                    [],
+                    $pluginEntry['query'],
+                    $pluginEntry['variables'] ?? [],
+                ];
+            }
+            if (isset($pluginEntry['response-disabled'])) {
+                $providerEntries[$pluginName . ':disabled'] = [
+                    'application/json',
+                    $pluginEntry['response-disabled'],
+                    $endpoint,
+                    [],
+                    $pluginEntry['query'],
+                    $pluginEntry['variables'] ?? [],
+                ];
+            }
             if (isset($pluginEntry['response-only-one-enabled'])) {
                 $providerEntries[$pluginName . ':only-one-enabled'] = [
                     'application/json',

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Improvements
 
 - Use bulk mutations in predefined persisted queries (#2728)
+- Added documentation for new PRO module **Polylang Mutations** (#2733)
 
 ### Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/3.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/3.1/en.md
@@ -4,6 +4,10 @@
 
 - Use bulk mutations in predefined persisted queries ([#2728](https://github.com/GatoGraphQL/GatoGraphQL/pull/2728))
 
+## [PRO] Improvements
+
+### Added Polylang Mutations
+
 ## Fixed
 
 - Don't replace chars in translation persisted queries ([#2731](https://github.com/GatoGraphQL/GatoGraphQL/pull/2731))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/3.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/3.1/en.md
@@ -3,10 +3,70 @@
 ## Improvements
 
 - Use bulk mutations in predefined persisted queries ([#2728](https://github.com/GatoGraphQL/GatoGraphQL/pull/2728))
+- Added documentation for new PRO module **Polylang Mutations** ([#2733](https://github.com/GatoGraphQL/GatoGraphQL/pull/2733))
 
 ## [PRO] Improvements
 
 ### Added Polylang Mutations
+
+The new PRO module **Polylang Mutations** provides mutations for the integration with the [Polylang](https://wordpress.org/plugins/polylang/) plugin.
+
+The GraphQL schema is provided with mutations to:
+
+- Establish the language for custom posts, tags and categories, and
+- Define associations among them (i.e. indicate that a set of custom posts, tags or categories is a translation for each other).
+
+| Mutation | Description |
+| --- | --- |
+| `polylangSetCustomPostLanguage` | Set the language of the custom post. |
+| `polylangSetTaxonomyTermLanguage` | Set the language of the taxonomy term. |
+| `polylangSaveCustomPostTranslationAssociation` | Set the translation association for the custom post. |
+| `polylangSaveTaxonomyTermTranslationAssociation` | Set the translation association for the taxonomy term. |
+
+For instance, the following query defines the language for 3 posts (to English, Spanish and French), and then defines that these 3 posts are a translation of each other:
+
+```graphql
+mutation {
+  post1: polylangSetCustomPostLanguage(input: {id: 1, language: "en"}) {
+    status
+    errors {
+      __typename
+      ...on ErrorPayload {
+        message
+      }
+    }
+  }
+  post2: polylangSetCustomPostLanguage(input: {id: 2, language: "es"}) {
+    status
+    errors {
+      __typename
+      ...on ErrorPayload {
+        message
+      }
+    }
+  }
+  post3: polylangSetCustomPostLanguage(input: {id: 3, language: "fr"}) {
+    status
+    errors {
+      __typename
+      ...on ErrorPayload {
+        message
+      }
+    }
+  }
+  polylangSaveCustomPostTranslationAssociation(input: {
+    ids: [1, 2, 3]
+  }) {
+    status
+    errors {
+      __typename
+      ...on ErrorPayload {
+        message
+      }
+    }
+  }
+}
+```
 
 ## Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -288,7 +288,9 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 
 = 3.1.0 =
 * Use bulk mutations in predefined persisted queries (#2728)
+* Added documentation for new PRO module **Polylang Mutations** (#2733)
 * Fixed: Don't replace chars in translation persisted queries (#2731)
+* [PRO] Added **Polylang Mutations**
 
 = 3.0.0 =
 * Breaking change: Require at least WordPress v6.0 (#2719)


### PR DESCRIPTION
## Improvements

- Added documentation for new PRO module **Polylang Mutations**

## [PRO] Improvements

### Added Polylang Mutations

The new PRO module **Polylang Mutations** provides mutations for the integration with the [Polylang](https://wordpress.org/plugins/polylang/) plugin.

The GraphQL schema is provided with mutations to:

- Establish the language for custom posts, tags and categories, and
- Define associations among them (i.e. indicate that a set of custom posts, tags or categories is a translation for each other).

| Mutation | Description |
| --- | --- |
| `polylangSetCustomPostLanguage` | Set the language of the custom post. |
| `polylangSetTaxonomyTermLanguage` | Set the language of the taxonomy term. |
| `polylangSaveCustomPostTranslationAssociation` | Set the translation association for the custom post. |
| `polylangSaveTaxonomyTermTranslationAssociation` | Set the translation association for the taxonomy term. |

For instance, the following query defines the language for 3 posts (to English, Spanish and French), and then defines that these 3 posts are a translation of each other:

```graphql
mutation {
  post1: polylangSetCustomPostLanguage(input: {id: 1, language: "en"}) {
    status
    errors {
      __typename
      ...on ErrorPayload {
        message
      }
    }
  }
  post2: polylangSetCustomPostLanguage(input: {id: 2, language: "es"}) {
    status
    errors {
      __typename
      ...on ErrorPayload {
        message
      }
    }
  }
  post3: polylangSetCustomPostLanguage(input: {id: 3, language: "fr"}) {
    status
    errors {
      __typename
      ...on ErrorPayload {
        message
      }
    }
  }
  polylangSaveCustomPostTranslationAssociation(input: {
    ids: [1, 2, 3]
  }) {
    status
    errors {
      __typename
      ...on ErrorPayload {
        message
      }
    }
  }
}
```