### PR TITLE
Support running Lando with proxied domain using port

### DIFF
--- a/webservers/gatographql-for-prod/utils/calculate-webserver-domain.sh
+++ b/webservers/gatographql-for-prod/utils/calculate-webserver-domain.sh
@@ -18,7 +18,7 @@ LOCALHOST_WEBSERVER_DOMAIN="$1"
 #
 # @see https://docs.lando.dev/core/v3/proxy.html
 # ----------------------------------------------------------------------
-MAYBE_ENABLED_PROXIED_WEBSERVER_DOMAIN=$(echo $LANDO_INFO | grep -E -o "https:\/\/$PROXIED_WEBSERVER_DOMAIN" | grep -E -o "$PROXIED_WEBSERVER_DOMAIN")
+MAYBE_ENABLED_PROXIED_WEBSERVER_DOMAIN=$(echo $LANDO_INFO | grep -E -o "https:\/\/$PROXIED_WEBSERVER_DOMAIN(:[0-9]+)?" | grep -E -o "$PROXIED_WEBSERVER_DOMAIN(:[0-9]+)?")
 WEBSERVER_DOMAIN=(${MAYBE_ENABLED_PROXIED_WEBSERVER_DOMAIN:=$LOCALHOST_WEBSERVER_DOMAIN})
 
 echo $WEBSERVER_DOMAIN

--- a/webservers/gatographql/utils/calculate-webserver-domain.sh
+++ b/webservers/gatographql/utils/calculate-webserver-domain.sh
@@ -18,7 +18,7 @@ LOCALHOST_WEBSERVER_DOMAIN="$1"
 #
 # @see https://docs.lando.dev/core/v3/proxy.html
 # ----------------------------------------------------------------------
-MAYBE_ENABLED_PROXIED_WEBSERVER_DOMAIN=$(echo $LANDO_INFO | grep -E -o "https:\/\/$PROXIED_WEBSERVER_DOMAIN" | grep -E -o "$PROXIED_WEBSERVER_DOMAIN")
+MAYBE_ENABLED_PROXIED_WEBSERVER_DOMAIN=$(echo $LANDO_INFO | grep -E -o "https:\/\/$PROXIED_WEBSERVER_DOMAIN(:[0-9]+)?" | grep -E -o "$PROXIED_WEBSERVER_DOMAIN(:[0-9]+)?")
 WEBSERVER_DOMAIN=(${MAYBE_ENABLED_PROXIED_WEBSERVER_DOMAIN:=$LOCALHOST_WEBSERVER_DOMAIN})
 
 echo $WEBSERVER_DOMAIN


### PR DESCRIPTION
If port `80` is taken, Lando can run on another port, such as:

- `http://gatographql.lndo.site:8000/`
- `https://gatographql.lndo.site:444/`

This PR will start the server on whatever port is assigned by Lando.