### PR TITLE
Polylang: Return entities of type `PLL_Language`

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.3/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.3/en.md
@@ -128,7 +128,9 @@ Running this query:
     __typename
     id
     title
-    polylangLanguage
+    polylangLanguage {
+      code
+    }
     polylangTranslationLanguageIDs
     polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
 
@@ -136,7 +138,9 @@ Running this query:
       __typename
       id
       name
-      polylangLanguage
+      polylangLanguage {
+        code
+      }
       polylangTranslationLanguageIDs
       polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
     }
@@ -145,7 +149,9 @@ Running this query:
       __typename
       id
       name
-      polylangLanguage
+      polylangLanguage {
+        code
+      }
       polylangTranslationLanguageIDs
       polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
     }
@@ -155,7 +161,9 @@ Running this query:
     __typename
     id
     title
-    polylangLanguage
+    polylangLanguage {
+      code
+    }
     polylangTranslationLanguageIDs
     polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
   }
@@ -164,7 +172,9 @@ Running this query:
     __typename
     id
     title
-    polylangLanguage
+    polylangLanguage {
+      code
+    }
     polylangTranslationLanguageIDs
     polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
   }
@@ -181,7 +191,9 @@ Running this query:
         "__typename": "Post",
         "id": 1668,
         "title": "Some post translated using Polylang",
-        "polylangLanguage": "en",
+        "polylangLanguage": {
+          "code": "en"
+        },
         "polylangTranslationLanguageIDs": {
           "fr": 1670,
           "es": 1672
@@ -196,7 +208,9 @@ Running this query:
             "__typename": "PostCategory",
             "id": 61,
             "name": "Category for Polylang",
-            "polylangLanguage": "en",
+            "polylangLanguage": {
+              "code": "en"
+            },
             "polylangTranslationLanguageIDs": {
               "fr": 63,
               "es": 65
@@ -213,7 +227,9 @@ Running this query:
             "__typename": "PostTag",
             "id": 67,
             "name": "Tag for Polylang",
-            "polylangLanguage": "en",
+            "polylangLanguage": {
+              "code": "en"
+            },
             "polylangTranslationLanguageIDs": {
               "fr": 69,
               "es": 71
@@ -232,7 +248,9 @@ Running this query:
         "__typename": "Page",
         "id": 1674,
         "title": "Some page translated using Polylang",
-        "polylangLanguage": "en",
+        "polylangLanguage": {
+          "code": "en"
+        },
         "polylangTranslationLanguageIDs": {
           "fr": 1676,
           "es": 1678
@@ -249,7 +267,9 @@ Running this query:
         "__typename": "Media",
         "id": 40,
         "title": "Media-for-Polylang",
-        "polylangLanguage": "en",
+        "polylangLanguage": {
+          "code": "en"
+        },
         "polylangTranslationLanguageIDs": {
           "fr": 42,
           "es": 44
@@ -292,7 +312,9 @@ Running this query:
       title
       customPostType
       polylangIsTranslatable
-      polylangLanguage
+      polylangLanguage {
+        code
+      }
       polylangTranslationLanguageIDs
       polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
       
@@ -302,7 +324,9 @@ Running this query:
           id
           name
           polylangIsTranslatable
-          polylangLanguage
+          polylangLanguage {
+            code
+          }
           polylangTranslationLanguageIDs
           polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
         }
@@ -314,7 +338,9 @@ Running this query:
           id
           name
           polylangIsTranslatable
-          polylangLanguage
+          polylangLanguage {
+            code
+          }
           polylangTranslationLanguageIDs
           polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
         }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.3/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.3/en.md
@@ -128,9 +128,7 @@ Running this query:
     __typename
     id
     title
-    polylangLanguage {
-      code
-    }
+    polylangLanguage
     polylangTranslationLanguageIDs
     polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
 
@@ -138,9 +136,7 @@ Running this query:
       __typename
       id
       name
-      polylangLanguage {
-        code
-      }
+      polylangLanguage
       polylangTranslationLanguageIDs
       polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
     }
@@ -149,9 +145,7 @@ Running this query:
       __typename
       id
       name
-      polylangLanguage {
-        code
-      }
+      polylangLanguage
       polylangTranslationLanguageIDs
       polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
     }
@@ -161,9 +155,7 @@ Running this query:
     __typename
     id
     title
-    polylangLanguage {
-      code
-    }
+    polylangLanguage
     polylangTranslationLanguageIDs
     polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
   }
@@ -172,9 +164,7 @@ Running this query:
     __typename
     id
     title
-    polylangLanguage {
-      code
-    }
+    polylangLanguage
     polylangTranslationLanguageIDs
     polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
   }
@@ -191,9 +181,7 @@ Running this query:
         "__typename": "Post",
         "id": 1668,
         "title": "Some post translated using Polylang",
-        "polylangLanguage": {
-          "code": "en"
-        },
+        "polylangLanguage": "en",
         "polylangTranslationLanguageIDs": {
           "fr": 1670,
           "es": 1672
@@ -208,9 +196,7 @@ Running this query:
             "__typename": "PostCategory",
             "id": 61,
             "name": "Category for Polylang",
-            "polylangLanguage": {
-              "code": "en"
-            },
+            "polylangLanguage": "en",
             "polylangTranslationLanguageIDs": {
               "fr": 63,
               "es": 65
@@ -227,9 +213,7 @@ Running this query:
             "__typename": "PostTag",
             "id": 67,
             "name": "Tag for Polylang",
-            "polylangLanguage": {
-              "code": "en"
-            },
+            "polylangLanguage": "en",
             "polylangTranslationLanguageIDs": {
               "fr": 69,
               "es": 71
@@ -248,9 +232,7 @@ Running this query:
         "__typename": "Page",
         "id": 1674,
         "title": "Some page translated using Polylang",
-        "polylangLanguage": {
-          "code": "en"
-        },
+        "polylangLanguage": "en",
         "polylangTranslationLanguageIDs": {
           "fr": 1676,
           "es": 1678
@@ -267,9 +249,7 @@ Running this query:
         "__typename": "Media",
         "id": 40,
         "title": "Media-for-Polylang",
-        "polylangLanguage": {
-          "code": "en"
-        },
+        "polylangLanguage": "en",
         "polylangTranslationLanguageIDs": {
           "fr": 42,
           "es": 44
@@ -312,9 +292,7 @@ Running this query:
       title
       customPostType
       polylangIsTranslatable
-      polylangLanguage {
-        code
-      }
+      polylangLanguage
       polylangTranslationLanguageIDs
       polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
       
@@ -324,9 +302,7 @@ Running this query:
           id
           name
           polylangIsTranslatable
-          polylangLanguage {
-            code
-          }
+          polylangLanguage
           polylangTranslationLanguageIDs
           polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
         }
@@ -338,9 +314,7 @@ Running this query:
           id
           name
           polylangIsTranslatable
-          polylangLanguage {
-            code
-          }
+          polylangLanguage
           polylangTranslationLanguageIDs
           polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
         }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.3/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/2.3/en.md
@@ -115,7 +115,7 @@ These types implement interface `PolylangTranslatable`. (Type `Media` does only 
 
 | Field | Description |
 | --- | --- |
-| `polylangLanguage` | Language code of the post or page, or `null` if no language was assigned (eg: Polylang was installed later on). |
+| `polylangLanguage` | Language of the post or page, or `null` if no language was assigned (eg: Polylang was installed later on). |
 | `polylangTranslationLanguageIDs` | Nodes for all the translation languages for the entity, as a JSON object with the language code as key and entity ID as value, or `null` if no language was assigned (eg: Polylang was installed later on). |
 
 Field `polylangTranslationLanguageIDs` provides the entity IDs for all the translations (i.e. post/page/category/tag/media). It accepts input `includeSelf`, to indicate if to include the queried entity's ID in the results (it's `false` by default), and inputs `includeLanguages` and `excludeLanguages`, to filter the included languages in the results.
@@ -277,7 +277,7 @@ In addition, field `polylangIsTranslatable` indicates if the CPT or taxonomy is 
 
 | Field | Description |
 | --- | --- |
-| `polylangLanguage` | Language code of the post or page, or `null` if no language was assigned (eg: Polylang was installed later on), or if the entity is not configured to be translated (via Polylang Settings). |
+| `polylangLanguage` | Language of the post or page, or `null` if no language was assigned (eg: Polylang was installed later on), or if the entity is not configured to be translated (via Polylang Settings). |
 | `polylangTranslationLanguageIDs` | Nodes for all the translation languages for the entity, as a JSON object with the language code as key and entity ID as value, or `null` if no language was assigned (eg: Polylang was installed later on), or if the entity is not configured to be translated (via Polylang Settings). |
 | `polylangIsTranslatable` | Indicate if the entity can be translated. |
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.0/en.md
@@ -21,6 +21,8 @@
 
 - Rename field `_intSubstract` to `_intSubtract`
 - Rename directive `@intSubstract` to `@intSubtract`
+- Renamed field `polylangEnabledLanguages` to `polylangLanguages`
+- Fields `polylangLanguage`, `polylangDefaultLanguage` and `polylangLanguages` return type `PolylangLanguage` instead of `String`
 
 ## [PRO] Improvements
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
@@ -17,8 +17,12 @@ Running this query:
 
 ```graphql
 {
-  polylangDefaultLanguage
-  polylangEnabledLanguages
+  polylangDefaultLanguage {
+    code
+  }
+  polylangEnabledLanguages {
+    code
+  }
 }
 ```
 
@@ -27,11 +31,19 @@ Running this query:
 ```json
 {
   "data": {
-    "polylangDefaultLanguage": "en",
+    "polylangDefaultLanguage": {
+      "code": "en"
+    },
     "polylangEnabledLanguages": [
-      "en",
-      "es",
-      "fr"
+      {
+        "code": "en"
+      },
+      {
+        "code": "es"
+      },
+      {
+        "code": "fr"
+      }
     ]
   }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
@@ -58,7 +58,9 @@ Running this query:
     __typename
     id
     title
-    polylangLanguage
+    polylangLanguage {
+      code
+    }
     polylangTranslationLanguageIDs
     polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
 
@@ -66,7 +68,9 @@ Running this query:
       __typename
       id
       name
-      polylangLanguage
+      polylangLanguage {
+        code
+      }
       polylangTranslationLanguageIDs
       polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
     }
@@ -75,7 +79,9 @@ Running this query:
       __typename
       id
       name
-      polylangLanguage
+      polylangLanguage {
+        code
+      }
       polylangTranslationLanguageIDs
       polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
     }
@@ -85,7 +91,9 @@ Running this query:
     __typename
     id
     title
-    polylangLanguage
+    polylangLanguage {
+      code
+    }
     polylangTranslationLanguageIDs
     polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
   }
@@ -94,7 +102,9 @@ Running this query:
     __typename
     id
     title
-    polylangLanguage
+    polylangLanguage {
+      code
+    }
     polylangTranslationLanguageIDs
     polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
   }
@@ -111,7 +121,9 @@ Running this query:
         "__typename": "Post",
         "id": 1668,
         "title": "Some post translated using Polylang",
-        "polylangLanguage": "en",
+        "polylangLanguage": {
+          "code": "en"
+        },
         "polylangTranslationLanguageIDs": {
           "fr": 1670,
           "es": 1672
@@ -126,7 +138,9 @@ Running this query:
             "__typename": "PostCategory",
             "id": 61,
             "name": "Category for Polylang",
-            "polylangLanguage": "en",
+            "polylangLanguage": {
+              "code": "en"
+            },
             "polylangTranslationLanguageIDs": {
               "fr": 63,
               "es": 65
@@ -143,7 +157,9 @@ Running this query:
             "__typename": "PostTag",
             "id": 67,
             "name": "Tag for Polylang",
-            "polylangLanguage": "en",
+            "polylangLanguage": {
+              "code": "en"
+            },
             "polylangTranslationLanguageIDs": {
               "fr": 69,
               "es": 71
@@ -162,7 +178,9 @@ Running this query:
         "__typename": "Page",
         "id": 1674,
         "title": "Some page translated using Polylang",
-        "polylangLanguage": "en",
+        "polylangLanguage": {
+          "code": "en"
+        },
         "polylangTranslationLanguageIDs": {
           "fr": 1676,
           "es": 1678
@@ -179,7 +197,9 @@ Running this query:
         "__typename": "Media",
         "id": 40,
         "title": "Media-for-Polylang",
-        "polylangLanguage": "en",
+        "polylangLanguage": {
+          "code": "en"
+        },
         "polylangTranslationLanguageIDs": {
           "fr": 42,
           "es": 44
@@ -222,7 +242,9 @@ Running this query:
       title
       customPostType
       polylangIsTranslatable
-      polylangLanguage
+      polylangLanguage {
+        code
+      }
       polylangTranslationLanguageIDs
       polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
       
@@ -232,7 +254,9 @@ Running this query:
           id
           name
           polylangIsTranslatable
-          polylangLanguage
+          polylangLanguage {
+            code
+          }
           polylangTranslationLanguageIDs
           polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
         }
@@ -244,7 +268,9 @@ Running this query:
           id
           name
           polylangIsTranslatable
-          polylangLanguage
+          polylangLanguage {
+            code
+          }
           polylangTranslationLanguageIDs
           polylangTranslationLanguageIDsWithSelf: polylangTranslationLanguageIDs(filter: { includeSelf: true })
         }
@@ -266,7 +292,9 @@ Running this query:
         "title": "Some CPT that has Polylang translation enabled",
         "customPostType": "some-cpt",
         "polylangIsTranslatable": true,
-        "polylangLanguage": "en",
+        "polylangLanguage": {
+          "code": "en"
+        },
         "polylangTranslationLanguageIDs": {
           "fr": 12,
           "es": 14
@@ -282,7 +310,9 @@ Running this query:
             "id": 30,
             "name": "Some Category for Polylang",
             "polylangIsTranslatable": true,
-            "polylangLanguage": "en",
+            "polylangLanguage": {
+              "code": "en"
+            },
             "polylangTranslationLanguageIDs": {
               "fr": 32,
               "es": 34
@@ -300,7 +330,9 @@ Running this query:
             "id": 50,
             "name": "Some Tag for Polylang",
             "polylangIsTranslatable": true,
-            "polylangLanguage": "en",
+            "polylangLanguage": {
+              "code": "en"
+            },
             "polylangTranslationLanguageIDs": {
               "fr": 52,
               "es": 54

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
@@ -11,7 +11,7 @@ Query the site metadata configured in Polylang.
 | Field | Description |
 | --- | --- |
 | `polylangDefaultLanguage` | Default language on Polylang, or `null` if there are no languages enabled. |
-| `polylangLanguages` | Enabled languages on Polylang. |
+| `polylangLanguages` | List of languages on Polylang. |
 
 Running this query:
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
@@ -57,7 +57,7 @@ These types implement interface `PolylangTranslatable`. (Type `Media` does only 
 
 | Field | Description |
 | --- | --- |
-| `polylangLanguage` | Language code of the post or page, or `null` if no language was assigned (eg: Polylang was installed later on). |
+| `polylangLanguage` | Language of the post or page, or `null` if no language was assigned (eg: Polylang was installed later on). |
 | `polylangTranslationLanguageIDs` | Nodes for all the translation languages for the entity, as a JSON object with the language code as key and entity ID as value, or `null` if no language was assigned (eg: Polylang was installed later on). |
 
 Field `polylangTranslationLanguageIDs` provides the entity IDs for all the translations (i.e. post/page/category/tag/media). It accepts input `includeSelf`, to indicate if to include the queried entity's ID in the results (it's `false` by default), and inputs `includeLanguages` and `excludeLanguages`, to filter the included languages in the results.
@@ -239,7 +239,7 @@ In addition, field `polylangIsTranslatable` indicates if the CPT or taxonomy is 
 
 | Field | Description |
 | --- | --- |
-| `polylangLanguage` | Language code of the post or page, or `null` if no language was assigned (eg: Polylang was installed later on), or if the entity is not configured to be translated (via Polylang Settings). |
+| `polylangLanguage` | Language of the post or page, or `null` if no language was assigned (eg: Polylang was installed later on), or if the entity is not configured to be translated (via Polylang Settings). |
 | `polylangTranslationLanguageIDs` | Nodes for all the translation languages for the entity, as a JSON object with the language code as key and entity ID as value, or `null` if no language was assigned (eg: Polylang was installed later on), or if the entity is not configured to be translated (via Polylang Settings). |
 | `polylangIsTranslatable` | Indicate if the entity can be translated. |
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
@@ -11,7 +11,7 @@ Query the site metadata configured in Polylang.
 | Field | Description |
 | --- | --- |
 | `polylangDefaultLanguage` | Default language on Polylang, or `null` if there are no languages enabled. |
-| `polylangEnabledLanguages` | Enabled languages on Polylang. |
+| `polylangLanguages` | Enabled languages on Polylang. |
 
 Running this query:
 
@@ -20,7 +20,7 @@ Running this query:
   polylangDefaultLanguage {
     code
   }
-  polylangEnabledLanguages {
+  polylangLanguages {
     code
   }
 }
@@ -34,7 +34,7 @@ Running this query:
     "polylangDefaultLanguage": {
       "code": "en"
     },
-    "polylangEnabledLanguages": [
+    "polylangLanguages": [
       {
         "code": "en"
       },

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -297,6 +297,8 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 * Fixed: "Call to protected method" exception in PHP 8.2 (#2741)
 * [PRO] Breaking change: Rename field `_intSubstract` to `_intSubtract`
 * [PRO] Breaking change: Rename directive `@intSubstract` to `@intSubtract`
+* [PRO] Breaking change: Renamed field `polylangEnabledLanguages` to `polylangLanguages`
+* [PRO] Breaking change: Fields `polylangLanguage`, `polylangDefaultLanguage` and `polylangLanguages` return type `PolylangLanguage` instead of `String`
 * [PRO] Added **Polylang Mutations**
 * [PRO] Added field `_arrayIntersect`
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/create-missing-translation-posts-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/create-missing-translation-posts-for-polylang.gql
@@ -84,8 +84,9 @@ query ExportOriginPost(
     ################################################################
 
 
-    polylangLanguage
-      @export(as: "fromLanguage")
+    polylangLanguage {
+      code @export(as: "fromLanguage")
+    }
     
 
     polylangTranslationLanguageIDs(filter: {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/create-missing-translation-posts-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/create-missing-translation-posts-for-polylang.gql
@@ -57,7 +57,7 @@ query ExportOriginPost(
     code @export(as: "defaultLanguage")
   }
 
-  enabledLanguages: polylangLanguages {
+  enabledLanguages: polylangLanguages(filter: { enabled: true }) {
     code @export(as: "enabledLanguages", type: LIST)
   }
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/create-missing-translation-posts-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/create-missing-translation-posts-for-polylang.gql
@@ -57,7 +57,7 @@ query ExportOriginPost(
     code @export(as: "defaultLanguage")
   }
 
-  enabledLanguages: polylangEnabledLanguages {
+  enabledLanguages: polylangLanguages {
     code @export(as: "enabledLanguages", type: LIST)
   }
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/create-missing-translation-posts-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/create-missing-translation-posts-for-polylang.gql
@@ -53,11 +53,13 @@ query ExportOriginPost(
 )
   @depends(on: "InitializeVariables")
 {
-  defaultLanguage: polylangDefaultLanguage
-    @export(as: "defaultLanguage")
+  defaultLanguage: polylangDefaultLanguage {
+    code @export(as: "defaultLanguage")
+  }
 
-  enabledLanguages: polylangEnabledLanguages
-    @export(as: "enabledLanguages")
+  enabledLanguages: polylangEnabledLanguages {
+    code @export(as: "enabledLanguages", type: LIST)
+  }
 
   originPost: post(by: { id: $postId }, status: any) {
     id

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
@@ -134,13 +134,12 @@ mutation UpdateOrRemoveFeaturedImageForTranslationPosts(
   {
     id
 
-    polylangLanguageCode: _objectProperty(
-      object: $translationPostLanguages,
-      by: { key: $__id }
-    )
+    polylangLanguage {
+      code
+    }
     polylangLanguage: _objectProperty(
       object: $languageLocaleCodes,
-      by: { key: $__polylangLanguageCode }
+      by: { key: $__polylangLanguage }
     )
 
     translationFeaturedImageID: _objectProperty(

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
@@ -134,12 +134,12 @@ mutation UpdateOrRemoveFeaturedImageForTranslationPosts(
   {
     id
 
-    polylangLanguage {
+    polylangLanguageLocale: polylangLanguage {
       code
     }
     polylangLanguage: _objectProperty(
       object: $languageLocaleCodes,
-      by: { key: $__polylangLanguage }
+      by: { key: $__polylangLanguageLocale }
     )
 
     translationFeaturedImageID: _objectProperty(

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
@@ -55,8 +55,9 @@ query InitializeVariables
 query ExportDataFromOriginPost($postId: ID!)
   @depends(on: "InitializeVariables")
 {
-  defaultLanguage: polylangDefaultLanguage
-    @export(as: "defaultLanguage")
+  defaultLanguage: polylangDefaultLanguage {
+    code @export(as: "defaultLanguage")
+  }
 
   originPost: post(by: { id: $postId }, status: any) {
     id

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
@@ -176,7 +176,7 @@ mutation UpdateOrRemoveFeaturedImageForTranslationPosts(
           featuredImage {
             id
             polylangLanguage {
-              en
+              code
             }
           }
         }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
@@ -61,8 +61,9 @@ query ExportDataFromOriginPost($postId: ID!)
   originPost: post(by: { id: $postId }, status: any) {
     id
 
-    polylangLanguage
-      @export(as: "fromLanguage")
+    polylangLanguage {
+      code @export(as: "fromLanguage")
+    }
     
     polylangTranslationLanguageIDs
     translationPostIds: _objectValues(object: $__polylangTranslationLanguageIDs)
@@ -92,6 +93,10 @@ query FilterTranslationPostsToUpdate(
 {
   translationPosts: posts(filter: { ids: $originPostTranslationPostIds, status: $statusToUpdate } ) {
     id
+
+    polylangLanguage {
+      code @export(as: "polylangLanguageIDCodes", type: DICTIONARY)
+    }
   }
 
   hasTranslationPosts: _notEmpty(value: $__translationPosts)
@@ -125,7 +130,10 @@ mutation UpdateOrRemoveFeaturedImageForTranslationPosts(
   {
     id
 
-    polylangLanguage
+    polylangLanguage: _objectProperty(
+      object: $polylangLanguageIDCodes,
+      by: { key: $__id }
+    )
     translationFeaturedImageID: _objectProperty(
       object: $featuredImageTranslationLanguageIDs,
       by: {
@@ -159,7 +167,9 @@ mutation UpdateOrRemoveFeaturedImageForTranslationPosts(
         ...on CustomPost {
           featuredImage {
             id
-            polylangLanguage
+            polylangLanguage {
+              en
+            }
           }
         }
       }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
@@ -101,10 +101,6 @@ query FilterTranslationPostsToUpdate(
 {
   translationPosts: posts(filter: { ids: $originPostTranslationPostIds, status: $statusToUpdate } ) {
     id
-
-    polylangLanguage {
-      code @export(as: "polylangLanguageIDCodes", type: DICTIONARY)
-    }
   }
 
   hasTranslationPosts: _notEmpty(value: $__translationPosts)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-featuredimage-for-polylang.gql
@@ -59,6 +59,13 @@ query ExportDataFromOriginPost($postId: ID!)
     code @export(as: "defaultLanguage")
   }
 
+  languages: polylangLanguages {
+    code @export(
+      as: "languageLocaleCodes"
+      type: DICTIONARY
+    )
+  }
+
   originPost: post(by: { id: $postId }, status: any) {
     id
 
@@ -131,10 +138,15 @@ mutation UpdateOrRemoveFeaturedImageForTranslationPosts(
   {
     id
 
-    polylangLanguage: _objectProperty(
-      object: $polylangLanguageIDCodes,
+    polylangLanguageCode: _objectProperty(
+      object: $translationPostLanguages,
       by: { key: $__id }
     )
+    polylangLanguage: _objectProperty(
+      object: $languageLocaleCodes,
+      by: { key: $__polylangLanguageCode }
+    )
+
     translationFeaturedImageID: _objectProperty(
       object: $featuredImageTranslationLanguageIDs,
       by: {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-tags-and-categories-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-tags-and-categories-for-polylang.gql
@@ -51,8 +51,9 @@ query InitializeVariables
 query ExportDataFromOriginPost($postId: ID!)
   @depends(on: "InitializeVariables")
 {
-  defaultLanguage: polylangDefaultLanguage
-    @export(as: "defaultLanguage")
+  defaultLanguage: polylangDefaultLanguage {
+    code @export(as: "defaultLanguage")
+  }
 
   originPost: post(by: { id: $postId }, status: any) {
     id

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-tags-and-categories-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-tags-and-categories-for-polylang.gql
@@ -57,8 +57,9 @@ query ExportDataFromOriginPost($postId: ID!)
   originPost: post(by: { id: $postId }, status: any) {
     id
 
-    polylangLanguage
-      @export(as: "fromLanguage")
+    polylangLanguage {
+      code @export(as: "fromLanguage")
+    }
     
     polylangTranslationLanguageIDs
     translationPostIds: _objectValues(object: $__polylangTranslationLanguageIDs)
@@ -70,7 +71,9 @@ query ExportDataFromOriginPost($postId: ID!)
     tags @export(as: "originPostTagIDs") {
       id
       name
-      polylangLanguage
+      polylangLanguage {
+        code
+      }
       polylangTranslationLanguageIDs
         @export(
           as: "tagIDTranslationLanguageIDs",
@@ -81,7 +84,9 @@ query ExportDataFromOriginPost($postId: ID!)
     categories @export(as: "originPostCategoryIDs") {
       id
       name
-      polylangLanguage
+      polylangLanguage {
+        code
+      }
       polylangTranslationLanguageIDs
         @export(
           as: "categoryIDTranslationLanguageIDs",
@@ -91,16 +96,34 @@ query ExportDataFromOriginPost($postId: ID!)
   }
 }
 
-query FilterTranslationPostsToUpdate(
+query ExportTranslationPostLanguages(
   $statusToUpdate: CustomPostStatusEnum! = draft
-  $triggerUpdateFromDefaultLanguageOnly: Boolean! = true
 )
   @depends(on: "ExportDataFromOriginPost")
   @include(if: $hasOriginPostTranslationPosts)
 {
+  translationPostLanguages: posts(filter: { ids: $originPostTranslationPostIds, status: $statusToUpdate } ) {
+    id
+
+    polylangLanguage {
+      code @export(as: "polylangLanguageIDCodes", type: DICTIONARY)
+    }
+  }
+}
+
+query FilterTranslationPostsToUpdate(
+  $statusToUpdate: CustomPostStatusEnum! = draft
+  $triggerUpdateFromDefaultLanguageOnly: Boolean! = true
+)
+  @depends(on: "ExportTranslationPostLanguages")
+  @include(if: $hasOriginPostTranslationPosts)
+{
   translationPosts: posts(filter: { ids: $originPostTranslationPostIds, status: $statusToUpdate } ) {
     id
-    polylangLanguage
+    polylangLanguage: _objectProperty(
+      object: $polylangLanguageIDCodes,
+      by: { key: $__id }
+    )
 
     translationPostTagIDs: _echo(value: $__polylangLanguage)
       @passOnwards(as: "lang")
@@ -202,7 +225,9 @@ mutation UpdateTagsAndCategoriesForTranslationPosts(
   updateTranslationPosts: posts(filter: { ids: $originPostTranslationPostIds, status: $statusToUpdate } )
   {
     id
-    polylangLanguage
+    polylangLanguage {
+      code
+    }
 
     tagIDs: _objectProperty(
       object: $translationPostTagIDs,
@@ -231,7 +256,9 @@ mutation UpdateTagsAndCategoriesForTranslationPosts(
         tags {
           id
           name
-          polylangLanguage
+          polylangLanguage {
+            code
+          }
         }
       }
     }
@@ -254,7 +281,9 @@ mutation UpdateTagsAndCategoriesForTranslationPosts(
         categories {
           id
           name
-          polylangLanguage
+          polylangLanguage {
+            code
+          }
         }
       }
     }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-tags-and-categories-for-polylang.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/sync-tags-and-categories-for-polylang.gql
@@ -55,6 +55,13 @@ query ExportDataFromOriginPost($postId: ID!)
     code @export(as: "defaultLanguage")
   }
 
+  languages: polylangLanguages {
+    code @export(
+      as: "languageLocaleCodes"
+      type: DICTIONARY
+    )
+  }
+
   originPost: post(by: { id: $postId }, status: any) {
     id
 
@@ -106,8 +113,11 @@ query ExportTranslationPostLanguages(
   translationPostLanguages: posts(filter: { ids: $originPostTranslationPostIds, status: $statusToUpdate } ) {
     id
 
-    polylangLanguage {
-      code @export(as: "polylangLanguageIDCodes", type: DICTIONARY)
+    polylangLanguage @export(
+      as: "translationPostLanguages"
+      type: DICTIONARY
+    ) {
+      code
     }
   }
 }
@@ -121,9 +131,13 @@ query FilterTranslationPostsToUpdate(
 {
   translationPosts: posts(filter: { ids: $originPostTranslationPostIds, status: $statusToUpdate } ) {
     id
-    polylangLanguage: _objectProperty(
-      object: $polylangLanguageIDCodes,
+    polylangLanguageCode: _objectProperty(
+      object: $translationPostLanguages,
       by: { key: $__id }
+    )
+    polylangLanguage: _objectProperty(
+      object: $languageLocaleCodes,
+      by: { key: $__polylangLanguageCode }
     )
 
     translationPostTagIDs: _echo(value: $__polylangLanguage)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
@@ -85,8 +85,9 @@ query ExportOriginPost(
 )
   @depends(on: "InitializeVariables")
 {
-  defaultLanguage: polylangDefaultLanguage
-    @export(as: "defaultLanguage")
+  defaultLanguage: polylangDefaultLanguage {
+    code @export(as: "defaultLanguage")
+  }
 
   originPost: post(by: { id: $postId }, status: any) {
     id

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
@@ -89,6 +89,13 @@ query ExportOriginPost(
     code @export(as: "defaultLanguage")
   }
 
+  languages: polylangLanguages {
+    code @export(
+      as: "languageLocaleCodes"
+      type: DICTIONARY
+    )
+  }
+
   originPost: post(by: { id: $postId }, status: any) {
     id
 
@@ -133,12 +140,11 @@ query FetchData(
   translationPosts: posts(filter: { ids: $translationPostIds, status: $statusToUpdate } ) {
     id
 
-    polylangLanguage {
+    polylangLanguage @export(
+      as: "translationPostLanguages"
+      type: DICTIONARY
+    ) {
       code
-        @export(
-          as: "translationPostLanguages"
-          type: DICTIONARY
-        )
     }
 
     rawTitle: _echo(value: $originRawTitle)
@@ -193,13 +199,21 @@ query TranslateData(
   translatedData: _echo(value: $dataToTranslate)
     @underEachJSONObjectProperty(
       passKeyOnwardsAs: "postID"
-      affectDirectivesUnderPos: [1, 2, 3]
+      affectDirectivesUnderPos: [1, 2, 3, 4]
     )
       @applyField(
         name: "_objectProperty",
         arguments: {
           object: $translationPostLanguages,
           by: { key: $postID }
+        },
+        passOnwardsAs: "toLanguageLocale"
+      )
+      @applyField(
+        name: "_objectProperty",
+        arguments: {
+          object: $languageLocaleCodes,
+          by: { key: $toLanguageLocale }
         },
         passOnwardsAs: "toLanguage"
       )

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-classic-editor.gql
@@ -92,8 +92,9 @@ query ExportOriginPost(
     id
 
 
-    polylangLanguage
-      @export(as: "fromLanguage")
+    polylangLanguage {
+      code @export(as: "fromLanguage")
+    }
     
 
     polylangTranslationLanguageIDs(filter: {
@@ -131,11 +132,13 @@ query FetchData(
   translationPosts: posts(filter: { ids: $translationPostIds, status: $statusToUpdate } ) {
     id
 
-    polylangLanguage
-      @export(
-        as: "translationPostLanguages"
-        type: DICTIONARY
-      )
+    polylangLanguage {
+      code
+        @export(
+          as: "translationPostLanguages"
+          type: DICTIONARY
+        )
+    }
 
     rawTitle: _echo(value: $originRawTitle)
     rawContent: _echo(value: $originRawContent)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
@@ -158,8 +158,9 @@ query ExportOriginPost(
 )
   @depends(on: "InitializeVariables")
 {
-  defaultLanguage: polylangDefaultLanguage
-    @export(as: "defaultLanguage")
+  defaultLanguage: polylangDefaultLanguage {
+    code @export(as: "defaultLanguage")
+  }
 
   originPost: post(by: { id: $postId }, status: any) {
     id

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
@@ -165,8 +165,9 @@ query ExportOriginPost(
     id
 
 
-    polylangLanguage
-      @export(as: "fromLanguage")
+    polylangLanguage {
+      code @export(as: "fromLanguage")
+    }
     
 
     polylangTranslationLanguageIDs(filter: {
@@ -759,12 +760,13 @@ query FetchData($statusToUpdate: CustomPostStatusEnum! = draft)
       @remove
 
 
-    polylangLanguage
-      @export(
-        as: "translationPostLanguages"
-        type: DICTIONARY
-      )
-      @remove
+    polylangLanguage {
+      code
+        @export(
+          as: "translationPostLanguages"
+          type: DICTIONARY
+        )
+    }
 
 
     coreHeadingContentItems: _echo(value: $originCoreHeadingContentItems)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translate-posts-for-polylang-gutenberg.gql
@@ -162,6 +162,13 @@ query ExportOriginPost(
     code @export(as: "defaultLanguage")
   }
 
+  languages: polylangLanguages {
+    code @export(
+      as: "languageLocaleCodes"
+      type: DICTIONARY
+    )
+  }
+
   originPost: post(by: { id: $postId }, status: any) {
     id
 
@@ -761,12 +768,11 @@ query FetchData($statusToUpdate: CustomPostStatusEnum! = draft)
       @remove
 
 
-    polylangLanguage {
+    polylangLanguage @export(
+      as: "translationPostLanguages"
+      type: DICTIONARY
+    ) {
       code
-        @export(
-          as: "translationPostLanguages"
-          type: DICTIONARY
-        )
     }
 
 
@@ -1311,13 +1317,21 @@ query TransformData(
       @underJSONObjectProperty(by: { key: "to" })
         @underEachJSONObjectProperty(
           passKeyOnwardsAs: "postId"
-          affectDirectivesUnderPos: [1, 2, 3]
+          affectDirectivesUnderPos: [1, 2, 3, 4]
         )
           @applyField(
             name: "_objectProperty",
             arguments: {
               object: $translationPostLanguages,
               by: { key: $postId }
+            },
+            passOnwardsAs: "toLanguageLocale"
+          )
+          @applyField(
+            name: "_objectProperty",
+            arguments: {
+              object: $languageLocaleCodes,
+              by: { key: $toLanguageLocale }
             },
             passOnwardsAs: "toLanguage"
           )


### PR DESCRIPTION
Improvements (with breaking changes) in Gato GraphQL PRO:

- Renamed field `polylangEnabledLanguages` to `polylangLanguages`
- Fields `polylangLanguage`, `polylangDefaultLanguage` and `polylangLanguages` return type `PolylangLanguage` instead of `String`