### PR TITLE
Add filtering posts/pages/cpts/taxonomies by Polylang language

### DIFF
--- a/layers/CMSSchema/packages/categories/src/TypeResolvers/InputObjectType/AbstractCategoriesFilterInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/categories/src/TypeResolvers/InputObjectType/AbstractCategoriesFilterInputObjectTypeResolver.php
@@ -6,7 +6,7 @@ namespace PoPCMSSchema\Categories\TypeResolvers\InputObjectType;
 
 use PoPCMSSchema\Taxonomies\TypeResolvers\InputObjectType\AbstractTaxonomiesFilterInputObjectTypeResolver;
 
-abstract class AbstractCategoriesFilterInputObjectTypeResolver extends AbstractTaxonomiesFilterInputObjectTypeResolver
+abstract class AbstractCategoriesFilterInputObjectTypeResolver extends AbstractTaxonomiesFilterInputObjectTypeResolver implements CategoriesFilterInputObjectTypeResolverInterface
 {
     public function getTypeDescription(): ?string
     {

--- a/layers/CMSSchema/packages/categories/src/TypeResolvers/InputObjectType/CategoriesFilterInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/categories/src/TypeResolvers/InputObjectType/CategoriesFilterInputObjectTypeResolverInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\Categories\TypeResolvers\InputObjectType;
+
+interface CategoriesFilterInputObjectTypeResolverInterface
+{
+}

--- a/layers/CMSSchema/packages/media/src/TypeResolvers/InputObjectType/AbstractMediaItemsFilterInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/media/src/TypeResolvers/InputObjectType/AbstractMediaItemsFilterInputObjectTypeResolver.php
@@ -13,7 +13,7 @@ use PoPCMSSchema\SchemaCommons\FilterInputs\SearchFilterInput;
 use PoPCMSSchema\SchemaCommons\TypeResolvers\InputObjectType\AbstractObjectsFilterInputObjectTypeResolver;
 use PoPCMSSchema\SchemaCommons\TypeResolvers\InputObjectType\DateQueryInputObjectTypeResolver;
 
-abstract class AbstractMediaItemsFilterInputObjectTypeResolver extends AbstractObjectsFilterInputObjectTypeResolver
+abstract class AbstractMediaItemsFilterInputObjectTypeResolver extends AbstractObjectsFilterInputObjectTypeResolver implements MediaItemsFilterInputObjectTypeResolverInterface
 {
     private ?DateQueryInputObjectTypeResolver $dateQueryInputObjectTypeResolver = null;
     private ?StringScalarTypeResolver $stringScalarTypeResolver = null;

--- a/layers/CMSSchema/packages/media/src/TypeResolvers/InputObjectType/MediaItemsFilterInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/media/src/TypeResolvers/InputObjectType/MediaItemsFilterInputObjectTypeResolverInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\Media\TypeResolvers\InputObjectType;
 
-interface MediaItemsFilterInputObjectTypeResolverInterface {
-
+interface MediaItemsFilterInputObjectTypeResolverInterface
+{
 }

--- a/layers/CMSSchema/packages/media/src/TypeResolvers/InputObjectType/MediaItemsFilterInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/media/src/TypeResolvers/InputObjectType/MediaItemsFilterInputObjectTypeResolverInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\Media\TypeResolvers\InputObjectType;
+
+interface MediaItemsFilterInputObjectTypeResolverInterface {
+
+}

--- a/layers/CMSSchema/packages/post-categories/src/FieldResolvers/ObjectType/RootPostCategoryObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-categories/src/FieldResolvers/ObjectType/RootPostCategoryObjectTypeFieldResolver.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace PoPCMSSchema\PostCategories\FieldResolvers\ObjectType;
 
 use PoPCMSSchema\Categories\TypeResolvers\InputObjectType\CategoryPaginationInputObjectTypeResolver;
-use PoPCMSSchema\Categories\TypeResolvers\InputObjectType\RootCategoriesFilterInputObjectTypeResolver;
 use PoPCMSSchema\PostCategories\TypeAPIs\PostCategoryTypeAPIInterface;
 use PoPCMSSchema\PostCategories\TypeResolvers\InputObjectType\PostCategoryByOneofInputObjectTypeResolver;
+use PoPCMSSchema\PostCategories\TypeResolvers\InputObjectType\RootPostCategoriesFilterInputObjectTypeResolver;
 use PoPCMSSchema\PostCategories\TypeResolvers\ObjectType\PostCategoryObjectTypeResolver;
 use PoPCMSSchema\SchemaCommons\DataLoading\ReturnTypes;
 use PoPCMSSchema\SchemaCommons\Resolvers\WithLimitFieldArgResolverTrait;
@@ -34,7 +34,7 @@ class RootPostCategoryObjectTypeFieldResolver extends AbstractQueryableObjectTyp
     private ?PostCategoryObjectTypeResolver $postCategoryObjectTypeResolver = null;
     private ?PostCategoryTypeAPIInterface $postCategoryTypeAPI = null;
     private ?PostCategoryByOneofInputObjectTypeResolver $postCategoryByOneofInputObjectTypeResolver = null;
-    private ?RootCategoriesFilterInputObjectTypeResolver $rootCategoriesFilterInputObjectTypeResolver = null;
+    private ?RootPostCategoriesFilterInputObjectTypeResolver $rootPostCategoriesFilterInputObjectTypeResolver = null;
     private ?CategoryPaginationInputObjectTypeResolver $categoryPaginationInputObjectTypeResolver = null;
     private ?TaxonomySortInputObjectTypeResolver $taxonomySortInputObjectTypeResolver = null;
 
@@ -103,18 +103,18 @@ class RootPostCategoryObjectTypeFieldResolver extends AbstractQueryableObjectTyp
         }
         return $this->postCategoryByOneofInputObjectTypeResolver;
     }
-    final public function setRootCategoriesFilterInputObjectTypeResolver(RootCategoriesFilterInputObjectTypeResolver $rootCategoriesFilterInputObjectTypeResolver): void
+    final public function setRootPostCategoriesFilterInputObjectTypeResolver(RootPostCategoriesFilterInputObjectTypeResolver $rootPostCategoriesFilterInputObjectTypeResolver): void
     {
-        $this->rootCategoriesFilterInputObjectTypeResolver = $rootCategoriesFilterInputObjectTypeResolver;
+        $this->rootPostCategoriesFilterInputObjectTypeResolver = $rootPostCategoriesFilterInputObjectTypeResolver;
     }
-    final protected function getRootCategoriesFilterInputObjectTypeResolver(): RootCategoriesFilterInputObjectTypeResolver
+    final protected function getRootPostCategoriesFilterInputObjectTypeResolver(): RootPostCategoriesFilterInputObjectTypeResolver
     {
-        if ($this->rootCategoriesFilterInputObjectTypeResolver === null) {
-            /** @var RootCategoriesFilterInputObjectTypeResolver */
-            $rootCategoriesFilterInputObjectTypeResolver = $this->instanceManager->getInstance(RootCategoriesFilterInputObjectTypeResolver::class);
-            $this->rootCategoriesFilterInputObjectTypeResolver = $rootCategoriesFilterInputObjectTypeResolver;
+        if ($this->rootPostCategoriesFilterInputObjectTypeResolver === null) {
+            /** @var RootPostCategoriesFilterInputObjectTypeResolver */
+            $rootPostCategoriesFilterInputObjectTypeResolver = $this->instanceManager->getInstance(RootPostCategoriesFilterInputObjectTypeResolver::class);
+            $this->rootPostCategoriesFilterInputObjectTypeResolver = $rootPostCategoriesFilterInputObjectTypeResolver;
         }
-        return $this->rootCategoriesFilterInputObjectTypeResolver;
+        return $this->rootPostCategoriesFilterInputObjectTypeResolver;
     }
     final public function setCategoryPaginationInputObjectTypeResolver(CategoryPaginationInputObjectTypeResolver $categoryPaginationInputObjectTypeResolver): void
     {
@@ -222,7 +222,7 @@ class RootPostCategoryObjectTypeFieldResolver extends AbstractQueryableObjectTyp
             'postCategoryNames' => array_merge(
                 $fieldArgNameTypeResolvers,
                 [
-                    'filter' => $this->getRootCategoriesFilterInputObjectTypeResolver(),
+                    'filter' => $this->getRootPostCategoriesFilterInputObjectTypeResolver(),
                     'pagination' => $this->getCategoryPaginationInputObjectTypeResolver(),
                     'sort' => $this->getTaxonomySortInputObjectTypeResolver(),
                 ]
@@ -230,7 +230,7 @@ class RootPostCategoryObjectTypeFieldResolver extends AbstractQueryableObjectTyp
             'postCategoryCount' => array_merge(
                 $fieldArgNameTypeResolvers,
                 [
-                    'filter' => $this->getRootCategoriesFilterInputObjectTypeResolver(),
+                    'filter' => $this->getRootPostCategoriesFilterInputObjectTypeResolver(),
                 ]
             ),
             default => $fieldArgNameTypeResolvers,

--- a/layers/CMSSchema/packages/post-categories/src/TypeResolvers/InputObjectType/PostCategoriesFilterInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/post-categories/src/TypeResolvers/InputObjectType/PostCategoriesFilterInputObjectTypeResolverInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\PostCategories\TypeResolvers\InputObjectType;
 
-interface PostCategoriesFilterInputObjectTypeResolverInterface {
-
+interface PostCategoriesFilterInputObjectTypeResolverInterface
+{
 }

--- a/layers/CMSSchema/packages/post-categories/src/TypeResolvers/InputObjectType/PostCategoriesFilterInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/post-categories/src/TypeResolvers/InputObjectType/PostCategoriesFilterInputObjectTypeResolverInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\PostCategories\TypeResolvers\InputObjectType;
+
+interface PostCategoriesFilterInputObjectTypeResolverInterface {
+
+}

--- a/layers/CMSSchema/packages/post-categories/src/TypeResolvers/InputObjectType/RootPostCategoriesFilterInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/post-categories/src/TypeResolvers/InputObjectType/RootPostCategoriesFilterInputObjectTypeResolver.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\PostCategories\TypeResolvers\InputObjectType;
+
+use PoPCMSSchema\Categories\TypeResolvers\InputObjectType\AbstractCategoriesFilterInputObjectTypeResolver;
+
+class RootPostCategoriesFilterInputObjectTypeResolver extends AbstractCategoriesFilterInputObjectTypeResolver implements PostCategoriesFilterInputObjectTypeResolverInterface
+{
+    public function getTypeName(): string
+    {
+        return 'RootPostCategoriesFilterInput';
+    }
+}

--- a/layers/CMSSchema/packages/post-tags/src/FieldResolvers/ObjectType/RootPostTagObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/post-tags/src/FieldResolvers/ObjectType/RootPostTagObjectTypeFieldResolver.php
@@ -9,7 +9,7 @@ use PoPCMSSchema\PostTags\TypeResolvers\InputObjectType\PostTagByOneofInputObjec
 use PoPCMSSchema\PostTags\TypeResolvers\ObjectType\PostTagObjectTypeResolver;
 use PoPCMSSchema\SchemaCommons\DataLoading\ReturnTypes;
 use PoPCMSSchema\SchemaCommons\Resolvers\WithLimitFieldArgResolverTrait;
-use PoPCMSSchema\Tags\TypeResolvers\InputObjectType\RootTagsFilterInputObjectTypeResolver;
+use PoPCMSSchema\PostTags\TypeResolvers\InputObjectType\RootPostTagsFilterInputObjectTypeResolver;
 use PoPCMSSchema\Tags\TypeResolvers\InputObjectType\TagPaginationInputObjectTypeResolver;
 use PoPCMSSchema\Taxonomies\TypeResolvers\InputObjectType\TaxonomySortInputObjectTypeResolver;
 use PoPSchema\SchemaCommons\Constants\QueryOptions;
@@ -36,7 +36,7 @@ class RootPostTagObjectTypeFieldResolver extends AbstractQueryableObjectTypeFiel
     private ?PostTagByOneofInputObjectTypeResolver $postTagByOneofInputObjectTypeResolver = null;
     private ?TagPaginationInputObjectTypeResolver $tagPaginationInputObjectTypeResolver = null;
     private ?TaxonomySortInputObjectTypeResolver $taxonomySortInputObjectTypeResolver = null;
-    private ?RootTagsFilterInputObjectTypeResolver $rootTagsFilterInputObjectTypeResolver = null;
+    private ?RootPostTagsFilterInputObjectTypeResolver $rootPostTagsFilterInputObjectTypeResolver = null;
 
     final public function setIntScalarTypeResolver(IntScalarTypeResolver $intScalarTypeResolver): void
     {
@@ -129,18 +129,18 @@ class RootPostTagObjectTypeFieldResolver extends AbstractQueryableObjectTypeFiel
         }
         return $this->taxonomySortInputObjectTypeResolver;
     }
-    final public function setRootTagsFilterInputObjectTypeResolver(RootTagsFilterInputObjectTypeResolver $rootTagsFilterInputObjectTypeResolver): void
+    final public function setRootPostTagsFilterInputObjectTypeResolver(RootPostTagsFilterInputObjectTypeResolver $rootPostTagsFilterInputObjectTypeResolver): void
     {
-        $this->rootTagsFilterInputObjectTypeResolver = $rootTagsFilterInputObjectTypeResolver;
+        $this->rootPostTagsFilterInputObjectTypeResolver = $rootPostTagsFilterInputObjectTypeResolver;
     }
-    final protected function getRootTagsFilterInputObjectTypeResolver(): RootTagsFilterInputObjectTypeResolver
+    final protected function getRootPostTagsFilterInputObjectTypeResolver(): RootPostTagsFilterInputObjectTypeResolver
     {
-        if ($this->rootTagsFilterInputObjectTypeResolver === null) {
-            /** @var RootTagsFilterInputObjectTypeResolver */
-            $rootTagsFilterInputObjectTypeResolver = $this->instanceManager->getInstance(RootTagsFilterInputObjectTypeResolver::class);
-            $this->rootTagsFilterInputObjectTypeResolver = $rootTagsFilterInputObjectTypeResolver;
+        if ($this->rootPostTagsFilterInputObjectTypeResolver === null) {
+            /** @var RootPostTagsFilterInputObjectTypeResolver */
+            $rootPostTagsFilterInputObjectTypeResolver = $this->instanceManager->getInstance(RootPostTagsFilterInputObjectTypeResolver::class);
+            $this->rootPostTagsFilterInputObjectTypeResolver = $rootPostTagsFilterInputObjectTypeResolver;
         }
-        return $this->rootTagsFilterInputObjectTypeResolver;
+        return $this->rootPostTagsFilterInputObjectTypeResolver;
     }
 
     /**
@@ -222,7 +222,7 @@ class RootPostTagObjectTypeFieldResolver extends AbstractQueryableObjectTypeFiel
             'postTagNames' => array_merge(
                 $fieldArgNameTypeResolvers,
                 [
-                    'filter' => $this->getRootTagsFilterInputObjectTypeResolver(),
+                    'filter' => $this->getRootPostTagsFilterInputObjectTypeResolver(),
                     'pagination' => $this->getTagPaginationInputObjectTypeResolver(),
                     'sort' => $this->getTaxonomySortInputObjectTypeResolver(),
                 ]
@@ -230,7 +230,7 @@ class RootPostTagObjectTypeFieldResolver extends AbstractQueryableObjectTypeFiel
             'postTagCount' => array_merge(
                 $fieldArgNameTypeResolvers,
                 [
-                    'filter' => $this->getRootTagsFilterInputObjectTypeResolver(),
+                    'filter' => $this->getRootPostTagsFilterInputObjectTypeResolver(),
                 ]
             ),
             default => $fieldArgNameTypeResolvers,

--- a/layers/CMSSchema/packages/post-tags/src/TypeResolvers/InputObjectType/PostTagsFilterInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/post-tags/src/TypeResolvers/InputObjectType/PostTagsFilterInputObjectTypeResolverInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\PostTags\TypeResolvers\InputObjectType;
+
+interface PostTagsFilterInputObjectTypeResolverInterface {
+
+}

--- a/layers/CMSSchema/packages/post-tags/src/TypeResolvers/InputObjectType/PostTagsFilterInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/post-tags/src/TypeResolvers/InputObjectType/PostTagsFilterInputObjectTypeResolverInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\PostTags\TypeResolvers\InputObjectType;
 
-interface PostTagsFilterInputObjectTypeResolverInterface {
-
+interface PostTagsFilterInputObjectTypeResolverInterface
+{
 }

--- a/layers/CMSSchema/packages/post-tags/src/TypeResolvers/InputObjectType/RootPostTagsFilterInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/post-tags/src/TypeResolvers/InputObjectType/RootPostTagsFilterInputObjectTypeResolver.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\PostTags\TypeResolvers\InputObjectType;
+
+use PoPCMSSchema\Tags\TypeResolvers\InputObjectType\AbstractTagsFilterInputObjectTypeResolver;
+
+class RootPostTagsFilterInputObjectTypeResolver extends AbstractTagsFilterInputObjectTypeResolver implements PostTagsFilterInputObjectTypeResolverInterface
+{
+    public function getTypeName(): string
+    {
+        return 'RootPostTagsFilterInput';
+    }
+}

--- a/layers/CMSSchema/packages/tags/src/TypeResolvers/InputObjectType/AbstractTagsFilterInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/tags/src/TypeResolvers/InputObjectType/AbstractTagsFilterInputObjectTypeResolver.php
@@ -6,7 +6,7 @@ namespace PoPCMSSchema\Tags\TypeResolvers\InputObjectType;
 
 use PoPCMSSchema\Taxonomies\TypeResolvers\InputObjectType\AbstractTaxonomiesFilterInputObjectTypeResolver;
 
-abstract class AbstractTagsFilterInputObjectTypeResolver extends AbstractTaxonomiesFilterInputObjectTypeResolver
+abstract class AbstractTagsFilterInputObjectTypeResolver extends AbstractTaxonomiesFilterInputObjectTypeResolver implements TagsFilterInputObjectTypeResolverInterface
 {
     public function getTypeDescription(): ?string
     {

--- a/layers/CMSSchema/packages/tags/src/TypeResolvers/InputObjectType/TagsFilterInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/tags/src/TypeResolvers/InputObjectType/TagsFilterInputObjectTypeResolverInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\Tags\TypeResolvers\InputObjectType;
+
+interface TagsFilterInputObjectTypeResolverInterface
+{
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.1/en.md
@@ -4,3 +4,83 @@
 
 ## [PRO] Improvements
 
+### Polylang: Filter data by language
+
+With the **Polylang** extension, we can now filter data by language.
+
+We can provide the language to filter by when fetching data for:
+
+- Posts
+- Pages
+- Custom posts
+- Categories
+- Tags
+- Media items
+
+The corresponding fields receive input `polylangLanguage`, and we can filter by code or locale, and by 1 or more than 1 language.
+
+For instance, passing `$languageCodes: ["es"]` will fetch data in Spanish:
+
+```graphql
+query FilterByLanguage($languageCodes: [String!])
+{
+  posts(filter: {
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    title
+  }
+
+  pages(filter: {
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    title
+  }
+
+  customPosts(filter: {
+    customPostTypes: ["some-cpt"]
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    title
+  }
+
+  postCategories(filter: {
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    name
+  }
+
+  postTags(filter: {
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    name
+  }
+
+  categories(
+    taxonomy: "some-category"
+    filter: { polylangLanguages: { codes: $languageCodes } }
+  ) {
+    id
+    name
+  }
+
+  tags(
+    taxonomy: "some-tag"
+    filter: { polylangLanguages: { codes: $languageCodes } }
+  ) {
+    id
+    name
+  }
+
+  mediaItems(filter: {
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    title
+  }
+}
+```

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/polylang/docs/modules/polylang/en.md
@@ -452,3 +452,82 @@ mutation {
   }
 }
 ```
+
+## Filter data by language
+
+We can provide the language to filter by when fetching data for:
+
+- Posts
+- Pages
+- Custom posts
+- Categories
+- Tags
+- Media items
+
+The corresponding fields receive input `polylangLanguage`, and we can filter by code or locale, and by 1 or more than 1 language.
+
+For instance, passing `$languageCodes: ["es"]` will fetch data in Spanish:
+
+```graphql
+query FilterByLanguage($languageCodes: [String!])
+{
+  posts(filter: {
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    title
+  }
+
+  pages(filter: {
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    title
+  }
+
+  customPosts(filter: {
+    customPostTypes: ["some-cpt"]
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    title
+  }
+
+  postCategories(filter: {
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    name
+  }
+
+  postTags(filter: {
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    name
+  }
+
+  categories(
+    taxonomy: "some-category"
+    filter: { polylangLanguages: { codes: $languageCodes } }
+  ) {
+    id
+    name
+  }
+
+  tags(
+    taxonomy: "some-tag"
+    filter: { polylangLanguages: { codes: $languageCodes } }
+  ) {
+    id
+    name
+  }
+
+  mediaItems(filter: {
+    polylangLanguages: { codes: $languageCodes }
+  }) {
+    id
+    title
+  }
+}
+```

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -286,6 +286,9 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 
 == Changelog ==
 
+= 4.1.0 =
+* [PRO] Polylang: Filter data by language
+
 = 4.0.0 =
 * Breaking change: Updated internal PHP hook structure for error payloads (#2739)
 * Use bulk mutations in predefined persisted queries (#2728)


### PR DESCRIPTION
Added documentation for new feature in PRO: **Polylang: Filter data by language**.

We can provide the language to filter by when fetching data for:

- Posts
- Pages
- Custom posts
- Categories
- Tags
- Media items

The corresponding fields receive input `polylangLanguage`, and we can filter by code or locale, and by 1 or more than 1 language.

For instance, passing `$languageCodes: ["es"]` will fetch data in Spanish:

```graphql
query FilterByLanguage($languageCodes: [String!])
{
  posts(filter: {
    polylangLanguages: { codes: $languageCodes }
  }) {
    id
    title
  }

  pages(filter: {
    polylangLanguages: { codes: $languageCodes }
  }) {
    id
    title
  }

  customPosts(filter: {
    customPostTypes: ["some-cpt"]
    polylangLanguages: { codes: $languageCodes }
  }) {
    id
    title
  }

  postCategories(filter: {
    polylangLanguages: { codes: $languageCodes }
  }) {
    id
    name
  }

  postTags(filter: {
    polylangLanguages: { codes: $languageCodes }
  }) {
    id
    name
  }

  categories(
    taxonomy: "some-category"
    filter: { polylangLanguages: { codes: $languageCodes } }
  ) {
    id
    name
  }

  tags(
    taxonomy: "some-tag"
    filter: { polylangLanguages: { codes: $languageCodes } }
  ) {
    id
    name
  }

  mediaItems(filter: {
    polylangLanguages: { codes: $languageCodes }
  }) {
    id
    title
  }
}
```
