### PR TITLE
Add translation language mapping in persisted queries

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -18,6 +18,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
   - [PRO] Create missing translation tags for Polylang
   - [PRO] Translate categories for MultilingualPress
   - [PRO] Translate tags for MultilingualPress
+- Added translation language mapping to persisted queries (#2775)
 
 ## 4.1.0 - 26/07/2024
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.2/en.md
@@ -3,13 +3,14 @@
 ## Improvements
 
 - Validate `assign_terms` capability on `setCategory` and `setTag` mutations ([#2772](https://github.com/GatoGraphQL/GatoGraphQL/pull/2772))
-- Added predefined persisted queries:  ([#2774](https://github.com/GatoGraphQL/GatoGraphQL/pull/2774))
+- Added predefined persisted queries: ([#2774](https://github.com/GatoGraphQL/GatoGraphQL/pull/2774))
   - Create missing translation categories for Polylang
   - Create missing translation tags for Polylang
   - Translate categories for Polylang
   - Translate tags for Polylang
   - Translate categories for MultilingualPress
   - Translate tags for MultilingualPress
+- Added translation language mapping to persisted queries ([#2775](https://github.com/GatoGraphQL/GatoGraphQL/pull/2775))
 
 ### Added mutations for categories ([#2764](https://github.com/GatoGraphQL/GatoGraphQL/pull/2764))
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -298,6 +298,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
   * Translate categories for MultilingualPress
   * Translate tags for MultilingualPress
 * [PRO] Define the Polylang language on tag and category mutations
+* Added translation language mapping to persisted queries (#2775)
 
 = 4.1.0 =
 * Send the referer on Guzzle requests (#2754)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translation-language-mapping.var.json
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/setup/persisted-queries/admin/transform/translation-language-mapping.var.json
@@ -1,0 +1,5 @@
+{
+  "languageMapping": {
+    "nb": "no"
+  }
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Plugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Plugin.php
@@ -1445,6 +1445,9 @@ class Plugin extends AbstractMainPlugin
                                     'admin/transform/translate-posts-for-polylang-gutenberg',
                                     VirtualTutorialLessons::TRANSLATING_POSTS_FOR_POLYLANG_AND_GUTENBERG,
                                 ),
+                                AbstractGraphiQLBlock::ATTRIBUTE_NAME_VARIABLES => $this->readSetupGraphQLVariablesJSONAndEncodeForOutput(
+                                    'admin/transform/translation-language-mapping',
+                                ),
                             ],
                         ],
                         ...$nestedMutationsSchemaConfigurationPersistedQueryBlocks,
@@ -1468,6 +1471,9 @@ class Plugin extends AbstractMainPlugin
                                 AbstractGraphiQLBlock::ATTRIBUTE_NAME_QUERY => $this->readSetupGraphQLPersistedQueryAndEncodeForOutput(
                                     'admin/transform/translate-posts-for-polylang-classic-editor',
                                     VirtualTutorialLessons::TRANSLATING_POSTS_FOR_POLYLANG_AND_CLASSIC_EDITOR,
+                                ),
+                                AbstractGraphiQLBlock::ATTRIBUTE_NAME_VARIABLES => $this->readSetupGraphQLVariablesJSONAndEncodeForOutput(
+                                    'admin/transform/translation-language-mapping',
                                 ),
                             ],
                         ],
@@ -1674,6 +1680,9 @@ class Plugin extends AbstractMainPlugin
                                     'admin/transform/translate-posts-for-multilingualpress-gutenberg',
                                     VirtualTutorialLessons::TRANSLATING_POSTS_FOR_MULTILINGUALPRESS_AND_GUTENBERG,
                                 ),
+                                AbstractGraphiQLBlock::ATTRIBUTE_NAME_VARIABLES => $this->readSetupGraphQLVariablesJSONAndEncodeForOutput(
+                                    'admin/transform/translation-language-mapping',
+                                ),
                             ],
                         ],
                         ...$nestedMutationsSchemaConfigurationPersistedQueryBlocks,
@@ -1697,6 +1706,9 @@ class Plugin extends AbstractMainPlugin
                                 AbstractGraphiQLBlock::ATTRIBUTE_NAME_QUERY => $this->readSetupGraphQLPersistedQueryAndEncodeForOutput(
                                     'admin/transform/translate-posts-for-multilingualpress-classic-editor',
                                     VirtualTutorialLessons::TRANSLATING_POSTS_FOR_MULTILINGUALPRESS_AND_CLASSIC_EDITOR,
+                                ),
+                                AbstractGraphiQLBlock::ATTRIBUTE_NAME_VARIABLES => $this->readSetupGraphQLVariablesJSONAndEncodeForOutput(
+                                    'admin/transform/translation-language-mapping',
                                 ),
                             ],
                         ],
@@ -1896,6 +1908,9 @@ class Plugin extends AbstractMainPlugin
                                     'admin/transform/translate-categories-for-polylang',
                                     VirtualTutorialLessons::TRANSLATING_CATEGORIES_FOR_POLYLANG,
                                 ),
+                                AbstractGraphiQLBlock::ATTRIBUTE_NAME_VARIABLES => $this->readSetupGraphQLVariablesJSONAndEncodeForOutput(
+                                    'admin/transform/translation-language-mapping',
+                                ),
                             ],
                         ],
                         ...$defaultSchemaConfigurationPersistedQueryBlocks,
@@ -1943,6 +1958,9 @@ class Plugin extends AbstractMainPlugin
                                 AbstractGraphiQLBlock::ATTRIBUTE_NAME_QUERY => $this->readSetupGraphQLPersistedQueryAndEncodeForOutput(
                                     'admin/transform/translate-tags-for-polylang',
                                     VirtualTutorialLessons::TRANSLATING_TAGS_FOR_POLYLANG,
+                                ),
+                                AbstractGraphiQLBlock::ATTRIBUTE_NAME_VARIABLES => $this->readSetupGraphQLVariablesJSONAndEncodeForOutput(
+                                    'admin/transform/translation-language-mapping',
                                 ),
                             ],
                         ],
@@ -1992,6 +2010,9 @@ class Plugin extends AbstractMainPlugin
                                     'admin/transform/translate-categories-for-multilingualpress',
                                     VirtualTutorialLessons::TRANSLATING_CATEGORIES_FOR_MULTILINGUALPRESS,
                                 ),
+                                AbstractGraphiQLBlock::ATTRIBUTE_NAME_VARIABLES => $this->readSetupGraphQLVariablesJSONAndEncodeForOutput(
+                                    'admin/transform/translation-language-mapping',
+                                ),
                             ],
                         ],
                         ...$defaultSchemaConfigurationPersistedQueryBlocks,
@@ -2015,6 +2036,9 @@ class Plugin extends AbstractMainPlugin
                                 AbstractGraphiQLBlock::ATTRIBUTE_NAME_QUERY => $this->readSetupGraphQLPersistedQueryAndEncodeForOutput(
                                     'admin/transform/translate-tags-for-multilingualpress',
                                     VirtualTutorialLessons::TRANSLATING_TAGS_FOR_MULTILINGUALPRESS,
+                                ),
+                                AbstractGraphiQLBlock::ATTRIBUTE_NAME_VARIABLES => $this->readSetupGraphQLVariablesJSONAndEncodeForOutput(
+                                    'admin/transform/translation-language-mapping',
                                 ),
                             ],
                         ],


### PR DESCRIPTION
For some languages, the code used by WordPress and Google Translate are different.

For instance, Norwegian is represented as "nb" by WordPress, and as "no" by Google Translate.

To support translating to these languages, we can provide the language code mapping via the `$languageMapping` GraphQL variable.

This PR already defines the mapping for already-identified languages, and sets it on the predefined persisted queries concerning translation (for Polylang and MultilingualPress):

```json
{
  "languageMapping": {
    "nb": "no"
  }
}
```