### PR TITLE
Trigger WordPress hooks with meta key in hook name for Automation (PRO)

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.2/en.md
@@ -393,3 +393,17 @@ mutation {
   }
 }
 ```
+
+### Trigger WordPress hooks with meta key in hook name for Automation
+
+WordPress hooks that create, update and delete meta values have been mapped to Gato GraphQL automation hooks, containing the meta key as part of the hook name, so they can be referenced directly within an automation rule.
+
+This makes it easier to capture and automate specific events, such as the assigning of a featured image to a post, which is based on meta key `_thumbnail_id`. Then, the automation can be triggered on event `gatographql:updated_post_meta:_thumbnail_id`.
+
+These are the added hook mappings:
+
+| WordPress hook | Mapped hook by Gato GraphQL |
+| --- | --- |
+| [`added_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/added_meta_type_meta/) | `gatographql:added_{$meta_type}_meta:{$meta_key}` |
+| [`updated_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/updated_meta_type_meta/) | `gatographql:updated_{$meta_type}_meta:{$meta_key}` |
+| [`deleted_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/deleted_meta_type_meta/) | `gatographql:deleted_{$meta_type}_meta:{$meta_key}` |

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/automation/docs/modules/automation/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/automation/docs/modules/automation/en.md
@@ -100,6 +100,9 @@ The following table lists down the mapped WordPress hooks:
 | WordPress hook | Mapped hook by Gato GraphQL |
 | --- | --- |
 | [`{$old_status}_to_{$new_status}`](https://developer.wordpress.org/reference/hooks/old_status_to_new_status/) (passing `WP_Post $post`) | `gatographql:{$old_status}_to_{$new_status}` (passing `int $postId`) |
+| [`added_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/added_meta_type_meta/) | `gatographql:added_{$meta_type}_meta:{$meta_key}` |
+| [`updated_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/updated_meta_type_meta/) | `gatographql:updated_{$meta_type}_meta:{$meta_key}` |
+| [`deleted_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/deleted_meta_type_meta/) | `gatographql:deleted_{$meta_type}_meta:{$meta_key}` |
 
 ### Debugging issues
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/automation/docs/modules/automation/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/automation/docs/modules/automation/en.md
@@ -95,6 +95,8 @@ Several of these hooks have been mapped by Gato GraphQL, by triggering a new hoo
 
 For instance, WordPress hook `draft_to_publish` passes the `$post` as variable (of type `WP_Post`). Gato GraphQL maps this hook as `gatographql:draft_to_publish`, and passes the `$postId` (of type `int`) as variable.
 
+For another example, WordPress hooks that create, update and delete meta values are mapped containing the meta key as part of the hook name. Then, an automation can be triggered when a featured image is assigned to a post, on hook `gatographql:updated_post_meta:_thumbnail_id`.
+
 The following table lists down the mapped WordPress hooks:
 
 | WordPress hook | Mapped hook by Gato GraphQL |

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -301,6 +301,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 * [PRO] Define the Polylang language on tag and category mutations
 * [PRO] Automation: Store the GraphQL response in the info logs
 * [PRO] Added Polylang Mutations for Media Items
+* [PRO] Trigger WordPress hooks with meta key in hook name for Automation
 
 = 4.1.0 =
 * Send the referer on Guzzle requests (#2754)


### PR DESCRIPTION
WordPress hooks that create, update and delete meta values have been mapped to Gato GraphQL automation hooks, containing the meta key as part of the hook name, so they can be referenced directly within an automation rule.

This makes it easier to capture and automate specific events, such as the assigning of a featured image to a post, which is based on meta key `_thumbnail_id`. Then, the automation can be triggered on event `gatographql:updated_post_meta:_thumbnail_id`.

These are the added hook mappings:

| WordPress hook | Mapped hook by Gato GraphQL |
| --- | --- |
| [`added_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/added_meta_type_meta/) | `gatographql:added_{$meta_type}_meta:{$meta_key}` |
| [`updated_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/updated_meta_type_meta/) | `gatographql:updated_{$meta_type}_meta:{$meta_key}` |
| [`deleted_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/deleted_meta_type_meta/) | `gatographql:deleted_{$meta_type}_meta:{$meta_key}` |