### PR TITLE
Map set_object_terms hook with taxonomy for automation

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.2/en.md
@@ -394,7 +394,7 @@ mutation {
 }
 ```
 
-### Trigger WordPress hooks with meta key in hook name for Automation
+### Map additional WordPress hooks for Automation
 
 WordPress hooks that create, update and delete meta values have been mapped to Gato GraphQL automation hooks, containing the meta key as part of the hook name, so they can be referenced directly within an automation rule.
 
@@ -407,3 +407,4 @@ These are the added hook mappings:
 | [`added_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/added_meta_type_meta/) | `gatographql:added_{$meta_type}_meta:{$meta_key}` |
 | [`updated_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/updated_meta_type_meta/) | `gatographql:updated_{$meta_type}_meta:{$meta_key}` |
 | [`deleted_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/deleted_meta_type_meta/) | `gatographql:deleted_{$meta_type}_meta:{$meta_key}` |
+| [`set_object_terms`](https://developer.wordpress.org/reference/hooks/set_object_terms/) | `gatographql:set_object_terms:{$taxonomy}` |

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/4.2/en.md
@@ -400,6 +400,8 @@ WordPress hooks that create, update and delete meta values have been mapped to G
 
 This makes it easier to capture and automate specific events, such as the assigning of a featured image to a post, which is based on meta key `_thumbnail_id`. Then, the automation can be triggered on event `gatographql:updated_post_meta:_thumbnail_id`.
 
+In addition, `set_object_terms` was mapped, including the `taxonomy` as part of the hook name.
+
 These are the added hook mappings:
 
 | WordPress hook | Mapped hook by Gato GraphQL |

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/automation/docs/modules/automation/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/automation/docs/modules/automation/en.md
@@ -105,6 +105,7 @@ The following table lists down the mapped WordPress hooks:
 | [`added_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/added_meta_type_meta/) | `gatographql:added_{$meta_type}_meta:{$meta_key}` |
 | [`updated_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/updated_meta_type_meta/) | `gatographql:updated_{$meta_type}_meta:{$meta_key}` |
 | [`deleted_{$meta_type}_meta`](https://developer.wordpress.org/reference/hooks/deleted_meta_type_meta/) | `gatographql:deleted_{$meta_type}_meta:{$meta_key}` |
+| [`set_object_terms`](https://developer.wordpress.org/reference/hooks/set_object_terms/) | `gatographql:set_object_terms:{$taxonomy}` |
 
 ### Debugging issues
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -301,7 +301,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 * [PRO] Define the Polylang language on tag and category mutations
 * [PRO] Automation: Store the GraphQL response in the info logs
 * [PRO] Added Polylang Mutations for Media Items
-* [PRO] Trigger WordPress hooks with meta key in hook name for Automation
+* [PRO] Map additional WordPress hooks for Automation
 
 = 4.1.0 =
 * Send the referer on Guzzle requests (#2754)


### PR DESCRIPTION
Map `set_object_terms` to include the `taxonomy` as part of the hook name.