### PR TITLE
Replace site domain straight to localhost

### DIFF
--- a/webservers/gatographql-for-prod/setup/configure-plugin-settings.sh
+++ b/webservers/gatographql-for-prod/setup/configure-plugin-settings.sh
@@ -4,8 +4,8 @@ echo Enabling modules for DEV
 
 ADMIN_USER_APP_PASSWORD=$(wp user meta get 1 app_password)
 # Using "localhost:89347" is not visible from within the container, so point straight to localhost, it always works
-# SITE_DOMAIN=$(wp option get siteurl)
-SITE_DOMAIN=https://localhost
+SITE_DOMAIN=$(wp option get siteurl)
+# SITE_DOMAIN=https://localhost
 
 curl -i --insecure \
   --user "admin:$(echo $ADMIN_USER_APP_PASSWORD)" \

--- a/webservers/gatographql-for-prod/setup/configure-plugin-settings.sh
+++ b/webservers/gatographql-for-prod/setup/configure-plugin-settings.sh
@@ -4,7 +4,9 @@ echo Enabling modules for DEV
 
 ADMIN_USER_APP_PASSWORD=$(wp user meta get 1 app_password)
 # Using "localhost:89347" is not visible from within the container, so point straight to localhost, it always works
-SITE_DOMAIN=$(wp option get siteurl)
+# Remove the port from the webserver URL
+SITE_DOMAIN=$(wp option get siteurl | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%-]*")
+# SITE_DOMAIN=$(wp option get siteurl)
 # SITE_DOMAIN=https://localhost
 
 curl -i --insecure \

--- a/webservers/gatographql/setup/configure-plugin-settings.sh
+++ b/webservers/gatographql/setup/configure-plugin-settings.sh
@@ -4,8 +4,8 @@ echo Enabling modules for DEV
 
 ADMIN_USER_APP_PASSWORD=$(wp user meta get 1 app_password)
 # Using "localhost:89347" is not visible from within the container, so point straight to localhost, it always works
-# SITE_DOMAIN=$(wp option get siteurl)
-SITE_DOMAIN=https://localhost
+SITE_DOMAIN=$(wp option get siteurl)
+# SITE_DOMAIN=https://localhost
 
 curl -i --insecure \
   --user "admin:$(echo $ADMIN_USER_APP_PASSWORD)" \

--- a/webservers/gatographql/setup/configure-plugin-settings.sh
+++ b/webservers/gatographql/setup/configure-plugin-settings.sh
@@ -4,7 +4,9 @@ echo Enabling modules for DEV
 
 ADMIN_USER_APP_PASSWORD=$(wp user meta get 1 app_password)
 # Using "localhost:89347" is not visible from within the container, so point straight to localhost, it always works
-SITE_DOMAIN=$(wp option get siteurl)
+# Remove the port from the webserver URL
+SITE_DOMAIN=$(wp option get siteurl | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%-]*")
+# SITE_DOMAIN=$(wp option get siteurl)
 # SITE_DOMAIN=https://localhost
 
 curl -i --insecure \


### PR DESCRIPTION
Use either `https://localhost` or `https://gatographql-prod.lndo.site` (taking it from the config), and also remove the port:

```bash
SITE_DOMAIN=$(wp option get siteurl | grep -Eo "(http|https)://[a-zA-Z0-9./?=_%-]*")
# SITE_DOMAIN=$(wp option get siteurl)
# SITE_DOMAIN=https://localhost
```