### PR TITLE
Return no results when filtering data by passing an empty array in `filter.ids` input

### DIFF
--- a/layers/CMSSchema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
+++ b/layers/CMSSchema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
@@ -119,6 +119,12 @@ abstract class AbstractCategoryTypeAPI extends AbstractTaxonomyTypeAPI implement
     public function getCategories(array $query, array $options = []): array
     {
         $query = $this->convertCategoriesQuery($query, $options);
+
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return [];
+        }
+        
         return get_categories($query);
     }
 

--- a/layers/CMSSchema/packages/comments-wp/src/TypeAPIs/CommentTypeAPI.php
+++ b/layers/CMSSchema/packages/comments-wp/src/TypeAPIs/CommentTypeAPI.php
@@ -48,7 +48,23 @@ class CommentTypeAPI implements CommentTypeAPIInterface
     public function getComments(array $query, array $options = []): array
     {
         $query = $this->convertCommentsQuery($query, $options);
+
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return [];
+        }
+
         return (array) get_comments($query);
+    }
+
+    /**
+     * Indicate if an empty array was passed to `filter.ids`
+     *
+     * @param array<string,mixed> $query
+     */
+    protected function isFilteringByEmptyArray(array $query): bool
+    {
+        return isset($query['comment__in']) && ($query['comment__in'] === '' || $query['comment__in'] === []);
     }
 
     /**
@@ -177,6 +193,12 @@ class CommentTypeAPI implements CommentTypeAPIInterface
     public function getCommentCount(array $query, array $options = []): int
     {
         $query = $this->convertCommentsQuery($query, $options);
+
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return 0;
+        }
+
         $query['number'] = 0;
         unset($query['offset']);
         $query['count'] = true;

--- a/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
+++ b/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
@@ -99,7 +99,23 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
     public function getCustomPosts(array $query, array $options = []): array
     {
         $query = $this->convertCustomPostsQuery($query, $options);
+
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return [];
+        }
+
         return get_posts($query);
+    }
+
+    /**
+     * Indicate if an empty array was passed to `filter.ids`
+     *
+     * @param array<string,mixed> $query
+     */
+    protected function isFilteringByEmptyArray(array $query): bool
+    {
+        return isset($query['include']) && ($query['include'] === '' || $query['include'] === []);
     }
 
     /**
@@ -111,6 +127,11 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
         // Convert parameters
         $options[SchemaCommonsQueryOptions::RETURN_TYPE] = ReturnTypes::IDS;
         $query = $this->convertCustomPostsQuery($query, $options);
+
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return 0;
+        }
 
         // All results, no offset
         $query['posts_per_page'] = -1;

--- a/layers/CMSSchema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
+++ b/layers/CMSSchema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
@@ -142,6 +142,12 @@ abstract class AbstractTagTypeAPI extends AbstractTaxonomyTypeAPI implements Tag
     public function getTags(array $query, array $options = []): array
     {
         $query = $this->convertTagsQuery($query, $options);
+
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return [];
+        }
+        
         $tags = get_tags($query);
         if ($tags instanceof WP_Error) {
             return [];

--- a/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/AbstractTaxonomyTypeAPI.php
+++ b/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/AbstractTaxonomyTypeAPI.php
@@ -94,6 +94,11 @@ abstract class AbstractTaxonomyTypeAPI implements TaxonomyTypeAPIInterface
         $customPostID = $this->getCustomPostID($customPostObjectOrID);
         $query = $this->convertTaxonomyTermsQuery($query, $options);
 
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return [];
+        }
+
         /** @var string|string[] */
         $taxonomyOrTaxonomies = $query['taxonomy'] ?? '';
         if (empty($taxonomyOrTaxonomies)) {
@@ -113,6 +118,16 @@ abstract class AbstractTaxonomyTypeAPI implements TaxonomyTypeAPIInterface
     }
 
     /**
+     * Indicate if an empty array was passed to `filter.ids`
+     *
+     * @param array<string,mixed> $query
+     */
+    protected function isFilteringByEmptyArray(array $query): bool
+    {
+        return isset($query['include']) && ($query['include'] === '' || $query['include'] === []);
+    }
+
+    /**
      * @param array<string,mixed> $query
      * @param array<string,mixed> $options
      */
@@ -129,6 +144,11 @@ abstract class AbstractTaxonomyTypeAPI implements TaxonomyTypeAPIInterface
         // So execute a normal `wp_get_post_categories` retrieving all the IDs, and count them
         $options[QueryOptions::RETURN_TYPE] = ReturnTypes::IDS;
         $query = $this->convertTaxonomyTermsQuery($query, $options);
+
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return 0;
+        }
 
         /** @var string|string[] */
         $taxonomyOrTaxonomies = $query['taxonomy'] ?? '';
@@ -310,6 +330,11 @@ abstract class AbstractTaxonomyTypeAPI implements TaxonomyTypeAPIInterface
     protected function getTaxonomyCount(array $query = [], array $options = []): ?int
     {
         $query = $this->convertTaxonomyTermsQuery($query, $options);
+
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return 0;
+        }
 
         // Indicate to return the count
         $query['count'] = true;

--- a/layers/CMSSchema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
+++ b/layers/CMSSchema/packages/users-wp/src/TypeAPIs/UserTypeAPI.php
@@ -67,6 +67,11 @@ class UserTypeAPI extends AbstractUserTypeAPI
         $options[QueryOptions::RETURN_TYPE] = ReturnTypes::IDS;
         $query = $this->convertUsersQuery($query, $options);
 
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return 0;
+        }
+
         // All results, no offset
         $query['number'] = -1;
         unset($query['offset']);
@@ -97,6 +102,17 @@ class UserTypeAPI extends AbstractUserTypeAPI
         }
         return $ret;
     }
+
+    /**
+     * Indicate if an empty array was passed to `filter.ids`
+     *
+     * @param array<string,mixed> $query
+     */
+    protected function isFilteringByEmptyArray(array $query): bool
+    {
+        return isset($query['include']) && ($query['include'] === '' || $query['include'] === []);
+    }
+    
     /**
      * @return array<string|int>|object[]
      * @param array<string,mixed> $query
@@ -106,6 +122,11 @@ class UserTypeAPI extends AbstractUserTypeAPI
     {
         // Convert the parameters
         $query = $this->convertUsersQuery($query, $options);
+
+        // If passing an empty array to `filter.ids`, return no results
+        if ($this->isFilteringByEmptyArray($query)) {
+            return [];
+        }
 
         // Limit users which have an email appearing on the input
         // WordPress does not allow to search by many email addresses, only 1!

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 5.0.0 - DATE
 
+### Breaking changes
+
+- Return no results when filtering data by an empty array (#2809)
+
 ### Improvements
 
 - Increase limit of chars in truncated response by Guzzle (#2800)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/5.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/5.0/en.md
@@ -16,7 +16,15 @@ query FilterPostsByIDs(
 }
 ```
 
-Previously, when passing an empty array in variable `$ids`, input `filter.ids` would be ignored, and the field would then return all results.
+Previously, when passing an empty array in variable `$ids`:
+
+```json
+{
+  "ids": []
+}
+```
+
+...input `filter.ids` would be ignored, and the field would then return all results.
 
 Now, passing an empty array means "retrieve no results".
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/5.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/5.0/en.md
@@ -22,11 +22,13 @@ Now, passing an empty array means "retrieve no results".
 
 To ignore the filter input, pass `null` instead.
 
-The same behavior applies for all fields that receive the `filter.ids` input:
+The same behavior applies for all fields that accept the `filter.ids` input:
 
-- `users`
+- `categories`
 - `comments`
 - `customPosts`
+- `tags`
+- `users`
 - etc
 
 ## Improvements

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/5.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/5.0/en.md
@@ -1,5 +1,34 @@
 # Release Notes: 5.0
 
+## Breaking changes
+
+### Return no results when filtering data by an empty array ([#2809](https://github.com/GatoGraphQL/GatoGraphQL/pull/2809))
+
+This GraphQL query filter posts by ID:
+
+```graphql
+query FilterPostsByIDs(
+  $ids: [ID!]
+) {
+  posts(filter: { ids: $ids }) {
+    title
+  }
+}
+```
+
+Previously, when passing an empty array in variable `$ids`, input `filter.ids` would be ignored, and the field would then return all results.
+
+Now, passing an empty array means "retrieve no results".
+
+To ignore the filter input, pass `null` instead.
+
+The same behavior applies for all fields that receive the `filter.ids` input:
+
+- `users`
+- `comments`
+- `customPosts`
+- etc
+
 ## Improvements
 
 - Increase limit of chars in truncated response by Guzzle ([#2800](https://github.com/GatoGraphQL/GatoGraphQL/pull/2800))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -287,6 +287,7 @@ The Gato GraphQL website contains extensive documentation, including [guides](ht
 == Changelog ==
 
 = 5.0.0 =
+* Breaking change: Return no results when filtering data by an empty array (#2809)
 * Increase limit of chars in truncated response by Guzzle (#2800)
 * Added field `isGutenbergEditorEnabled` (#2801)
 * Use `isGutenbergEditorEnabled` in predefined persisted queries (#2802)


### PR DESCRIPTION
This GraphQL query filter posts by ID:

```graphql
query FilterPostsByIDs(
  $ids: [ID!]
) {
  posts(filter: { ids: $ids }) {
    title
  }
}
```

Previously, when passing an empty array in variable `$ids`:

```json
{
  "ids": []
}
```

...input `filter.ids` would be ignored, and the field would then return all results.

Now, passing an empty array means "retrieve no results".

To ignore the filter input, pass `null` instead.

The same behavior applies for all fields that accept the `filter.ids` input:

- `categories`
- `comments`
- `customPosts`
- `tags`
- `users`
- etc