### PR TITLE
Fix issue with __FILE__ and symlinking in Lando

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/includes/startup.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/includes/startup.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 use GatoGraphQL\GatoGraphQL\PluginApp;
 use PoP\Root\Environment as RootEnvironment;
-
-declare(strict_types=1);
 
 /**
  * Make sure this function is not declared more than once

--- a/layers/GatoGraphQLForWP/plugins/gatographql/includes/startup.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/includes/startup.php
@@ -1,6 +1,7 @@
 <?php
 
 use GatoGraphQL\GatoGraphQL\PluginApp;
+use PoP\Root\Environment as RootEnvironment;
 
 declare(strict_types=1);
 
@@ -58,6 +59,9 @@ if (!function_exists('maybeAdaptGatoGraphQLBundledExtensionPluginFile')) {
         string $extensionClass,
         string $extensionPackageOwner,
     ): string {
+        if (!RootEnvironment::isApplicationEnvironmentDev()) {
+            return $extensionFile;
+        }
         $extensionManager = PluginApp::getExtensionManager();
         if (!$extensionManager->isExtensionBundled($extensionClass)) {
             return $extensionFile;

--- a/layers/GatoGraphQLForWP/plugins/gatographql/includes/startup.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/includes/startup.php
@@ -42,7 +42,7 @@ if (!function_exists('checkGatoGraphQLMemoryRequirements')) {
     }
 }
 
-if (!function_exists('getGatoGraphQLBundledExtensionExpectedPluginFile')) {
+if (!function_exists('maybeAdaptGatoGraphQLBundledExtensionPluginFile')) {
     /**
      * During development, due to symlinking in Lando, __FILE__ for bundled
      * extensions doesn't point to the expected location under "vendor",
@@ -53,7 +53,7 @@ if (!function_exists('getGatoGraphQLBundledExtensionExpectedPluginFile')) {
      *
      * This function fixes the file path with the expected behavior.
      */
-    function getGatoGraphQLBundledExtensionExpectedPluginFile(
+    function maybeAdaptGatoGraphQLBundledExtensionPluginFile(
         string $extensionFile,
         string $extensionClass,
         string $extensionPackageOwner,

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/AbstractStandalonePlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/AbstractStandalonePlugin.php
@@ -6,6 +6,7 @@ namespace GatoGraphQL\GatoGraphQL;
 
 use GatoGraphQL\GatoGraphQL\Plugin;
 use GatoGraphQL\GatoGraphQL\PluginSkeleton\MainPluginInitializationConfigurationInterface;
+use GatoGraphQL\GatoGraphQL\PluginSkeleton\PluginInfoInterface;
 use GatoGraphQL\GatoGraphQL\PluginSkeleton\StandalonePluginTrait;
 
 /**

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/AbstractStandalonePlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/AbstractStandalonePlugin.php
@@ -18,7 +18,7 @@ use GatoGraphQL\GatoGraphQL\PluginSkeleton\StandalonePluginTrait;
 abstract class AbstractStandalonePlugin extends Plugin
 {
     use StandalonePluginTrait;
-    
+
     public function __construct(
         string $pluginFile, /** The main plugin file */
         string $pluginVersion,

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace GatoGraphQL\GatoGraphQL\PluginSkeleton;
 
+use GatoGraphQL\GatoGraphQL\PluginApp;
 use GatoGraphQL\GatoGraphQL\PluginAppHooks;
 use PoP\Root\Helpers\ClassHelpers;
 use PoP\Root\Module\ModuleInterface;
@@ -36,6 +37,21 @@ abstract class AbstractExtension extends AbstractPlugin implements ExtensionInte
         ?string $pluginURL = null, /** Useful to override by standalone plugins */
         ?ExtensionInitializationConfigurationInterface $extensionInitializationConfiguration = null,
     ) {
+        /**
+         * During development, due to symlinking in Lando, __FILE__ for bundled
+         * extensions doesn't point to the expected location under "vendor"
+         */
+        $extensionManager = PluginApp::getExtensionManager();
+        $extensionClass = get_called_class();
+        if ($extensionManager->isExtensionBundled($extensionClass)) {
+            /** @var BundleExtensionInterface */
+            $bundlingExtension = $extensionManager->getBundlingExtensionClass($extensionClass);
+            $bundlePluginFile = $bundlingExtension->getPluginFile();
+            $extensionFileComponents = explode('/', $pluginFile);
+            $extensionFileComponentsCount = count($extensionFileComponents);
+            $pluginFile = dirname($bundlePluginFile) . '/vendor/gatographql-pro/' . $extensionFileComponents[$extensionFileComponentsCount - 2] . '/' . $extensionFileComponents[$extensionFileComponentsCount - 1];
+        }
+        
         parent::__construct(
             $pluginFile,
             $pluginVersion,

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractExtension.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractExtension.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace GatoGraphQL\GatoGraphQL\PluginSkeleton;
 
-use GatoGraphQL\GatoGraphQL\PluginApp;
 use GatoGraphQL\GatoGraphQL\PluginAppHooks;
 use PoP\Root\Helpers\ClassHelpers;
 use PoP\Root\Module\ModuleInterface;
@@ -37,21 +36,6 @@ abstract class AbstractExtension extends AbstractPlugin implements ExtensionInte
         ?string $pluginURL = null, /** Useful to override by standalone plugins */
         ?ExtensionInitializationConfigurationInterface $extensionInitializationConfiguration = null,
     ) {
-        /**
-         * During development, due to symlinking in Lando, __FILE__ for bundled
-         * extensions doesn't point to the expected location under "vendor"
-         */
-        $extensionManager = PluginApp::getExtensionManager();
-        $extensionClass = get_called_class();
-        if ($extensionManager->isExtensionBundled($extensionClass)) {
-            /** @var BundleExtensionInterface */
-            $bundlingExtension = $extensionManager->getBundlingExtensionClass($extensionClass);
-            $bundlePluginFile = $bundlingExtension->getPluginFile();
-            $extensionFileComponents = explode('/', $pluginFile);
-            $extensionFileComponentsCount = count($extensionFileComponents);
-            $pluginFile = dirname($bundlePluginFile) . '/vendor/gatographql-pro/' . $extensionFileComponents[$extensionFileComponentsCount - 2] . '/' . $extensionFileComponents[$extensionFileComponentsCount - 1];
-        }
-        
         parent::__construct(
             $pluginFile,
             $pluginVersion,


### PR DESCRIPTION
During development, due to symlinking in Lando, getting `__FILE__` for bundled extensions doesn't point to the expected location under `vendor/`, but to the symlinked path.

As a consequence, the PluginDir and PluginURL for the plugin/module is not calculated correctly, and block scripts in the WordPress editor are not loaded.

Function `maybeAdaptGatoGraphQLBundledExtensionPluginFile` fixes the file path with the expected behavior:

```php
// Create and set-up the extension instance
$extensionManager->register(new GatoGraphQLExtension(
  maybeAdaptGatoGraphQLBundledExtensionPluginFile(
    __FILE__,
    GatoGraphQLExtension::class,
    'my-company-for-gatographql',
  ),
  $extensionVersion,
  $extensionName,
  $commitHash
))->setup();
```