### PR TITLE
Externalize all 'Gato GraphQL' titles

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Environment.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Environment.php
@@ -7,6 +7,7 @@ namespace GatoGraphQL\GatoGraphQL;
 class Environment
 {
     public final const PLUGIN_NAMESPACE_FOR_DB = 'PLUGIN_NAMESPACE_FOR_DB';
+    public final const PLUGIN_NAME = 'PLUGIN_NAME';
     public final const ADD_EXCERPT_AS_DESCRIPTION = 'ADD_EXCERPT_AS_DESCRIPTION';
     public final const GROUP_FIELDS_UNDER_TYPE_FOR_PRINT = 'GROUP_FIELDS_UNDER_TYPE_FOR_PRINT';
     public final const NO_ITEMS_SELECTED_LABEL = 'NO_ITEMS_SELECTED_LABEL';

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/ModuleConfiguration.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/ModuleConfiguration.php
@@ -38,6 +38,23 @@ class ModuleConfiguration extends AbstractModuleConfiguration
     }
 
     /**
+     * Plugin name.
+     *
+     * Useful for standalone plugins to override
+     * this value.
+     */
+    public function getPluginName(): string
+    {
+        $envVariable = Environment::PLUGIN_NAME;
+        $defaultValue = \__('Gato GraphQL', 'gatographql');
+
+        return $this->retrieveConfigurationValueOrUseDefault(
+            $envVariable,
+            $defaultValue,
+        );
+    }
+
+    /**
      * Group the fields under the type when printing it for the user
      */
     public function groupFieldsUnderTypeForPrint(): bool

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace GatoGraphQL\GatoGraphQL\Services\MenuPages;
 
 use GatoGraphQL\GatoGraphQL\Admin\Tables\TableInterface;
+use GatoGraphQL\GatoGraphQL\Module;
+use GatoGraphQL\GatoGraphQL\ModuleConfiguration;
+use PoP\ComponentModel\App;
 
 /**
  * Table menu page
@@ -13,7 +16,16 @@ abstract class AbstractTableMenuPage extends AbstractPluginMenuPage
 {
     protected ?TableInterface $tableObject;
 
-    abstract protected function getHeader(): string;
+    protected function getHeader(): string
+    {
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        return sprintf(
+            \__('%s - %s', 'gatographql'),
+            $moduleConfiguration->getPluginName(),
+            $this->getMenuPageTitle()
+        );
+    }
 
     protected function hasViews(): bool
     {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php
@@ -7,6 +7,8 @@ namespace GatoGraphQL\GatoGraphQL\Services\MenuPages;
 use GatoGraphQL\GatoGraphQL\App;
 use GatoGraphQL\GatoGraphQL\Constants\RequestParams;
 use GatoGraphQL\GatoGraphQL\ContentProcessors\PluginMarkdownContentRetrieverTrait;
+use GatoGraphQL\GatoGraphQL\Module;
+use GatoGraphQL\GatoGraphQL\ModuleConfiguration;
 use GatoGraphQL\GatoGraphQL\Registries\ModuleRegistryInterface;
 use GatoGraphQL\GatoGraphQL\Services\MenuPages\AbstractDocsMenuPage;
 use PoP\ComponentModel\Misc\GeneralUtils;
@@ -196,7 +198,16 @@ abstract class AbstractVerticalTabDocsMenuPage extends AbstractDocsMenuPage
         return false;
     }
 
-    abstract protected function getPageTitle(): string;
+    protected function getPageTitle(): string
+    {
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        return sprintf(
+            \__('%s - %s', 'gatographql'),
+            $moduleConfiguration->getPluginName(),
+            $this->getMenuPageTitle()
+        );
+    }
 
     protected function getPageHeaderHTML(): string
     {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/ExtensionDocsMenuPage.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/ExtensionDocsMenuPage.php
@@ -47,11 +47,6 @@ class ExtensionDocsMenuPage extends AbstractVerticalTabDocsMenuPage
         return $this->getExtensionsMenuPage()->isServiceEnabled();
     }
 
-    protected function getPageTitle(): string
-    {
-        return \__('Gato GraphQL - Extension Reference Docs', 'gatographql');
-    }
-
     protected function getContentID(): string
     {
         return 'gatographql-extension-docs';

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/ExtensionsMenuPage.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/ExtensionsMenuPage.php
@@ -48,11 +48,6 @@ class ExtensionsMenuPage extends AbstractTableMenuPage
         return __('Extensions', 'gatographql');
     }
 
-    protected function getHeader(): string
-    {
-        return \__('Gato GraphQL — Extensions', 'gatographql');
-    }
-
     protected function hasViews(): bool
     {
         return false;

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/ModulesMenuPage.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/ModulesMenuPage.php
@@ -26,11 +26,6 @@ class ModulesMenuPage extends AbstractItemListTableMenuPage
         return __('Modules', 'gatographql');
     }
 
-    protected function getHeader(): string
-    {
-        return \__('Gato GraphQL — Modules', 'gatographql');
-    }
-
     protected function hasViews(): bool
     {
         return true;

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/SettingsMenuPage.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/SettingsMenuPage.php
@@ -9,6 +9,8 @@ use GatoGraphQL\GatoGraphQL\Constants\RequestParams;
 use GatoGraphQL\GatoGraphQL\Container\ContainerManagerInterface;
 use GatoGraphQL\GatoGraphQL\Facades\UserSettingsManagerFacade;
 use GatoGraphQL\GatoGraphQL\Marketplace\LicenseValidationServiceInterface;
+use GatoGraphQL\GatoGraphQL\Module;
+use GatoGraphQL\GatoGraphQL\ModuleConfiguration;
 use GatoGraphQL\GatoGraphQL\ModuleResolvers\EndpointFunctionalityModuleResolver;
 use GatoGraphQL\GatoGraphQL\ModuleResolvers\PluginGeneralSettingsFunctionalityModuleResolver;
 use GatoGraphQL\GatoGraphQL\ModuleResolvers\PluginManagementFunctionalityModuleResolver;
@@ -20,9 +22,9 @@ use GatoGraphQL\GatoGraphQL\SettingsCategoryResolvers\SettingsCategoryResolver;
 use GatoGraphQL\GatoGraphQL\Settings\Options;
 use GatoGraphQL\GatoGraphQL\Settings\SettingsNormalizerInterface;
 use GatoGraphQL\GatoGraphQL\Settings\UserSettingsManagerInterface;
+
 use PoP\ComponentModel\Configuration\RequestHelpers;
 use PoP\ComponentModel\Constants\FrameworkParams;
-
 use function update_option;
 
 /**
@@ -708,7 +710,13 @@ class SettingsMenuPage extends AbstractPluginMenuPage
 
     protected function getPageTitle(): string
     {
-        return \__('Gato GraphQL — Settings', 'gatographql');
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        return sprintf(
+            \__('%s - %s', 'gatographql'),
+            $moduleConfiguration->getPluginName(),
+            $this->getMenuPageTitle()
+        );
     }
 
     /**

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/TutorialMenuPage.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/TutorialMenuPage.php
@@ -59,11 +59,6 @@ class TutorialMenuPage extends AbstractVerticalTabDocsMenuPage
         return __('Schema Tutorial', 'gatographql');
     }
 
-    protected function getPageTitle(): string
-    {
-        return \__('Gato GraphQL - Schema Tutorial', 'gatographql');
-    }
-
     protected function getContentID(): string
     {
         return 'gatographql-tutorial';

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Menus/PluginMenu.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Menus/PluginMenu.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace GatoGraphQL\GatoGraphQL\Services\Menus;
 
+use GatoGraphQL\GatoGraphQL\Module;
+use GatoGraphQL\GatoGraphQL\ModuleConfiguration;
 use GatoGraphQL\GatoGraphQL\Security\UserAuthorizationInterface;
+use PoP\ComponentModel\App;
 
 /**
  * Main plugin's admin menu
@@ -34,10 +37,13 @@ class PluginMenu extends AbstractMenu
 
     public function addMenuPage(): void
     {
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $menuName = $moduleConfiguration->getPluginName();
         $schemaEditorAccessCapability = $this->getUserAuthorization()->getSchemaEditorAccessCapability();
         \add_menu_page(
-            __('Gato GraphQL', 'gatographql'),
-            __('Gato GraphQL', 'gatographql'),
+            $menuName,
+            $menuName,
             $schemaEditorAccessCapability,
             $this->getName(),
             function (): void {


### PR DESCRIPTION
So they can be overridden by a standalone plugin.