### PR TITLE
Remove all function aliases from scoper-autoload.php

### DIFF
--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -251,7 +251,7 @@ jobs:
 
             -   name: Remove all function aliases from scoper-autoload.php
                 run: |
-                    sed -i -E 's/if \(!function_exists(\'([a-zA-Z0-9_]+)\')\) { function/\/\/if (!function_exists(\'\1\')) { function' vendor/scoper-autoload.php
+                    sed -i -E 's/if \(!function_exists\(\'([a-zA-Z0-9_]+)\'\)\) { function/\/\/if (!function_exists(\'\1\')) { function' vendor/scoper-autoload.php
                 working-directory: ${{ matrix.pluginConfig.path }}
                 if: ${{ matrix.pluginConfig.scoping }}
 

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -249,6 +249,12 @@ jobs:
                 working-directory: ${{ matrix.pluginConfig.path }}
                 if: ${{ matrix.pluginConfig.scoping }}
 
+            -   name: Remove all function aliases from scoper-autoload.php
+                run: |
+                    sed -i 's/if (!function_exists(/\/\/if (!function_exists(/' vendor/scoper-autoload.php
+                working-directory: ${{ matrix.pluginConfig.path }}
+                if: ${{ matrix.pluginConfig.scoping }}
+
     ###########################################################################
     # Generate plugin, and Upload as artifact
     ###########################################################################

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -251,7 +251,7 @@ jobs:
 
             -   name: Remove all function aliases from scoper-autoload.php
                 run: |
-                    sed -i -E 's/if \(!function_exists('([a-zA-Z0-9_]+)')\) { function/\/\/if (!function_exists('\1')) { function' vendor/scoper-autoload.php
+                    sed -i -E 's/if \(!function_exists(\'([a-zA-Z0-9_]+)\')\) { function/\/\/if (!function_exists(\'\1\')) { function' vendor/scoper-autoload.php
                 working-directory: ${{ matrix.pluginConfig.path }}
                 if: ${{ matrix.pluginConfig.scoping }}
 

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -251,7 +251,7 @@ jobs:
 
             -   name: Remove all function aliases from scoper-autoload.php
                 run: |
-                    sed -i -E 's/(if \(\!function_exists\(.+\)\) { function)/\/\/ \1/' vendor/scoper-autoload.php
+                    sed -i -E 's/(if \(\!function_exists\(.+\)\) \{ function)/\/\/ \1/' vendor/scoper-autoload.php
                 working-directory: ${{ matrix.pluginConfig.path }}
                 if: ${{ matrix.pluginConfig.scoping }}
 

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -251,7 +251,7 @@ jobs:
 
             -   name: Remove all function aliases from scoper-autoload.php
                 run: |
-                    sed -i -E 's/if \(!function_exists\(\'([a-zA-Z0-9_]+)\'\)\) { function/\/\/if (!function_exists(\'\1\')) { function' vendor/scoper-autoload.php
+                    sed -i -E 's/(if \(\!function_exists\(.+\)\) { function)/\/\/ \1/' vendor/scoper-autoload.php
                 working-directory: ${{ matrix.pluginConfig.path }}
                 if: ${{ matrix.pluginConfig.scoping }}
 

--- a/.github/workflows/generate_plugins.yml
+++ b/.github/workflows/generate_plugins.yml
@@ -251,7 +251,7 @@ jobs:
 
             -   name: Remove all function aliases from scoper-autoload.php
                 run: |
-                    sed -i 's/if (!function_exists(/\/\/if (!function_exists(/' vendor/scoper-autoload.php
+                    sed -i -E 's/if \(!function_exists('([a-zA-Z0-9_]+)')\) { function/\/\/if (!function_exists('\1')) { function' vendor/scoper-autoload.php
                 working-directory: ${{ matrix.pluginConfig.path }}
                 if: ${{ matrix.pluginConfig.scoping }}
 


### PR DESCRIPTION
Because they point to non-existing functions:

```php
if (!function_exists('ctype_alnum')) { function ctype_alnum() { return \GatoExternalPrefixByGatoGraphQL\ctype_alnum(...func_get_args()); } }
if (!function_exists('ctype_alpha')) { function ctype_alpha() { return \GatoExternalPrefixByGatoGraphQL\ctype_alpha(...func_get_args()); } }
if (!function_exists('ctype_cntrl')) { function ctype_cntrl() { return \GatoExternalPrefixByGatoGraphQL\ctype_cntrl(...func_get_args()); } }
if (!function_exists('ctype_digit')) { function ctype_digit() { return \GatoExternalPrefixByGatoGraphQL\ctype_digit(...func_get_args()); } }
// etc
```

The problem is when also installing a standalone plugin on the same site, which does use one of these aliased functions, and then it doesn't exist!!!

In particular, a standalone plugin may generate:

```php
if (!function_exists('humbug_phpscoper_expose_class')) { function humbug_phpscoper_expose_class() { return \GatoInternalPrefixByGatoMultilingualforPolylang\humbug_phpscoper_expose_class(...func_get_args()); } }
```

And then, Gato GraphQL's `scoper-autoload.php` will invoke that (non-existing) method:

```php
if (!function_exists('humbug_phpscoper_expose_class')) {
    function humbug_phpscoper_expose_class($exposed, $prefixed) {
        if (!class_exists($exposed, false) && !interface_exists($exposed, false) && !trait_exists($exposed, false)) {
            spl_autoload_call($prefixed);
        }
    }
}
humbug_phpscoper_expose_class('DateMalformedIntervalStringException', 'GatoExternalPrefixByGatoGraphQL\DateMalformedIntervalStringException');
```

Notice that it supposedly defines it first, but by then it's already defined by the standalone plugin, throwing an exception.