### PR TITLE
Allow method handling hook `allowed_block_types_all` to receive `null`

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -8,7 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Fixed
 
-- Allow method handling hook `allowed_block_types_all` to receive `null`
+- Allow method handling hook `allowed_block_types_all` to receive `null` (#2965)
 
 ## 7.0.2 - 13/11/2024
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `gatographql` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 7.0.3 - 15/11/2024
+
+### Fixed
+
+- Allow method handling hook `allowed_block_types_all` to receive `null`
+
 ## 7.0.2 - 13/11/2024
 
 ### Fixed

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/7.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/7.0/en.md
@@ -18,7 +18,7 @@
 - Fetching raw attribute sources with multiple nodes in blocks ([#2909](https://github.com/GatoGraphQL/GatoGraphQL/pull/2909))
 - Renamed "Gato GraphQL Shop" to "Gato Shop" (`v7.0.1`)
 - Changed label in Settings form button to "Save Changes (all from this tab)" (`v7.0.2`)
-- Allow method handling hook `allowed_block_types_all` to receive `null` (`v7.0.3`)
+- Allow method handling hook `allowed_block_types_all` to receive `null` (`v7.0.3`) ([#2965](https://github.com/GatoGraphQL/GatoGraphQL/pull/2965))
 
 ## [Extensions] Improvements
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/7.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/7.0/en.md
@@ -18,6 +18,7 @@
 - Fetching raw attribute sources with multiple nodes in blocks ([#2909](https://github.com/GatoGraphQL/GatoGraphQL/pull/2909))
 - Renamed "Gato GraphQL Shop" to "Gato Shop" (`v7.0.1`)
 - Changed label in Settings form button to "Save Changes (all from this tab)" (`v7.0.2`)
+- Allow method handling hook `allowed_block_types_all` to receive `null` (`v7.0.3`)
 
 ## [Extensions] Improvements
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -172,7 +172,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 == Changelog ==
 
 = 7.0.3 =
-* Allow method handling hook `allowed_block_types_all` to receive `null`
+* Allow method handling hook `allowed_block_types_all` to receive `null` (#2965)
 
 = 7.0.2 =
 * Changed label in Settings form button to "Save Changes (all from this tab)"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -171,6 +171,9 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 == Changelog ==
 
+= 7.0.3 =
+* Allow method handling hook `allowed_block_types_all` to receive `null`
+
 = 7.0.2 =
 * Changed label in Settings form button to "Save Changes (all from this tab)"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/CustomPostTypes/AbstractCustomPostType.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/CustomPostTypes/AbstractCustomPostType.php
@@ -799,8 +799,11 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
      * @param string[]|bool $allowedBlocks The list of blocks, or `true` for all of them
      * @return string[]|bool The list of blocks, or `true` for all of them
      */
-    public function allowGutenbergBlocksForCustomPostTypeViaBlockEditorContext(array|bool $allowedBlocks, WP_Block_Editor_Context $blockEditorContext): array|bool
+    public function allowGutenbergBlocksForCustomPostTypeViaBlockEditorContext(array|bool $allowedBlocks, ?WP_Block_Editor_Context $blockEditorContext): array|bool
     {
+        if ($blockEditorContext === null) {
+            return $allowedBlocks;
+        }
         if ($blockEditorContext->post === null) {
             return $allowedBlocks;
         }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/CustomPostTypes/AbstractCustomPostType.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/CustomPostTypes/AbstractCustomPostType.php
@@ -819,8 +819,12 @@ abstract class AbstractCustomPostType extends AbstractAutomaticallyInstantiatedS
      * @param string[]|bool $allowedBlocks The list of blocks, or `true` for all of them
      * @return string[]|bool The list of blocks, or `true` for all of them
      */
-    public function allowGutenbergBlocksForCustomPostType(array|bool $allowedBlocks, WP_Post $post): array|bool
+    public function allowGutenbergBlocksForCustomPostType(array|bool $allowedBlocks, ?WP_Post $post): array|bool
     {
+        if ($post === null) {
+            return $allowedBlocks;
+        }
+
         /**
          * Check if it is this CPT
          */


### PR DESCRIPTION
Due to bug happening when visiting Search & Filters settings pages:

```
[14-Nov-2024 11:34:49 UTC] PHP Fatal error:  Uncaught TypeError: GatoGraphQL\GatoGraphQL\Services\CustomPostTypes\AbstractCustomPostType::allowGutenbergBlocksForCustomPostTypeViaBlockEditorContext(): Argument #2 ($blockEditorContext) must be of type WP_Block_Editor_Context, null given, called in /home/runcloud/webapps/CollabAnthNetwork/wp-includes/class-wp-hook.php on line 324 and defined in /home/runcloud/webapps/CollabAnthNetwork/wp-content/plugins/gatographql/src/Services/CustomPostTypes/AbstractCustomPostType.php:825
Stack trace:
#0 /home/runcloud/webapps/CollabAnthNetwork/wp-includes/class-wp-hook.php(324): GatoGraphQL\GatoGraphQL\Services\CustomPostTypes\AbstractCustomPostType->allowGutenbergBlocksForCustomPostTypeViaBlockEditorContext()
#1 /home/runcloud/webapps/CollabAnthNetwork/wp-includes/plugin.php(205): WP_Hook->apply_filters()
#2 /home/runcloud/webapps/CollabAnthNetwork/wp-includes/block-editor.php(127): apply_filters()
#3 /home/runcloud/webapps/CollabAnthNetwork/wp-includes/block-editor.php(492): get_allowed_block_types()
#4 /home/runcloud/webapps/CollabAnthNetwork/wp-content/plugins/search-filter/includes/class-admin.php(396): get_block_editor_settings()
#5 /home/runcloud/webapps/CollabAnthNetwork/wp-content/plugins/search-filter/includes/class-admin.php(353): Search_Filter\Admin->get_editor_settings()
#6 /home/runcloud/webapps/CollabAnthNetwork/wp-includes/class-wp-hook.php(324): Search_Filter\Admin->enqueue_scripts()
#7 /home/runcloud/webapps/CollabAnthNetwork/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters()
#8 /home/runcloud/webapps/CollabAnthNetwork/wp-includes/plugin.php(517): WP_Hook->do_action()
#9 /home/runcloud/webapps/CollabAnthNetwork/wp-admin/admin-header.php(118): do_action()
#10 /home/runcloud/webapps/CollabAnthNetwork/wp-admin/admin.php(239): require_once('...')
#11 {main}
  thrown in /home/runcloud/webapps/CollabAnthNetwork/wp-content/plugins/gatographql/src/Services/CustomPostTypes/AbstractCustomPostType.php on line 825
```