### PR TITLE
Only register block JS scripts when in allowed CPTs

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Fixed
 
 - Catch exception from SymfonyDI on `admin_init` hook (#2974)
+- Only register block JS scripts when in allowed CPT (#2975)
 
 ## 8.0.0 - 30/11/2024
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/8.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/8.0/en.md
@@ -7,3 +7,4 @@
 ## Fixed
 
 - Catch exception from SymfonyDI on `admin_init` hook ([#2974](https://github.com/GatoGraphQL/GatoGraphQL/pull/2974)) (`v8.0.1`)
+- Only register block JS scripts when in allowed CPT ([#2975](https://github.com/GatoGraphQL/GatoGraphQL/pull/2975)) (`v8.0.1`)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -173,6 +173,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 = 8.0.1 =
 * Fixed: Catch exception from SymfonyDI on `admin_init` hook (#2974)
+* Fixed: Only register block JS scripts when in allowed CPT (#2975)
 
 = 8.0.0 =
 * Extensions (eg: the "All Extensions" bundle) can now be updated from the Plugins page (#2972)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Blocks/AbstractBlock.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Blocks/AbstractBlock.php
@@ -344,6 +344,17 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
      * Registers all block assets so that they can be enqueued through the block editor
      * in the corresponding context.
      *
+     * --------------------------------------------------------------------------------
+     * 
+     * Only register the blocks when editing/viewing the corresponding CPTs,
+     * to enable standalone plugins to be installed alongside Gato GraphQL,
+     * and avoid a conflict from the same block registered twice.
+     *
+     * For instance, running Gato GraphQL and Gato Multilingual for Polylang
+     * would print error on screen:
+     *
+     *    Notice: Function WP_Block_Type_Registry::register was called incorrectly. Block type "gatographql-pro/graphiql" is already registered. Please see Debugging in WordPress for more information. (This message was added in version 5.0.0.) in /Users/leo/Local Sites/playground/app/public/wp-includes/functions.php on line 6114
+     *
      * @see https://developer.wordpress.org/block-editor/tutorials/block-tutorial/applying-styles-with-stylesheets/
      */
     public function initBlock(): void
@@ -354,17 +365,6 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
          * Otherwise, the block would be registered but the category is not,
          * printing error console such as:
          * > The block "gatographql/schema-configuration" must have a registered category.
-         *
-         * --------
-         * 
-         * Only register the blocks when editing/viewing the corresponding CPTs,
-         * to enable standalone plugins to be installed alongside Gato GraphQL,
-         * and avoid a conflict from the same block registered twice.
-         *
-         * For instance, running Gato GraphQL and Gato Multilingual for Polylang
-         * would print error on screen:
-         *
-         *    Notice: Function WP_Block_Type_Registry::register was called incorrectly. Block type "gatographql-pro/graphiql" is already registered. Please see Debugging in WordPress for more information. (This message was added in version 5.0.0.) in /Users/leo/Local Sites/playground/app/public/wp-includes/functions.php on line 6114
          */
         $allowedCustomPostTypes = $this->getAllowedPostTypes();
         $isAdmin = is_admin();

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Blocks/AbstractBlock.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Blocks/AbstractBlock.php
@@ -345,6 +345,17 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
          * Otherwise, the block would be registered but the category is not,
          * printing error console such as:
          * > The block "gatographql/schema-configuration" must have a registered category.
+         *
+         * --------
+         * 
+         * Only register the blocks when editing/viewing the corresponding CPTs,
+         * to enable standalone plugins to be installed alongside Gato GraphQL,
+         * and avoid a conflict from the same block registered twice.
+         *
+         * For instance, running Gato GraphQL and Gato Multilingual for Polylang
+         * would print error on screen:
+         *
+         *    Notice: Function WP_Block_Type_Registry::register was called incorrectly. Block type "gatographql-pro/graphiql" is already registered. Please see Debugging in WordPress for more information. (This message was added in version 5.0.0.) in /Users/leo/Local Sites/playground/app/public/wp-includes/functions.php on line 6114
          */
         if (\is_admin()) {
             if ($customPostTypes = $this->getAllowedPostTypes()) {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Blocks/AbstractBlock.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Blocks/AbstractBlock.php
@@ -22,7 +22,14 @@ use PoP\Root\Constants\HookNames;
 use PoP\Root\Services\AbstractAutomaticallyInstantiatedService;
 use PoP\Root\Services\BasicServiceTrait;
 
+use function add_action;
 use function is_admin;
+use function is_singular;
+use function register_block_type;
+use function wp_localize_script;
+use function wp_enqueue_style;
+use function wp_register_script;
+use function wp_register_style;
 
 /**
  * Base class for a Gutenberg block, within a multi-block plugin.
@@ -370,7 +377,7 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
          * or viewing the post in the frontend
          */
         if (($isAdmin && !in_array($this->getEditorHelpers()->getEditingCustomPostType(), $allowedCustomPostTypes))
-            || (!$isAdmin && !\is_singular($allowedCustomPostTypes))
+            || (!$isAdmin && !is_singular($allowedCustomPostTypes))
         ) {
             return;
         }
@@ -383,7 +390,7 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
                 $mainPlugin = PluginApp::getMainPlugin();
                 $mainPluginURL = $mainPlugin->getPluginURL();
                 $mainPluginVersion = $mainPlugin->getPluginVersion();
-                \wp_enqueue_style(
+                wp_enqueue_style(
                     'highlight-style',
                     $mainPluginURL . 'assets/css/vendors/highlight-11.6.0/a11y-dark.min.css',
                     array(),
@@ -413,7 +420,7 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
         $index_js     = 'build/index.js';
         $script_asset = require($script_asset_path);
         $scriptRegistrationName = $blockRegistrationName . '-block-editor';
-        \wp_register_script(
+        wp_register_script(
             $scriptRegistrationName,
             $url . $index_js,
             array_merge(
@@ -431,7 +438,7 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
             $editor_css = 'build/index.css';
             /** @var string */
             $modificationTime = filemtime("$dir/$editor_css");
-            \wp_register_style(
+            wp_register_style(
                 $blockRegistrationName . '-block-editor',
                 $url . $editor_css,
                 array(),
@@ -447,7 +454,7 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
             $style_css = 'build/style-index.css';
             /** @var string */
             $modificationTime = filemtime("$dir/$style_css");
-            \wp_register_style(
+            wp_register_style(
                 $blockRegistrationName . '-block',
                 $url . $style_css,
                 array(),
@@ -463,9 +470,9 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
          * which calls ComponentModelModuleConfiguration::mustNamespaceTypes(),
          * which is initialized during "wp"
          */
-        \add_action('wp_print_scripts', function () use ($scriptRegistrationName): void {
+        add_action('wp_print_scripts', function () use ($scriptRegistrationName): void {
             if ($localizedData = $this->getLocalizedData()) {
-                \wp_localize_script(
+                wp_localize_script(
                     $scriptRegistrationName,
                     $this->getBlockLocalizationName(),
                     $localizedData
@@ -488,7 +495,7 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
         }
 
         if ($this->registerBlockServerSide()) {
-            \register_block_type($blockFullName, $blockConfiguration);
+            register_block_type($blockFullName, $blockConfiguration);
         }
 
         /**
@@ -521,7 +528,7 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
             return true;
         }
 
-        return \is_singular($allowedCustomPostTypes);
+        return is_singular($allowedCustomPostTypes);
     }
 
     protected function loadClientScriptsInCorrespondingSingleCPTsOnly(): bool

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Blocks/AbstractBlock.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Blocks/AbstractBlock.php
@@ -345,7 +345,7 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
      * in the corresponding context.
      *
      * --------------------------------------------------------------------------------
-     * 
+     *
      * Only register the blocks when editing/viewing the corresponding CPTs,
      * to enable standalone plugins to be installed alongside Gato GraphQL,
      * and avoid a conflict from the same block registered twice.
@@ -376,7 +376,8 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
          * Check that we're either eding the post in the wp-admin,
          * or viewing the post in the frontend
          */
-        if (($isAdmin && !in_array($this->getEditorHelpers()->getEditingCustomPostType(), $allowedCustomPostTypes))
+        if (
+            ($isAdmin && !in_array($this->getEditorHelpers()->getEditingCustomPostType(), $allowedCustomPostTypes))
             || (!$isAdmin && !is_singular($allowedCustomPostTypes))
         ) {
             return;

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Blocks/AbstractBlock.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Blocks/AbstractBlock.php
@@ -360,11 +360,15 @@ abstract class AbstractBlock extends AbstractAutomaticallyInstantiatedService im
          *    Notice: Function WP_Block_Type_Registry::register was called incorrectly. Block type "gatographql-pro/graphiql" is already registered. Please see Debugging in WordPress for more information. (This message was added in version 5.0.0.) in /Users/leo/Local Sites/playground/app/public/wp-includes/functions.php on line 6114
          */
         $allowedCustomPostTypes = $this->getAllowedPostTypes();
-        if ($allowedCustomPostTypes === []) {
+        $isAdmin = is_admin();
+        if ($allowedCustomPostTypes === [] && ($isAdmin || $this->loadClientScriptsInCorrespondingSingleCPTsOnly())) {
             return;
         }
 
-        $isAdmin = is_admin();
+        /**
+         * Check that we're either eding the post in the wp-admin,
+         * or viewing the post in the frontend
+         */
         if (($isAdmin && !in_array($this->getEditorHelpers()->getEditingCustomPostType(), $allowedCustomPostTypes))
             || (!$isAdmin && !\is_singular($allowedCustomPostTypes))
         ) {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/SettingsMenuPage.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/SettingsMenuPage.php
@@ -331,7 +331,7 @@ class SettingsMenuPage extends AbstractPluginMenuPage
                                         ?>
                                             <div id="section-<?php echo esc_attr($itemSetting[Properties::NAME]) ?>" class="gatographql-settings-item" <?php if (!empty($cssStyle)) :
                                                 ?>style="<?php echo esc_attr($cssStyle) ?>"<?php
-                                                            endif; ?>>
+                                                             endif; ?>>
                                                 <?php
                                                 if (!empty($possibleValues)) {
                                                     $this->printSelectField($optionsFormName, $module, $itemSetting);


### PR DESCRIPTION
Only register the blocks when editing/viewing the corresponding CPTs, to enable standalone plugins to be installed alongside Gato GraphQL, and avoid a conflict from the same block registered twice.

For instance, running Gato GraphQL and Gato Multilingual for Polylang would print error on screen:

```
Notice: Function WP_Block_Type_Registry::register was called incorrectly. Block type "gatographql-pro/graphiql" is already registered. Please see Debugging in WordPress for more information. (This message was added in version 5.0.0.) in /Users/leo/Local Sites/playground/app/public/wp-includes/functions.php on line 6114
```