### PR TITLE
Enable updating extensions from Plugins page after major release

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,8 @@ composer fix-style
 
 ## Release notes
 
-- **[8.0](layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/8.0/en.md)** (current)
+- **[9.0](layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/9.0/en.md)** (current)
+- [8.0](layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/8.0/en.md)
 - [7.0](layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/7.0/en.md)
 - [6.0](layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/6.0/en.md)
 - [5.0](layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/5.0/en.md)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -4,13 +4,21 @@ All notable changes to `gatographql` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
-## 8.0.1 - DATE
+## 9.0.0 - DATE
+
+### Breaking changes
+
+- Changed signature of method `assertCommercialLicenseHasBeenActivated` (#2978)
+
+### Improvements
+
+- Only register block JS scripts when in allowed CPT (#2975)
+- Enable updating extensions from Plugins page after major release (#2978)
 
 ### Fixed
 
 - Catch exception from SymfonyDI on `admin_init` hook (#2974)
-- Only register block JS scripts when in allowed CPT (#2975)
-- Show "Visit plugin site" link instead of "View details" for commercial plugins (#2976)
+- Show "Visit plugin site" link instead of "View details" for extensions (#2976)
 - Fixed "Deprecated: Calling get_parent_class() without arguments is deprecated" (#2977)
 
 ## 8.0.0 - 30/11/2024

--- a/layers/GatoGraphQLForWP/plugins/gatographql/README.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/README.md
@@ -172,7 +172,8 @@ composer fix-style
 
 ## Release notes
 
-- **[8.0](docs/release-notes/8.0/en.md)** (current)
+- **[9.0](docs/release-notes/9.0/en.md)** (current)
+- [8.0](docs/release-notes/8.0/en.md)
 - [7.0](docs/release-notes/7.0/en.md)
 - [6.0](docs/release-notes/6.0/en.md)
 - [5.0](docs/release-notes/5.0/en.md)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/general/about/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/general/about/en.md
@@ -96,7 +96,8 @@ Gato GraphQL is a productivity tool for interacting with data in your WordPress 
 
 New features released on each version:
 
-- **[8.0](../../release-notes/8.0/en.md)** (current)
+- **[9.0](../../release-notes/9.0/en.md)** (current)
+- [8.0](../../release-notes/8.0/en.md)
 - [7.0](../../release-notes/7.0/en.md)
 - [6.0](../../release-notes/6.0/en.md)
 - [5.0](../../release-notes/5.0/en.md)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/8.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/8.0/en.md
@@ -3,10 +3,3 @@
 ## Improvements
 
 - Extensions (eg: the "All Extensions" bundle) can now be updated from the Plugins page ([#2972](https://github.com/GatoGraphQL/GatoGraphQL/pull/2972))
-
-## Fixed
-
-- Catch exception from SymfonyDI on `admin_init` hook ([#2974](https://github.com/GatoGraphQL/GatoGraphQL/pull/2974)) (`v8.0.1`)
-- Only register block JS scripts when in allowed CPT ([#2975](https://github.com/GatoGraphQL/GatoGraphQL/pull/2975)) (`v8.0.1`)
-- Show "Visit plugin site" link instead of "View details" for commercial plugins ([#2976](https://github.com/GatoGraphQL/GatoGraphQL/pull/2976)) (`v8.0.1`)
-- Fixed "Deprecated: Calling get_parent_class() without arguments is deprecated" ([#2977](https://github.com/GatoGraphQL/GatoGraphQL/pull/2977)) (`v8.0.1`)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/9.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/9.0/en.md
@@ -1,0 +1,16 @@
+# Release Notes: 9.0
+
+## Breaking changes
+
+- Changed signature of method `assertCommercialLicenseHasBeenActivated` ([#2978](https://github.com/GatoGraphQL/GatoGraphQL/pull/2978))
+
+## Improvements
+
+- Only register block JS scripts when in allowed CPT ([#2975](https://github.com/GatoGraphQL/GatoGraphQL/pull/2975))
+- Enable updating extensions from Plugins page after major release ([#2978](https://github.com/GatoGraphQL/GatoGraphQL/pull/2978))
+
+## Fixed
+
+- Catch exception from SymfonyDI on `admin_init` hook ([#2974](https://github.com/GatoGraphQL/GatoGraphQL/pull/2974))
+- Show "Visit plugin site" link instead of "View details" for extensions ([#2976](https://github.com/GatoGraphQL/GatoGraphQL/pull/2976))
+- Fixed "Deprecated: Calling get_parent_class() without arguments is deprecated" ([#2977](https://github.com/GatoGraphQL/GatoGraphQL/pull/2977))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -171,10 +171,12 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 == Changelog ==
 
-= 8.0.1 =
+= 9.0.0 =
+* Breaking change: Changed signature of method `assertCommercialLicenseHasBeenActivated` (#2978)
+* Only register block JS scripts when in allowed CPT (#2975)
+* Enable updating extensions from Plugins page after major release (#2978)
 * Fixed: Catch exception from SymfonyDI on `admin_init` hook (#2974)
-* Fixed: Only register block JS scripts when in allowed CPT (#2975)
-* Fixed: Show "Visit plugin site" link instead of "View details" for commercial plugins (#2976)
+* Fixed: Show "Visit plugin site" link instead of "View details" for extensions (#2976)
 * Fixed "Deprecated: Calling get_parent_class() without arguments is deprecated" (#2977)
 
 = 8.0.0 =

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Marketplace/AbstractMarketplaceProviderCommercialPluginUpdaterService.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Marketplace/AbstractMarketplaceProviderCommercialPluginUpdaterService.php
@@ -73,17 +73,17 @@ abstract class AbstractMarketplaceProviderCommercialPluginUpdaterService impleme
          * `isCommercial` belongs to `Extension`, not `Plugin`)
          */
         $extensionManager = PluginApp::getExtensionManager();
-        $pluginBaseNameInstances = $extensionManager->getExtensions();
+        $activeExtensionDataEntries = $extensionManager->getActivatedLicenseCommercialExtensionSlugDataEntries();
         foreach ($licenseKeys as $pluginSlug => $pluginLicenseKey) {
-            foreach ($pluginBaseNameInstances as $pluginBaseName => $extensionInstance) {
-                if ($extensionInstance->getPluginSlug() !== $pluginSlug) {
+            foreach ($activeExtensionDataEntries as $activeExtensionData) {
+                if ($activeExtensionData->slug !== $pluginSlug) {
                     continue;
                 }
                 $this->pluginSlugDataEntries[$pluginSlug] = new CommercialPluginUpdatedPluginData(
-                    $extensionInstance->getPluginName(),
-                    $extensionInstance->getPluginSlug(),
-                    $extensionInstance->getPluginBaseName(),
-                    $extensionInstance->getPluginVersion(),
+                    $activeExtensionData->name,
+                    $activeExtensionData->slug,
+                    $activeExtensionData->baseName,
+                    $activeExtensionData->version,
                     $pluginLicenseKey,
                     str_replace('-', '_', $pluginSlug) . '_updater',
                 );

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Marketplace/AbstractMarketplaceProviderCommercialPluginUpdaterService.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Marketplace/AbstractMarketplaceProviderCommercialPluginUpdaterService.php
@@ -80,7 +80,10 @@ abstract class AbstractMarketplaceProviderCommercialPluginUpdaterService impleme
                     continue;
                 }
                 $this->pluginSlugDataEntries[$pluginSlug] = new CommercialPluginUpdatedPluginData(
-                    $extensionInstance,
+                    $extensionInstance->getPluginName(),
+                    $extensionInstance->getPluginSlug(),
+                    $extensionInstance->getPluginBaseName(),
+                    $extensionInstance->getPluginVersion(),
                     $pluginLicenseKey,
                     str_replace('-', '_', $pluginSlug) . '_updater',
                 );
@@ -128,8 +131,8 @@ abstract class AbstractMarketplaceProviderCommercialPluginUpdaterService impleme
         }
 
         $result       = $remote->update;
-        $result->name = $pluginData->plugin->getPluginName();
-        $result->slug = $pluginData->plugin->getPluginSlug();
+        $result->name = $pluginData->pluginName;
+        $result->slug = $pluginData->pluginSlug;
         $result->sections = (array) $result->sections;
 
         return $result;
@@ -185,15 +188,15 @@ abstract class AbstractMarketplaceProviderCommercialPluginUpdaterService impleme
 
         foreach ($this->pluginSlugDataEntries as $pluginData) {
             $res = (object) array(
-                'id'            => $pluginData->plugin->getPluginBaseName(),
+                'id'            => $pluginData->pluginBaseName,
                 /**
                  * If providing the slug, the plugin item in the Plugins page
                  * will have link "View details", which produces an error,
                  * instead of the expected "Visit plugin site"
                  */
-                // 'slug'          => $pluginData->plugin->getPluginSlug(),
-                'plugin'        => $pluginData->plugin->getPluginBaseName(),
-                'new_version'   => $pluginData->plugin->getPluginVersion(),
+                // 'slug'          => $pluginData->pluginSlug,
+                'plugin'        => $pluginData->pluginBaseName,
+                'new_version'   => $pluginData->pluginVersion,
                 'url'           => '',
                 'package'       => '',
                 'icons'         => [],
@@ -208,7 +211,7 @@ abstract class AbstractMarketplaceProviderCommercialPluginUpdaterService impleme
 
             if (
                 $remote && ($remote->success ?? null) && !empty($remote->update)
-                && version_compare($pluginData->plugin->getPluginVersion(), $remote->update->version, '<')
+                && version_compare($pluginData->pluginVersion, $remote->update->version, '<')
             ) {
                 $res->new_version = $remote->update->version;
                 $res->package     = $remote->update->download_link;
@@ -246,7 +249,7 @@ abstract class AbstractMarketplaceProviderCommercialPluginUpdaterService impleme
         $pluginIDs = $options['plugins'];
         foreach ($pluginIDs as $pluginID) {
             foreach ($this->pluginSlugDataEntries as $pluginData) {
-                if ($pluginID !== $pluginData->plugin->getPluginBaseName()) {
+                if ($pluginID !== $pluginData->pluginBaseName) {
                     continue;
                 }
                 delete_transient($pluginData->cacheKey);

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Marketplace/ObjectModels/CommercialPluginUpdatedPluginData.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Marketplace/ObjectModels/CommercialPluginUpdatedPluginData.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace GatoGraphQL\GatoGraphQL\Marketplace\ObjectModels;
 
-use GatoGraphQL\GatoGraphQL\PluginSkeleton\PluginInterface;
-
 class CommercialPluginUpdatedPluginData
 {
     public function __construct(

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Marketplace/ObjectModels/CommercialPluginUpdatedPluginData.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Marketplace/ObjectModels/CommercialPluginUpdatedPluginData.php
@@ -9,7 +9,10 @@ use GatoGraphQL\GatoGraphQL\PluginSkeleton\PluginInterface;
 class CommercialPluginUpdatedPluginData
 {
     public function __construct(
-        public readonly PluginInterface $plugin,
+        public readonly string $pluginName,
+        public readonly string $pluginSlug,
+        public readonly string $pluginBaseName,
+        public readonly string $pluginVersion,
         public readonly string $licenseKey,
         public readonly string $cacheKey,
     ) {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/ObjectModels/ActiveLicenseCommercialExtensionData.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/ObjectModels/ActiveLicenseCommercialExtensionData.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GatoGraphQL\GatoGraphQL\ObjectModels;
+
+class ActiveLicenseCommercialExtensionData
+{
+    public function __construct(
+        public readonly string $productName,
+        public readonly string $name,
+        public readonly string $slug,
+        public readonly string $baseName,
+        public readonly string $version,
+    ) {
+    }
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
@@ -21,8 +21,8 @@ use GatoGraphQL\GatoGraphQL\SettingsCategoryResolvers\SettingsCategoryResolver;
 use GatoGraphQL\GatoGraphQL\StaticHelpers\AdminHelpers;
 use GatoGraphQL\GatoGraphQL\StaticHelpers\PluginVersionHelpers;
 use GatoGraphQL\GatoGraphQL\StaticHelpers\SettingsHelpers;
-
 use PoP\Root\Facades\Instances\InstanceManagerFacade;
+
 use function plugin_basename;
 
 class ExtensionManager extends AbstractPluginManager

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
@@ -283,6 +283,8 @@ class ExtensionManager extends AbstractPluginManager
         string $extensionSlug,
         string $extensionProductName,
         string $extensionName,
+        string $extensionBaseName,
+        string $extensionVersion,
     ): bool {
         /**
          * Retrieve from the DB which licenses have been activated,

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
@@ -280,12 +280,14 @@ class ExtensionManager extends AbstractPluginManager
      * @param string $extensionProductName The EXACT name as the product is stored in the Gato Shop (i.e. in the Marketplace Provider's system)
      */
     public function assertCommercialLicenseHasBeenActivated(
-        string $extensionSlug,
+        string $extensionFile,
         string $extensionProductName,
         string $extensionName,
-        string $extensionBaseName,
         string $extensionVersion,
     ): bool {
+        $extensionBaseName = \plugin_basename($extensionFile);
+        $extensionSlug = dirname($extensionBaseName);
+        
         /**
          * Retrieve from the DB which licenses have been activated,
          * and check if this extension is in it

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
@@ -411,9 +411,9 @@ class ExtensionManager extends AbstractPluginManager
     }
 
     /**
-     * @return array<string,string> Extension Slug => Extension Product Name
+     * @return array<string,string> Extension Slug => ActiveLicenseCommercialExtensionData
      */
-    public function getActivatedLicenseCommercialExtensionSlugProductNames(): array
+    public function getActivatedLicenseCommercialExtensionSlugDataEntries(): array
     {
         return $this->activatedLicenseCommercialExtensionSlugDataEntries;
     }
@@ -434,7 +434,7 @@ class ExtensionManager extends AbstractPluginManager
         if ($this->commercialExtensionSlugProductNames === null) {
             $this->commercialExtensionSlugProductNames = array_merge(
                 $this->getNonActivatedLicenseCommercialExtensionSlugProductNames(),
-                $this->getActivatedLicenseCommercialExtensionSlugProductNames(),
+                $this->getActivatedLicenseCommercialExtensionSlugDataEntries(),
             );
             ksort($this->commercialExtensionSlugProductNames);
         }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
@@ -434,7 +434,10 @@ class ExtensionManager extends AbstractPluginManager
         if ($this->commercialExtensionSlugProductNames === null) {
             $this->commercialExtensionSlugProductNames = array_merge(
                 $this->getNonActivatedLicenseCommercialExtensionSlugProductNames(),
-                $this->getActivatedLicenseCommercialExtensionSlugDataEntries(),
+                array_map(
+                    fn (ActiveLicenseCommercialExtensionData $extensionData) => $extensionData->productName,
+                    $this->getActivatedLicenseCommercialExtensionSlugDataEntries()
+                ),
             );
             ksort($this->commercialExtensionSlugProductNames);
         }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
@@ -411,7 +411,7 @@ class ExtensionManager extends AbstractPluginManager
     }
 
     /**
-     * @return array<string,string> Extension Slug => ActiveLicenseCommercialExtensionData
+     * @return array<string,ActiveLicenseCommercialExtensionData> Extension Slug => ActiveLicenseCommercialExtensionData
      */
     public function getActivatedLicenseCommercialExtensionSlugDataEntries(): array
     {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
@@ -22,6 +22,8 @@ use GatoGraphQL\GatoGraphQL\StaticHelpers\PluginVersionHelpers;
 use GatoGraphQL\GatoGraphQL\StaticHelpers\SettingsHelpers;
 use PoP\Root\Facades\Instances\InstanceManagerFacade;
 
+use function plugin_basename;
+
 class ExtensionManager extends AbstractPluginManager
 {
     /** @var string[] */
@@ -285,9 +287,9 @@ class ExtensionManager extends AbstractPluginManager
         string $extensionName,
         string $extensionVersion,
     ): bool {
-        $extensionBaseName = \plugin_basename($extensionFile);
+        $extensionBaseName = plugin_basename($extensionFile);
         $extensionSlug = dirname($extensionBaseName);
-        
+
         /**
          * Retrieve from the DB which licenses have been activated,
          * and check if this extension is in it

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
@@ -37,7 +37,7 @@ class ExtensionManager extends AbstractPluginManager
     private array $nonActivatedLicenseCommercialExtensionSlugProductNames = [];
 
     /** @var array<string,ActiveLicenseCommercialExtensionData> Extension Slug => ActiveLicenseCommercialExtensionData */
-    private array $activatedLicenseCommercialExtensionSlugProductNames = [];
+    private array $activatedLicenseCommercialExtensionSlugDataEntries = [];
 
     /** @var array<string,string>|null Extension Slug => Extension Product Name */
     private ?array $commercialExtensionSlugProductNames = null;
@@ -343,7 +343,7 @@ class ExtensionManager extends AbstractPluginManager
         }
 
         // Everything is good!
-        $this->activatedLicenseCommercialExtensionSlugProductNames[$extensionSlug] = new ActiveLicenseCommercialExtensionData(
+        $this->activatedLicenseCommercialExtensionSlugDataEntries[$extensionSlug] = new ActiveLicenseCommercialExtensionData(
             $extensionProductName,
             $extensionName,
             $extensionSlug,
@@ -415,7 +415,7 @@ class ExtensionManager extends AbstractPluginManager
      */
     public function getActivatedLicenseCommercialExtensionSlugProductNames(): array
     {
-        return $this->activatedLicenseCommercialExtensionSlugProductNames;
+        return $this->activatedLicenseCommercialExtensionSlugDataEntries;
     }
 
     /**
@@ -423,7 +423,7 @@ class ExtensionManager extends AbstractPluginManager
      */
     public function isExtensionLicenseActive(string $extensionSlug): bool
     {
-        return isset($this->activatedLicenseCommercialExtensionSlugProductNames[$extensionSlug]);
+        return isset($this->activatedLicenseCommercialExtensionSlugDataEntries[$extensionSlug]);
     }
 
     /**

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginManagement/ExtensionManager.php
@@ -11,6 +11,7 @@ use GatoGraphQL\GatoGraphQL\Facades\Registries\ModuleRegistryFacade;
 use GatoGraphQL\GatoGraphQL\Facades\Registries\SettingsCategoryRegistryFacade;
 use GatoGraphQL\GatoGraphQL\Marketplace\Constants\LicenseStatus;
 use GatoGraphQL\GatoGraphQL\ModuleResolvers\PluginManagementFunctionalityModuleResolver;
+use GatoGraphQL\GatoGraphQL\ObjectModels\ActiveLicenseCommercialExtensionData;
 use GatoGraphQL\GatoGraphQL\PluginApp;
 use GatoGraphQL\GatoGraphQL\PluginSkeleton\BundleExtensionInterface;
 use GatoGraphQL\GatoGraphQL\PluginSkeleton\ExtensionInterface;
@@ -20,8 +21,8 @@ use GatoGraphQL\GatoGraphQL\SettingsCategoryResolvers\SettingsCategoryResolver;
 use GatoGraphQL\GatoGraphQL\StaticHelpers\AdminHelpers;
 use GatoGraphQL\GatoGraphQL\StaticHelpers\PluginVersionHelpers;
 use GatoGraphQL\GatoGraphQL\StaticHelpers\SettingsHelpers;
-use PoP\Root\Facades\Instances\InstanceManagerFacade;
 
+use PoP\Root\Facades\Instances\InstanceManagerFacade;
 use function plugin_basename;
 
 class ExtensionManager extends AbstractPluginManager
@@ -35,7 +36,7 @@ class ExtensionManager extends AbstractPluginManager
     /** @var array<string,string> Extension Slug => Extension Product Name */
     private array $nonActivatedLicenseCommercialExtensionSlugProductNames = [];
 
-    /** @var array<string,string> Extension Slug => Extension Product Name */
+    /** @var array<string,ActiveLicenseCommercialExtensionData> Extension Slug => ActiveLicenseCommercialExtensionData */
     private array $activatedLicenseCommercialExtensionSlugProductNames = [];
 
     /** @var array<string,string>|null Extension Slug => Extension Product Name */
@@ -342,7 +343,13 @@ class ExtensionManager extends AbstractPluginManager
         }
 
         // Everything is good!
-        $this->activatedLicenseCommercialExtensionSlugProductNames[$extensionSlug] = $extensionProductName;
+        $this->activatedLicenseCommercialExtensionSlugProductNames[$extensionSlug] = new ActiveLicenseCommercialExtensionData(
+            $extensionProductName,
+            $extensionName,
+            $extensionSlug,
+            $extensionBaseName,
+            $extensionVersion,
+        );
         return true;
     }
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -573,7 +573,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                  * has been invoked
                  */
                 $extensionManager = PluginApp::getExtensionManager();
-                if ($extensionManager->getActivatedLicenseCommercialExtensionSlugProductNames() === []) {
+                if ($extensionManager->getActivatedLicenseCommercialExtensionSlugDataEntries() === []) {
                     return;
                 }
 


### PR DESCRIPTION
In `v8.0.0` we introducing updating commercial extensions directly from the Plugins page.

However, when the extension's version constraint is not satisfied (eg: Gato GraphQL is `v8.0.0` and extension is `v7.0.0`), then the extension is not loaded, and it doesn't validate if its license is valid.

As such, it also doesn't offer updating the plugin! Hence, whenever there's a major release, the plugin cannot be updated.

This PR fixes this issue.