### PR TITLE
Improve performance when caching resolvers for a queried field

### DIFF
--- a/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/ObjectType/AbstractObjectTypeResolver.php
@@ -1121,7 +1121,7 @@ abstract class AbstractObjectTypeResolver extends AbstractRelationalTypeResolver
     {
         if ($fieldOrFieldName instanceof FieldInterface) {
             $field = $fieldOrFieldName;
-            $cacheKey = $field->asFieldOutputQueryString();
+            $cacheKey = $field->getName();
         } else {
             $cacheKey = $fieldOrFieldName;
         }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -14,6 +14,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - Only register block JS scripts when in allowed CPT (#2975)
 - Enable updating extensions from Plugins page after major release (#2978)
+- Improve performance when caching resolvers for a queried field (#2981)
 
 ### Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/9.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/9.0/en.md
@@ -8,6 +8,7 @@
 
 - Only register block JS scripts when in allowed CPT ([#2975](https://github.com/GatoGraphQL/GatoGraphQL/pull/2975))
 - Enable updating extensions from Plugins page after major release ([#2978](https://github.com/GatoGraphQL/GatoGraphQL/pull/2978))
+- Improve performance when caching resolvers for a queried field ([#2981](https://github.com/GatoGraphQL/GatoGraphQL/pull/2981))
 
 ## Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -175,6 +175,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 * Breaking change: Changed signature of method `assertCommercialLicenseHasBeenActivated` (#2978)
 * Only register block JS scripts when in allowed CPT (#2975)
 * Enable updating extensions from Plugins page after major release (#2978)
+* Improve performance when caching resolvers for a queried field (#2981)
 * Fixed: Catch exception from SymfonyDI on `admin_init` hook (#2974)
 * Fixed: Show "Visit plugin site" link instead of "View details" for extensions (#2976)
 * Fixed "Deprecated: Calling get_parent_class() without arguments is deprecated" (#2977)


### PR DESCRIPTION
Replaced this line:

```php
$cacheKey = $field->asFieldOutputQueryString();
```

with this:

```php
$cacheKey = $field->getName();
```

The reason is that executing `$field->asFieldOutputQueryString()` is extremely expensive and slow when the field is an `InputValue` with a `JSON`!

For instance, if getting external data using `_sendJSONObjectItemHTTPRequest` and the response is super big, then the query string for that JSON value will take many many seconds to compute.