### PR TITLE
Fix bug: Do not use HTML5 parser when parsing blocks

### DIFF
--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/blocks.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/blocks.json
@@ -1927,13 +1927,15 @@
                     {
                         "name": "core\/categories",
                         "attributes": {
+                            "taxonomy": "category",
                             "displayAsDropdown": false,
                             "showHierarchy": false,
                             "showPostCounts": false,
                             "showOnlyTopLevel": false,
-                            "showEmpty": false
+                            "showEmpty": false,
+                            "showLabel": true
                         },
-                        "contentSource": "<!-- wp:categories {\"displayAsDropdown\":false,\"showHierarchy\":false,\"showPostCounts\":false,\"showOnlyTopLevel\":false,\"showEmpty\":false} \/-->",
+                        "contentSource": "<!-- wp:categories {\"taxonomy\":\"category\",\"displayAsDropdown\":false,\"showHierarchy\":false,\"showPostCounts\":false,\"showOnlyTopLevel\":false,\"showEmpty\":false,\"showLabel\":true} \/-->",
                         "innerBlocks": null
                     },
                     {
@@ -1986,11 +1988,13 @@
                         "attributes": {
                             "showHierarchy": true,
                             "showPostCounts": true,
+                            "taxonomy": "category",
                             "displayAsDropdown": false,
                             "showOnlyTopLevel": false,
-                            "showEmpty": false
+                            "showEmpty": false,
+                            "showLabel": true
                         },
-                        "contentSource": "<!-- wp:categories {\"showHierarchy\":true,\"showPostCounts\":true,\"displayAsDropdown\":false,\"showOnlyTopLevel\":false,\"showEmpty\":false} \/-->",
+                        "contentSource": "<!-- wp:categories {\"showHierarchy\":true,\"showPostCounts\":true,\"taxonomy\":\"category\",\"displayAsDropdown\":false,\"showOnlyTopLevel\":false,\"showEmpty\":false,\"showLabel\":true} \/-->",
                         "innerBlocks": null
                     },
                     {
@@ -2033,11 +2037,13 @@
                     {
                         "name": "core\/categories",
                         "attributes": {
+                            "taxonomy": "category",
                             "displayAsDropdown": false,
                             "showHierarchy": false,
                             "showPostCounts": false,
                             "showOnlyTopLevel": false,
-                            "showEmpty": false
+                            "showEmpty": false,
+                            "showLabel": true
                         }
                     },
                     {
@@ -2082,9 +2088,11 @@
                         "attributes": {
                             "showHierarchy": true,
                             "showPostCounts": true,
+                            "taxonomy": "category",
                             "displayAsDropdown": false,
                             "showOnlyTopLevel": false,
-                            "showEmpty": false
+                            "showEmpty": false,
+                            "showLabel": true
                         }
                     },
                     {
@@ -2125,11 +2133,13 @@
                     {
                         "name": "core\/categories",
                         "attributes": {
+                            "taxonomy": "category",
                             "displayAsDropdown": false,
                             "showHierarchy": false,
                             "showPostCounts": false,
                             "showOnlyTopLevel": false,
-                            "showEmpty": false
+                            "showEmpty": false,
+                            "showLabel": true
                         },
                         "innerBlockPositions": null,
                         "parentBlockPosition": null
@@ -2184,9 +2194,11 @@
                         "attributes": {
                             "showHierarchy": true,
                             "showPostCounts": true,
+                            "taxonomy": "category",
                             "displayAsDropdown": false,
                             "showOnlyTopLevel": false,
-                            "showEmpty": false
+                            "showEmpty": false,
+                            "showLabel": true
                         },
                         "innerBlockPositions": null,
                         "parentBlockPosition": null
@@ -7619,13 +7631,15 @@
                 {
                     "name": "core\/categories",
                     "attributes": {
+                        "taxonomy": "category",
                         "displayAsDropdown": false,
                         "showHierarchy": false,
                         "showPostCounts": false,
                         "showOnlyTopLevel": false,
-                        "showEmpty": false
+                        "showEmpty": false,
+                        "showLabel": true
                     },
-                    "contentSource": "<!-- wp:categories {\"displayAsDropdown\":false,\"showHierarchy\":false,\"showPostCounts\":false,\"showOnlyTopLevel\":false,\"showEmpty\":false} \/-->",
+                    "contentSource": "<!-- wp:categories {\"taxonomy\":\"category\",\"displayAsDropdown\":false,\"showHierarchy\":false,\"showPostCounts\":false,\"showOnlyTopLevel\":false,\"showEmpty\":false,\"showLabel\":true} \/-->",
                     "innerBlocks": null
                 },
                 {
@@ -7678,11 +7692,13 @@
                     "attributes": {
                         "showHierarchy": true,
                         "showPostCounts": true,
+                        "taxonomy": "category",
                         "displayAsDropdown": false,
                         "showOnlyTopLevel": false,
-                        "showEmpty": false
+                        "showEmpty": false,
+                        "showLabel": true
                     },
-                    "contentSource": "<!-- wp:categories {\"showHierarchy\":true,\"showPostCounts\":true,\"displayAsDropdown\":false,\"showOnlyTopLevel\":false,\"showEmpty\":false} \/-->",
+                    "contentSource": "<!-- wp:categories {\"showHierarchy\":true,\"showPostCounts\":true,\"taxonomy\":\"category\",\"displayAsDropdown\":false,\"showOnlyTopLevel\":false,\"showEmpty\":false,\"showLabel\":true} \/-->",
                     "innerBlocks": null
                 },
                 {
@@ -7725,11 +7741,13 @@
                 {
                     "name": "core\/categories",
                     "attributes": {
+                        "taxonomy": "category",
                         "displayAsDropdown": false,
                         "showHierarchy": false,
                         "showPostCounts": false,
                         "showOnlyTopLevel": false,
-                        "showEmpty": false
+                        "showEmpty": false,
+                        "showLabel": true
                     }
                 },
                 {
@@ -7774,9 +7792,11 @@
                     "attributes": {
                         "showHierarchy": true,
                         "showPostCounts": true,
+                        "taxonomy": "category",
                         "displayAsDropdown": false,
                         "showOnlyTopLevel": false,
-                        "showEmpty": false
+                        "showEmpty": false,
+                        "showLabel": true
                     }
                 },
                 {
@@ -7817,11 +7837,13 @@
                 {
                     "name": "core\/categories",
                     "attributes": {
+                        "taxonomy": "category",
                         "displayAsDropdown": false,
                         "showHierarchy": false,
                         "showPostCounts": false,
                         "showOnlyTopLevel": false,
-                        "showEmpty": false
+                        "showEmpty": false,
+                        "showLabel": true
                     },
                     "innerBlockPositions": null,
                     "parentBlockPosition": null
@@ -7876,9 +7898,11 @@
                     "attributes": {
                         "showHierarchy": true,
                         "showPostCounts": true,
+                        "taxonomy": "category",
                         "displayAsDropdown": false,
                         "showOnlyTopLevel": false,
-                        "showEmpty": false
+                        "showEmpty": false,
+                        "showLabel": true
                     },
                     "innerBlockPositions": null,
                     "parentBlockPosition": null

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 10.1.1 - DATE
 
+### Fixed
+
+- Do not use HTML5 Parser when parsing blocks (#3023)
+
 ### Improvements
 
 - Plugin updates: Use the same icon as the Gato GraphQL plugin for the extensions (#3022)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/10.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/10.1/en.md
@@ -18,6 +18,7 @@
 ## Fixed
 
 - Exception when serializing an array value ([#3017](https://github.com/GatoGraphQL/GatoGraphQL/pull/3017))
+- Do not use HTML5 Parser when parsing blocks (`v10.1.1`) ([#3023](https://github.com/GatoGraphQL/GatoGraphQL/pull/3023))
 
 ## [Extensions] Added
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -202,6 +202,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 = 10.1.1 =
 * Plugin updates: Use the same icon as the Gato GraphQL plugin for the extensions (#3022)
+* Fixed bug: Do not use HTML5 Parser when parsing blocks (#3023)
 * [Extensions][Translation] Pass language + country code on `@strTranslate(to:)`
 
 = 10.1.0 =

--- a/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
+++ b/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
@@ -345,7 +345,7 @@ class BlockContentParser extends AbstractBasicService implements BlockContentPar
                  * Watch out! We must disable the HTML5 parser!
                  * @see https://github.com/GatoGraphQL/GatoGraphQL/pull/3023
                  */
-                false 
+                false
             );
 
             // Enter the <body> tag for block parsing

--- a/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
+++ b/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
@@ -341,7 +341,11 @@ class BlockContentParser extends AbstractBasicService implements BlockContentPar
                 sprintf('<!doctype html><html><body>%s</body></html>', $block['innerHTML']),
                 null,
                 null,
-                false
+                /**
+                 * Watch out! We must disable the HTML5 parser!
+                 * @see https://github.com/GatoGraphQL/GatoGraphQL/pull/3023
+                 */
+                false 
             );
 
             // Enter the <body> tag for block parsing

--- a/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
+++ b/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
@@ -337,7 +337,12 @@ class BlockContentParser extends AbstractBasicService implements BlockContentPar
             }
 
             // Specify a manual doctype so that the parser will use the HTML5 parser
-            $crawler = new Crawler(sprintf('<!doctype html><html><body>%s</body></html>', $block['innerHTML']));
+            $crawler = new Crawler(
+                sprintf('<!doctype html><html><body>%s</body></html>', $block['innerHTML']),
+                null,
+                null,
+                false
+            );
 
             // Enter the <body> tag for block parsing
             $crawler = $crawler->filter('body');


### PR DESCRIPTION
(Watch out: For some reason, the `&nbsp;` is not shown in the Gutenberg editor, even if it exists in the stored data.)

When the stored post content contains `&nbsp;`, it is retrieved differently by `rawContent` and `blocks`, creating issues.

For instance, for the following stored content:

```html
<!-- wp:paragraph -->
<p>Maize, also known as&nbsp;corn.</p>
<!-- /wp:paragraph -->
```

When running this query:

```graphql
query {
  customPosts(filter: { ids: [2834] }) {
    rawContent
    originCoreParagraph: blockFlattenedDataItems(
      filterBy: { include: "core/paragraph" }
    )
  }
}
```

We get that stored string with `&nbsp;` in `blockFlattenedDataItems`, and without in `rawContent`:

```json
{
  "data": {
    "customPosts": [
      {
        "rawContent": "<!-- wp:paragraph -->\n<p>Maize, also known as corn.</p>\n<!-- /wp:paragraph -->",
        "originCoreParagraph": [
          {
            "name": "core/paragraph",
            "attributes": {
              "content": "Maize, also known as&nbsp;corn.",
              "dropCap": false
            }
          }
        ]
      }
    ]
  }
}
```

And then processing the string later on (eg: for translation) may fail.

Solution: do not use the HTML5 parser when parsing blocks.