### PR TITLE
Revert not using HTML5 parser in Crawler

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,10 +6,6 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 10.1.1 - DATE
 
-### Fixed
-
-- Do not use HTML5 Parser when parsing blocks (#3023)
-
 ### Improvements
 
 - Plugin updates: Use the same icon as the Gato GraphQL plugin for the extensions (#3022)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/10.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/10.1/en.md
@@ -18,7 +18,6 @@
 ## Fixed
 
 - Exception when serializing an array value ([#3017](https://github.com/GatoGraphQL/GatoGraphQL/pull/3017))
-- Do not use HTML5 Parser when parsing blocks (`v10.1.1`) ([#3023](https://github.com/GatoGraphQL/GatoGraphQL/pull/3023))
 
 ## [Extensions] Added
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -202,7 +202,6 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 = 10.1.1 =
 * Plugin updates: Use the same icon as the Gato GraphQL plugin for the extensions (#3022)
-* Fixed bug: Do not use HTML5 Parser when parsing blocks (#3023)
 * [Extensions][Translation] Pass language + country code on `@strTranslate(to:)`
 
 = 10.1.0 =

--- a/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
+++ b/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
@@ -337,16 +337,7 @@ class BlockContentParser extends AbstractBasicService implements BlockContentPar
             }
 
             // Specify a manual doctype so that the parser will use the HTML5 parser
-            $crawler = new Crawler(
-                sprintf('<!doctype html><html><body>%s</body></html>', $block['innerHTML']),
-                null,
-                null,
-                /**
-                 * Watch out! We must disable the HTML5 parser!
-                 * @see https://github.com/GatoGraphQL/GatoGraphQL/pull/3023
-                 */
-                false
-            );
+            $crawler = new Crawler(sprintf('<!doctype html><html><body>%s</body></html>', $block['innerHTML']));
 
             // Enter the <body> tag for block parsing
             $crawler = $crawler->filter('body');


### PR DESCRIPTION
Revert #3023 because it then produces another bug: The `&nbsp;` in this content is not retrieved right:

```html
<!-- wp:paragraph -->
<p><strong>Diego Maradona</strong> (30 October 1960&nbsp;– 25 November 2020) ...</p>
<!-- /wp:paragraph -->
```