### PR TITLE
Fixed: Returning no results from `get_posts` when passing many CPTs

### DIFF
--- a/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
+++ b/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
@@ -126,6 +126,14 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
          * Solution: if there are no results, and more than 1 CPT is passed,
          * then merge the results from querying each CPT individually.
          */
+        if ($results === [] && is_array($query['post_type']) && count($query['post_type']) > 1) {
+            /** @var string[] */
+            $customPostTypes = $query['post_type'];
+            foreach ($customPostTypes as $customPostType) {
+                $query['post_type'] = $customPostType;
+                $results = array_merge($results, get_posts($query));
+            }
+        }
 
         return $results;
     }

--- a/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
+++ b/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
@@ -130,8 +130,15 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
             /** @var string[] */
             $customPostTypes = $query['post_type'];
             foreach ($customPostTypes as $customPostType) {
-                $query['post_type'] = $customPostType;
-                $results = array_merge($results, get_posts($query));
+                $results = [
+                    ...$results,
+                    ...get_posts(
+                        [
+                            ...$query,
+                            'post_type' => $customPostType,
+                        ]
+                    )
+                ];
             }
         }
 

--- a/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
+++ b/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
@@ -107,7 +107,27 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
             return [];
         }
 
-        return get_posts($query);
+        $results = get_posts($query);
+
+        /**
+         * Watch out: When fetching a CPT entry of type "template_bricks"
+         * passing "post_type" => ["post", "bricks_template"] sometimes
+         * doesn't work, while passing "post_type" => "bricks_template"
+         * does work.
+         *
+         * According to Cursor AI:
+         * 
+         *   > The issue occurs because some custom post types (like "bricks_template")
+         *   > have special handling in WordPress core that expects them to be queried
+         *   > individually, not as part of an array. When you pass an array like
+         *   > ["post", "bricks_template"], WordPress sometimes fails to properly
+         *   > handle the mixed query.
+         *
+         * Solution: if there are no results, and more than 1 CPT is passed,
+         * then merge the results from querying each CPT individually.
+         */
+
+        return $results;
     }
 
     /**

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -26,6 +26,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Fixed
 
 - Avoid overriding logic: Querying "attachment" doesn't work in an array (#3123)
+- Returning no results from `get_posts` when passing many CPTs (#3128)
 
 ## 13.0.2 - 24/05/2025
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/13.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/13.1/en.md
@@ -20,3 +20,4 @@
 ## Fixed
 
 - Avoid overriding logic: Querying "attachment" doesn't work in an array ([#3123](https://github.com/GatoGraphQL/GatoGraphQL/pull/3123))
+- Returning no results from `get_posts` when passing many CPTs ([#3128](https://github.com/GatoGraphQL/GatoGraphQL/pull/3128))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -231,8 +231,9 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 * Added new input `IncludeExcludeFilterInput` (#3127)
 * Allow reinstalling plugin initial data when plugin/theme dependency is activated/deactivated (#3119)
 * Made `customPostType` param on the `updateCustomPost` mutation optional (#3120)
-* Avoid overriding logic: Querying "attachment" doesn't work in an array (#3123)
 * Use `NonEmptyString` for `slug` on custom post mutations (#3126)
+* Avoid overriding logic: Querying "attachment" doesn't work in an array (#3123)
+* Fixed: Returning no results from `get_posts` when passing many CPTs (#3128)
 
 = 13.0.2 =
 * Fixed: Do not show the notification count badge in the plugin menu if the Logs page is not enabled (#3112)


### PR DESCRIPTION
When fetching a CPT entry of type `"template_bricks"` passing `"post_type" => ["post", "bricks_template"]` sometimes doesn't work, while passing `"post_type" => "bricks_template"` does work.

According to Cursor AI:

> The issue occurs because some custom post types (like "bricks_template") have special handling in WordPress core that expects them to be queried individually, not as part of an array. When you pass an array like ["post", "bricks_template"], WordPress sometimes fails to properly handle the mixed query.

**Solution:** if there are no results, and more than 1 CPT is passed, then merge the results from querying each CPT individually.