### PR TITLE
Support for "partial" errors (shown in the response, but not bubbled up on nested directives)

### DIFF
--- a/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeFieldDirectiveResolver.php
+++ b/layers/Engine/packages/component-model/src/DirectiveResolvers/ResolveValueAndMergeFieldDirectiveResolver.php
@@ -435,7 +435,9 @@ final class ResolveValueAndMergeFieldDirectiveResolver extends AbstractGlobalFie
         );
 
         // 3. Add the output in the DB
-        if ($objectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
+        if ($objectTypeFieldResolutionFeedbackStore->getErrors() !== []
+            || $objectTypeFieldResolutionFeedbackStore->getPartialErrors() !== []
+        ) {
             // Set the response for the failing field as null
             $resolvedIDFieldValues[$id][$field] = null;
             $this->setAppStateForFieldValuePromises(

--- a/layers/Engine/packages/component-model/src/Feedback/DocumentFeedbackStore.php
+++ b/layers/Engine/packages/component-model/src/Feedback/DocumentFeedbackStore.php
@@ -9,6 +9,8 @@ class DocumentFeedbackStore
     /** @var DocumentFeedbackInterface[] */
     private array $errors = [];
     /** @var DocumentFeedbackInterface[] */
+    private array $partialErrors = [];
+    /** @var DocumentFeedbackInterface[] */
     private array $warnings = [];
     /** @var DocumentFeedbackInterface[] */
     private array $deprecations = [];
@@ -43,6 +45,32 @@ class DocumentFeedbackStore
     public function setErrors(array $errors): void
     {
         $this->errors = $errors;
+    }
+
+    public function getPartialErrorCount(): int
+    {
+        return count($this->getPartialErrors());
+    }
+
+    /**
+     * @return DocumentFeedbackInterface[]
+     */
+    public function getPartialErrors(): array
+    {
+        return $this->partialErrors;
+    }
+
+    public function addPartialError(DocumentFeedbackInterface $partialError): void
+    {
+        $this->partialErrors[] = $partialError;
+    }
+
+    /**
+     * @param DocumentFeedbackInterface[] $partialErrors
+     */
+    public function setPartialErrors(array $partialErrors): void
+    {
+        $this->partialErrors = $partialErrors;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Feedback/FeedbackEntryManager.php
+++ b/layers/Engine/packages/component-model/src/Feedback/FeedbackEntryManager.php
@@ -411,7 +411,11 @@ class FeedbackEntryManager extends AbstractBasicService implements FeedbackEntry
     ): void {
         /** @var SplObjectStorage<RelationalTypeResolverInterface,SplObjectStorage<FieldInterface,mixed>> */
         $iterationSchemaErrors = new SplObjectStorage();
-        foreach ($schemaFeedbackStore->getErrors() as $schemaFeedbackError) {
+        $schemaFeedbackErrors = array_merge(
+            $schemaFeedbackStore->getErrors(),
+            $schemaFeedbackStore->getPartialErrors(),
+        );
+        foreach ($schemaFeedbackErrors as $schemaFeedbackError) {
             $this->transferSchemaFeedbackEntries(
                 $schemaFeedbackError,
                 $iterationSchemaErrors,

--- a/layers/Engine/packages/component-model/src/Feedback/FeedbackEntryManager.php
+++ b/layers/Engine/packages/component-model/src/Feedback/FeedbackEntryManager.php
@@ -69,11 +69,11 @@ class FeedbackEntryManager extends AbstractBasicService implements FeedbackEntry
 
         // Errors
         $generalFeedbackStore = App::getFeedbackStore()->generalFeedbackStore;
-        if ($generalErrors = $generalFeedbackStore->getErrors()) {
+        if ($generalErrors = [...$generalFeedbackStore->getErrors(), ...$generalFeedbackStore->getPartialErrors()]) {
             $data[Response::GENERAL_FEEDBACK][FeedbackCategories::ERROR] = $this->getGeneralFeedbackEntriesForOutput($generalErrors);
         }
         $documentFeedbackStore = App::getFeedbackStore()->documentFeedbackStore;
-        if ($documentErrors = $documentFeedbackStore->getErrors()) {
+        if ($documentErrors = [...$documentFeedbackStore->getErrors(), ...$documentFeedbackStore->getPartialErrors()]) {
             $data[Response::DOCUMENT_FEEDBACK][FeedbackCategories::ERROR] = $this->getDocumentFeedbackEntriesForOutput($documentErrors);
         }
 
@@ -227,7 +227,7 @@ class FeedbackEntryManager extends AbstractBasicService implements FeedbackEntry
     ): void {
         /** @var SplObjectStorage<RelationalTypeResolverInterface,SplObjectStorage<FieldInterface,mixed>> */
         $iterationObjectErrors = new SplObjectStorage();
-        foreach ($objectResolutionFeedbackStore->getErrors() as $objectFeedbackError) {
+        foreach ([...$objectResolutionFeedbackStore->getErrors(), ...$objectResolutionFeedbackStore->getPartialErrors()] as $objectFeedbackError) {
             $this->transferObjectFeedbackEntries(
                 $objectFeedbackError,
                 $iterationObjectErrors,
@@ -411,11 +411,7 @@ class FeedbackEntryManager extends AbstractBasicService implements FeedbackEntry
     ): void {
         /** @var SplObjectStorage<RelationalTypeResolverInterface,SplObjectStorage<FieldInterface,mixed>> */
         $iterationSchemaErrors = new SplObjectStorage();
-        $schemaFeedbackErrors = array_merge(
-            $schemaFeedbackStore->getErrors(),
-            $schemaFeedbackStore->getPartialErrors(),
-        );
-        foreach ($schemaFeedbackErrors as $schemaFeedbackError) {
+        foreach ([...$schemaFeedbackStore->getErrors(), ...$schemaFeedbackStore->getPartialErrors()] as $schemaFeedbackError) {
             $this->transferSchemaFeedbackEntries(
                 $schemaFeedbackError,
                 $iterationSchemaErrors,

--- a/layers/Engine/packages/component-model/src/Feedback/GeneralFeedbackStore.php
+++ b/layers/Engine/packages/component-model/src/Feedback/GeneralFeedbackStore.php
@@ -9,6 +9,8 @@ class GeneralFeedbackStore
     /** @var GeneralFeedbackInterface[] */
     private array $errors = [];
     /** @var GeneralFeedbackInterface[] */
+    private array $partialErrors = [];
+    /** @var GeneralFeedbackInterface[] */
     private array $warnings = [];
     /** @var GeneralFeedbackInterface[] */
     private array $deprecations = [];
@@ -43,6 +45,32 @@ class GeneralFeedbackStore
     public function setErrors(array $errors): void
     {
         $this->errors = $errors;
+    }
+
+    public function getPartialErrorCount(): int
+    {
+        return count($this->getPartialErrors());
+    }
+
+    /**
+     * @return GeneralFeedbackInterface[]
+     */
+    public function getPartialErrors(): array
+    {
+        return $this->partialErrors;
+    }
+
+    public function addPartialError(GeneralFeedbackInterface $partialError): void
+    {
+        $this->partialErrors[] = $partialError;
+    }
+
+    /**
+     * @param GeneralFeedbackInterface[] $partialErrors
+     */
+    public function setPartialErrors(array $partialErrors): void
+    {
+        $this->partialErrors = $partialErrors;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Feedback/ObjectResolutionFeedbackStore.php
+++ b/layers/Engine/packages/component-model/src/Feedback/ObjectResolutionFeedbackStore.php
@@ -13,6 +13,8 @@ class ObjectResolutionFeedbackStore
     /** @var ObjectResolutionFeedbackInterface[] */
     private array $errors = [];
     /** @var ObjectResolutionFeedbackInterface[] */
+    private array $partialErrors = [];
+    /** @var ObjectResolutionFeedbackInterface[] */
     private array $warnings = [];
     /** @var ObjectResolutionFeedbackInterface[] */
     private array $deprecations = [];
@@ -29,6 +31,10 @@ class ObjectResolutionFeedbackStore
         $this->errors = array_merge(
             $this->errors,
             $objectResolutionFeedbackStore->getErrors()
+        );
+        $this->partialErrors = array_merge(
+            $this->partialErrors,
+            $objectResolutionFeedbackStore->getPartialErrors()
         );
         $this->warnings = array_merge(
             $this->warnings,
@@ -64,6 +70,14 @@ class ObjectResolutionFeedbackStore
         foreach ($objectTypeFieldResolutionFeedbackStore->getErrors() as $objectTypeFieldResolutionFeedbackError) {
             $this->errors[] = ObjectResolutionFeedback::fromObjectTypeFieldResolutionFeedback(
                 $objectTypeFieldResolutionFeedbackError,
+                $relationalTypeResolver,
+                $directive,
+                $idFieldSet,
+            );
+        }
+        foreach ($objectTypeFieldResolutionFeedbackStore->getPartialErrors() as $objectTypeFieldResolutionFeedbackPartialError) {
+            $this->errors[] = ObjectResolutionFeedback::fromObjectTypeFieldResolutionFeedback(
+                $objectTypeFieldResolutionFeedbackPartialError,
                 $relationalTypeResolver,
                 $directive,
                 $idFieldSet,
@@ -135,6 +149,32 @@ class ObjectResolutionFeedbackStore
     public function setErrors(array $errors): void
     {
         $this->errors = $errors;
+    }
+
+    public function getPartialErrorCount(): int
+    {
+        return count($this->getPartialErrors());
+    }
+
+    /**
+     * @return ObjectResolutionFeedbackInterface[]
+     */
+    public function getPartialErrors(): array
+    {
+        return $this->partialErrors;
+    }
+
+    public function addPartialError(ObjectResolutionFeedbackInterface $partialError): void
+    {
+        $this->partialErrors[] = $partialError;
+    }
+
+    /**
+     * @param ObjectResolutionFeedbackInterface[] $partialErrors
+     */
+    public function setPartialErrors(array $partialErrors): void
+    {
+        $this->partialErrors = $partialErrors;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Feedback/ObjectTypeFieldResolutionFeedbackStore.php
+++ b/layers/Engine/packages/component-model/src/Feedback/ObjectTypeFieldResolutionFeedbackStore.php
@@ -9,6 +9,8 @@ class ObjectTypeFieldResolutionFeedbackStore
     /** @var ObjectTypeFieldResolutionFeedbackInterface[] */
     private array $errors = [];
     /** @var ObjectTypeFieldResolutionFeedbackInterface[] */
+    private array $partialErrors = [];
+    /** @var ObjectTypeFieldResolutionFeedbackInterface[] */
     private array $warnings = [];
     /** @var ObjectTypeFieldResolutionFeedbackInterface[] */
     private array $deprecations = [];
@@ -25,6 +27,10 @@ class ObjectTypeFieldResolutionFeedbackStore
         $this->errors = array_merge(
             $this->errors,
             $objectTypeFieldResolutionFeedbackStore->getErrors()
+        );
+        $this->partialErrors = array_merge(
+            $this->partialErrors,
+            $objectTypeFieldResolutionFeedbackStore->getPartialErrors()
         );
         $this->warnings = array_merge(
             $this->warnings,
@@ -72,6 +78,32 @@ class ObjectTypeFieldResolutionFeedbackStore
     public function setErrors(array $errors): void
     {
         $this->errors = $errors;
+    }
+
+    public function getPartialErrorCount(): int
+    {
+        return count($this->getPartialErrors());
+    }
+
+    /**
+     * @return ObjectTypeFieldResolutionFeedbackInterface[]
+     */
+    public function getPartialErrors(): array
+    {
+        return $this->partialErrors;
+    }
+
+    public function addPartialError(ObjectTypeFieldResolutionFeedbackInterface $partialError): void
+    {
+        $this->partialErrors[] = $partialError;
+    }
+
+    /**
+     * @param ObjectTypeFieldResolutionFeedbackInterface[] $partialErrors
+     */
+    public function setPartialErrors(array $partialErrors): void
+    {
+        $this->partialErrors = $partialErrors;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/Feedback/SchemaFeedbackStore.php
+++ b/layers/Engine/packages/component-model/src/Feedback/SchemaFeedbackStore.php
@@ -12,6 +12,8 @@ class SchemaFeedbackStore
     /** @var SchemaFeedbackInterface[] */
     private array $errors = [];
     /** @var SchemaFeedbackInterface[] */
+    private array $partialErrors = [];
+    /** @var SchemaFeedbackInterface[] */
     private array $warnings = [];
     /** @var SchemaFeedbackInterface[] */
     private array $deprecations = [];
@@ -28,6 +30,10 @@ class SchemaFeedbackStore
         $this->errors = array_merge(
             $this->errors,
             $schemaFeedbackStore->getErrors()
+        );
+        $this->partialErrors = array_merge(
+            $this->partialErrors,
+            $schemaFeedbackStore->getPartialErrors()
         );
         $this->warnings = array_merge(
             $this->warnings,
@@ -62,6 +68,13 @@ class SchemaFeedbackStore
         foreach ($objectTypeFieldResolutionFeedbackStore->getErrors() as $objectTypeFieldResolutionFeedbackError) {
             $this->errors[] = SchemaFeedback::fromObjectTypeFieldResolutionFeedback(
                 $objectTypeFieldResolutionFeedbackError,
+                $relationalTypeResolver,
+                $fields,
+            );
+        }
+        foreach ($objectTypeFieldResolutionFeedbackStore->getPartialErrors() as $objectTypeFieldResolutionFeedbackPartialError) {
+            $this->partialErrors[] = SchemaFeedback::fromObjectTypeFieldResolutionFeedback(
+                $objectTypeFieldResolutionFeedbackPartialError,
                 $relationalTypeResolver,
                 $fields,
             );
@@ -127,6 +140,32 @@ class SchemaFeedbackStore
     public function setErrors(array $errors): void
     {
         $this->errors = $errors;
+    }
+
+    public function getPartialErrorCount(): int
+    {
+        return count($this->getPartialErrors());
+    }
+
+    /**
+     * @return SchemaFeedbackInterface[]
+     */
+    public function getPartialErrors(): array
+    {
+        return $this->partialErrors;
+    }
+
+    public function addPartialError(SchemaFeedbackInterface $partialError): void
+    {
+        $this->partialErrors[] = $partialError;
+    }
+
+    /**
+     * @param SchemaFeedbackInterface[] $partialErrors
+     */
+    public function setPartialErrors(array $partialErrors): void
+    {
+        $this->partialErrors = $partialErrors;
     }
 
     /**

--- a/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
+++ b/layers/Engine/packages/component-model/src/TypeResolvers/AbstractRelationalTypeResolver.php
@@ -1141,8 +1141,12 @@ abstract class AbstractRelationalTypeResolver extends AbstractTypeResolver imple
             );
             $engineIterationFeedbackStore->incorporate($separateEngineIterationFeedbackStore);
 
-            // If any directive failed validation and the field must be set to `null`,
-            // then skip processing that field altogether
+            /**
+             * If any directive failed validation and the field must be set to `null`,
+             * then skip processing that field altogether.
+             *
+             * Notice this does not apply to "partial" errors.
+             */
             /** @var array<string|int,FieldInterface[]> */
             $errorIDFields = [];
             if ($separateEngineIterationFeedbackStore->objectResolutionFeedbackStore->getErrors() !== []) {

--- a/layers/Engine/packages/root/src/Feedback/FeedbackCategories.php
+++ b/layers/Engine/packages/root/src/Feedback/FeedbackCategories.php
@@ -6,6 +6,40 @@ namespace PoP\Root\Feedback;
 
 class FeedbackCategories
 {
+    /**
+     * This entry accounts for two types of errors:
+     *
+     * - Errors
+     * - Partial errors
+     *
+     * The difference is that partial errors do not set the whole field to `null`,
+     * but only the part that failed.
+     *
+     * For instance, in this query:
+     *
+     *   ```
+     *   query {
+     *     _echo(value: {
+     *       es: ["hello", "world"],
+     *       fr: ["how are you", "my friend?"],
+     *       de: ["everything good?", "really?"]
+     *     })
+     *       @underEachJSONObjectProperty(
+     *       passKeyOnwardsAs: "toLang",
+     *       )
+     *       @underEachArrayItem
+     *         @strTranslate(
+     *           from: "en",
+     *           to: $toLang
+     *         )
+     *   }
+     *   ```
+     * 
+     * When the API request for a single language fails, if using ->addError
+     * in `@strTranslate`, then the whole field will be set to `null`, whereas
+     * using ->addPartialError will set the field to `null` only for the
+     * language that failed.
+     */
     public final const ERROR = 'error';
     public final const DEPRECATION = 'deprecation';
     public final const LOG = 'log';

--- a/layers/Engine/packages/root/src/Feedback/FeedbackCategories.php
+++ b/layers/Engine/packages/root/src/Feedback/FeedbackCategories.php
@@ -12,8 +12,9 @@ class FeedbackCategories
      * - Errors
      * - Partial errors
      *
-     * The difference is that partial errors do not set the whole field to `null`,
-     * but only the part that failed.
+     * The difference is that partial errors are not bubbled up,
+     * then they won't necessarily set the whole field to `null`,
+     * eg: using nested directives.
      *
      * For instance, in this query:
      *

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -18,6 +18,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Added new input `IncludeExcludeFilterInput` (#3127)
 - Added documentation for new fields `_strArrayReplace` and `_strArrayReplaceMultiple` from the **PHP Functions via Schema** extension (#3129)
 - Added field `optionObjectValues` (#3133)
+- Support for "partial" errors (shown in the response, but not bubbled up on nested directives) (#3135)
 
 ### Improvements
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/13.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/13.1/en.md
@@ -12,6 +12,7 @@
 - Added new input `IncludeExcludeFilterInput` ([#3127](https://github.com/GatoGraphQL/GatoGraphQL/pull/3127))
 - Added documentation for new fields `_strArrayReplace` and `_strArrayReplaceMultiple` from the **PHP Functions via Schema** extension ([#3129](https://github.com/GatoGraphQL/GatoGraphQL/pull/3129))
 - Added field `optionObjectValues` ([#3133](https://github.com/GatoGraphQL/GatoGraphQL/pull/3133))
+- Support for "partial" errors (shown in the response, but not bubbled up on nested directives) ([#3135](https://github.com/GatoGraphQL/GatoGraphQL/pull/3135))
 
 ## Improvements
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -231,6 +231,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 * Added new input `IncludeExcludeFilterInput` (#3127)
 * Added documentation for new fields `_strArrayReplace` and `_strArrayReplaceMultiple` from the **PHP Functions via Schema** extension (#3129)
 * Added field `optionObjectValues` (#3133)
+* Support for "partial" errors (shown in the response, but not bubbled up on nested directives) (#3135)
 * Print errors before warnings in the response (#3134)
 * Allow reinstalling plugin initial data when plugin/theme dependency is activated/deactivated (#3119)
 * Made `customPostType` param on the `updateCustomPost` mutation optional (#3120)


### PR DESCRIPTION
This entry accounts for two types of errors:

- Errors
- Partial errors

The difference is that partial errors are not bubbled up, then they won't necessarily set the whole field to `null`, eg: using nested directives.

For instance, in this query:

```gql
query {
  _echo(value: {
    es: ["hello", "world"]
    fr: ["how are you", "my friend?"]
    de: ["everything good?", "really?"]
  })
    @underEachJSONObjectProperty(passKeyOnwardsAs: "toLang")
      @underEachArrayItem
        @strTranslate(from: "en", to: $toLang)
}
```

When the API request for a single language fails, if using `->addError` in `@strTranslate`, then the whole field will be set to `null`, whereas using `->addPartialError` will set the field to `null` only for the language that failed.