### PR TITLE
Fix exception in extensions page

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Fixed
 
 - Handle empty response when LemonSqueezy service is down (#3139)
+- Exception in Extensions page (#3140)
 
 ## 13.1.0 - 25/06/2025
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/13.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/13.1/en.md
@@ -29,3 +29,4 @@
 - Returning no results from `get_posts` when passing many CPTs ([#3128](https://github.com/GatoGraphQL/GatoGraphQL/pull/3128))
 - Handle empty response when LemonSqueezy service is down (#3139)
 - Exception thrown when multiple fields have errors (`v13.1.1`) ([#3139](https://github.com/GatoGraphQL/GatoGraphQL/pull/3139))
+- Exception in Extensions page (`v13.1.1`) ([#3140](https://github.com/GatoGraphQL/GatoGraphQL/pull/3140))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -222,6 +222,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 = 13.1.1 =
 * Handle empty response when LemonSqueezy service is down (#3139)
+* Fixed exception in Extensions page (#3140)
 
 = 13.1.0 =
 * Enable extensions if required theme is active (#3114)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Admin/Tables/AbstractExtensionListTable.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Admin/Tables/AbstractExtensionListTable.php
@@ -41,17 +41,17 @@ abstract class AbstractExtensionListTable extends WP_Plugin_Install_List_Table i
      */
     public function prepare_items()
     {
-        \add_filter('install_plugins_tabs', $this->overrideInstallPluginTabs(...));
-        \add_filter('install_plugins_nonmenu_tabs', $this->overrideInstallPluginNonMenuTabs(...));
-        \add_filter('plugins_api', $this->overridePluginsAPI(...));
-        \add_filter('plugins_api_result', $this->overridePluginsAPIResult(...));
+        \add_filter('install_plugins_tabs', $this->overrideInstallPluginTabs(...), PHP_INT_MAX);
+        \add_filter('install_plugins_nonmenu_tabs', $this->overrideInstallPluginNonMenuTabs(...), PHP_INT_MAX);
+        \add_filter('plugins_api', $this->overridePluginsAPI(...), PHP_INT_MAX);
+        \add_filter('plugins_api_result', $this->overridePluginsAPIResult(...), PHP_INT_MAX);
         \add_filter('plugin_install_action_links', $this->overridePluginInstallActionLinks(...), PHP_INT_MAX, 2);
         parent::prepare_items();
         \remove_filter('plugin_install_action_links', $this->overridePluginInstallActionLinks(...), PHP_INT_MAX);
-        \remove_filter('plugins_api_result', $this->overridePluginsAPIResult(...));
-        \remove_filter('plugins_api', $this->overridePluginsAPI(...));
-        \remove_filter('install_plugins_nonmenu_tabs', $this->overrideInstallPluginNonMenuTabs(...));
-        \remove_filter('install_plugins_tabs', $this->overrideInstallPluginTabs(...));
+        \remove_filter('plugins_api_result', $this->overridePluginsAPIResult(...), PHP_INT_MAX);
+        \remove_filter('plugins_api', $this->overridePluginsAPI(...), PHP_INT_MAX);
+        \remove_filter('install_plugins_nonmenu_tabs', $this->overrideInstallPluginNonMenuTabs(...), PHP_INT_MAX);
+        \remove_filter('install_plugins_tabs', $this->overrideInstallPluginTabs(...), PHP_INT_MAX);
     }
 
     /**


### PR DESCRIPTION
Reported error:

```
EXCEPTION Fatal Error
GatoGraphQL\GatoGraphQL\Admin\Tables\ExtensionListTable::getOpeningModuleDocInModalLinkURL(): Argument #2 ($module) must be of type string, null given, called in /home/dodoxebija3151/web/[testr.instawp.xyz/public_html/wp-content/plugins/gatographql/src/Admin/Tables/ExtensionListTable.php](http://testr.instawp.xyz/public_html/wp-content/plugins/gatographql/src/Admin/Tables/ExtensionListTable.php) on line 187
Occurred in file: /home/dodoxebija3151/web/[testr.instawp.xyz/public_html/wp-content/plugins/gatographql/src/Admin/Tables/WithOpeningModuleDocInModalListTableTrait.php](http://testr.instawp.xyz/public_html/wp-content/plugins/gatographql/src/Admin/Tables/WithOpeningModuleDocInModalListTableTrait.php) on line 11
```

**Solution:**

I have this code overriding the call to the WP plugin API:

```php
        \add_filter('plugins_api', $this->overridePluginsAPI(...));
        \add_filter('plugins_api_result', $this->overridePluginsAPIResult(...));
```

Possibly you have some plugin that also overrides those hooks, thus overriding my code.

Assuming it’s that, adding priority `PHP_INT_MAX` to my hooks will most likely solve the issue.