### PR TITLE
Fix QueryableInterface adapter

### DIFF
--- a/layers/Engine/packages/component-model/src/Resolvers/QueryableInterfaceSchemaDefinitionResolverAdapter.php
+++ b/layers/Engine/packages/component-model/src/Resolvers/QueryableInterfaceSchemaDefinitionResolverAdapter.php
@@ -13,8 +13,10 @@ class QueryableInterfaceSchemaDefinitionResolverAdapter extends InterfaceSchemaD
 {
     public function getFieldFilterInputContainerComponent(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?Component
     {
-        /** @var QueryableInterfaceTypeFieldSchemaDefinitionResolverInterface */
-        $interfaceTypeFieldSchemaDefinitionResolver = $this->interfaceTypeFieldSchemaDefinitionResolver;
-        return $interfaceTypeFieldSchemaDefinitionResolver->getFieldFilterInputContainerComponent($fieldName);
+        if (!($this->interfaceTypeFieldSchemaDefinitionResolver instanceof QueryableInterfaceTypeFieldSchemaDefinitionResolverInterface)) {
+            return null;
+        }
+
+        return $this->interfaceTypeFieldSchemaDefinitionResolver->getFieldFilterInputContainerComponent($fieldName);
     }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -21,6 +21,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - Cast post ID to int (for if 3rd-party CPT returns it as string) (#3213)
 - Meta not returned as array (#3214)
+- QueryableInterface adapter (#3215)
 
 ## 15.0.0 - 23/09/2025
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/15.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/15.1/en.md
@@ -15,3 +15,4 @@
 
 - Cast post ID to int (for if 3rd-party CPT returns it as string) ([#3213](https://github.com/GatoGraphQL/GatoGraphQL/pull/3213))
 - Meta not returned as array ([#3214](https://github.com/GatoGraphQL/GatoGraphQL/pull/3214))
+- QueryableInterface adapter ([#3215](https://github.com/GatoGraphQL/GatoGraphQL/pull/3215))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -230,6 +230,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 * Allow returning null values in field connections of type List (#3212)
 * Fixed - Cast post ID to int (for if 3rd-party CPT returns it as string) (#3213)
 * Fixed - Meta not returned as array (#3214)
+* Fixed - QueryableInterface adapter (#3215)
 
 = 15.0.0 =
 * Breaking change: Removed the BasicService trait (#3208)


### PR DESCRIPTION
Fixed exception when adding the QueryableInterface to WooCommerceProduct (via `getImplementedInterfaceTypeFieldResolvers`, without the CustomPostInterface.

The issue is that doing `parent::getFieldFilterInputContainerComponent` throws error, as that upstream class `QueryableInterfaceTypeFieldResolver` does not implement that method.