### PR TITLE
Allow the custom post author to be null

### DIFF
--- a/layers/CMSSchema/packages/media-mutations/src/MutationResolvers/AbstractCreateOrUpdateMediaItemMutationResolver.php
+++ b/layers/CMSSchema/packages/media-mutations/src/MutationResolvers/AbstractCreateOrUpdateMediaItemMutationResolver.php
@@ -128,6 +128,9 @@ abstract class AbstractCreateOrUpdateMediaItemMutationResolver extends AbstractM
 
         /** @var int|string|null */
         $authorID = $fieldDataAccessor->getValue(MutationInputProperties::AUTHOR_ID);
+        if ((string) $authorID === "0") {
+            $authorID = null;
+        }
 
         if ($authorID !== null) {
             // If providing the author, check that the user exists

--- a/layers/CMSSchema/packages/users-wp/src/ConditionalOnModule/CustomPosts/TypeAPIs/CustomPostUserTypeAPI.php
+++ b/layers/CMSSchema/packages/users-wp/src/ConditionalOnModule/CustomPosts/TypeAPIs/CustomPostUserTypeAPI.php
@@ -17,13 +17,21 @@ class CustomPostUserTypeAPI implements CustomPostUserTypeAPIInterface
         if (is_object($customPostObjectOrID)) {
             /** @var WP_Post */
             $customPost = $customPostObjectOrID;
-            return $customPost->post_author;
+            return $this->getAuthorFromCustomPost($customPost);
         }
 
         $customPostID = $customPostObjectOrID;
         /** @var WP_Post|null */
         $customPost = \get_post((int)$customPostID);
         if ($customPost === null) {
+            return null;
+        }
+        return $this->getAuthorFromCustomPost($customPost);
+    }
+
+    protected function getAuthorFromCustomPost(WP_Post $customPost): string|int|null
+    {
+        if ((string) $customPost->post_author === "0") {
             return null;
         }
         return $customPost->post_author;

--- a/layers/CMSSchema/packages/users/src/FieldResolvers/InterfaceType/WithAuthorInterfaceTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/users/src/FieldResolvers/InterfaceType/WithAuthorInterfaceTypeFieldResolver.php
@@ -6,7 +6,6 @@ namespace PoPCMSSchema\Users\FieldResolvers\InterfaceType;
 
 use PoP\ComponentModel\TypeResolvers\InterfaceType\InterfaceTypeResolverInterface;
 use PoP\ComponentModel\FieldResolvers\InterfaceType\AbstractInterfaceTypeFieldResolver;
-use PoP\ComponentModel\Schema\SchemaTypeModifiers;
 use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
 use PoPCMSSchema\Users\TypeResolvers\InterfaceType\WithAuthorInterfaceTypeResolver;
 use PoPCMSSchema\Users\TypeResolvers\ObjectType\UserObjectTypeResolver;
@@ -45,14 +44,19 @@ class WithAuthorInterfaceTypeFieldResolver extends AbstractInterfaceTypeFieldRes
         ];
     }
 
-    public function getFieldTypeModifiers(string $fieldName): int
-    {
-        switch ($fieldName) {
-            case 'author':
-                return SchemaTypeModifiers::NON_NULLABLE;
-        }
-        return parent::getFieldTypeModifiers($fieldName);
-    }
+    /**
+     * Allow the custom post author to be null!
+     * Eg: when using AI to create posts, it may not assign an author,
+     * and it'll keep ID 0 in the DB
+     */
+    // public function getFieldTypeModifiers(string $fieldName): int
+    // {
+    //     switch ($fieldName) {
+    //         case 'author':
+    //             return SchemaTypeModifiers::NON_NULLABLE;
+    //     }
+    //     return parent::getFieldTypeModifiers($fieldName);
+    // }
 
     public function getFieldDescription(string $fieldName): ?string
     {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -15,6 +15,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Tested up to WordPress 7.0 (#3289)
 - Support AI Connectors from WordPress 7.0 (#3290)
 - Updated documentation for Translation extension, now supporting Gemini as a translation service provider (#3292)
+- Allow the custom post `author` to be null (e.g. when the post has no assigned user / author ID 0) (#3293)
 
 ### Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/17.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/17.2/en.md
@@ -8,6 +8,7 @@
 - Tested up to WordPress 7.0 ([#3289](https://github.com/GatoGraphQL/GatoGraphQL/pull/3289))
 - Support AI Connectors from WordPress 7.0 ([#3290](https://github.com/GatoGraphQL/GatoGraphQL/pull/3290))
 - Updated documentation for Translation extension, now supporting Gemini as a translation service provider ([#3292](https://github.com/GatoGraphQL/GatoGraphQL/pull/3292))
+- Allow the custom post `author` to be null (e.g. when the post has no assigned user / author ID 0) ([#3293](https://github.com/GatoGraphQL/GatoGraphQL/pull/3293))
 
 ### Fixed
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -229,6 +229,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 * Improved - Tested up to WordPress 7.0 (#3289)
 * Improved - Support AI Connectors from WordPress 7.0 (#3290)
 * Improved - Updated documentation for Translation extension, now supporting Gemini as a translation service provider (#3292)
+* Improved - Allow the custom post `author` to be null (e.g. when the post has no assigned user / author ID 0) (#3293)
 * Fixed - Handle null response from license API (eg: when access is forbidden via network) (#3288)
 
 = 17.1.1 =


### PR DESCRIPTION
Allow the custom post author to be null!

Eg: when using AI to create posts, it may not assign an author, and it'll keep ID 0 in the DB.