### PR TITLE
MQE: amortize per-op route-level work; defer database formatting

### DIFF
--- a/layers/Engine/packages/component-model/src/Engine/Engine.php
+++ b/layers/Engine/packages/component-model/src/Engine/Engine.php
@@ -573,6 +573,22 @@ class Engine extends AbstractBasicService implements EngineInterface
             $appStateManager->override('route', $currentRoute);
         }
 
+        // Format the accumulated databases/unionTypeOutputKeyIDs ONCE here.
+        // Per-op processAndGenerateData() calls under SEQUENTIAL_PASS MQE
+        // skip this step (otherwise they'd redo it N times, walking
+        // SplObjectStorage entries that grow with each call). The
+        // `array_replace_recursive` into engineState->data merges the
+        // formatted output alongside whatever processAndGenerateData()
+        // already wrote (componentdata, feedback, requestmeta, etc.).
+        $dataoutputitems = App::getState('dataoutputitems');
+        if (in_array(DataOutputItems::DATABASES, $dataoutputitems)) {
+            $engineState = App::getEngineState();
+            $engineState->data = array_replace_recursive(
+                $engineState->data,
+                $this->formatAccumulatedDatabasesForOutput($engineState->databases, $engineState->unionTypeOutputKeyIDs)
+            );
+        }
+
         // Add session/site meta
         $this->addSharedMeta();
 
@@ -672,15 +688,51 @@ class Engine extends AbstractBasicService implements EngineInterface
 
         $engineState = App::getEngineState();
 
-        // Save it to be used by the children class
-        // Static props are needed for both static/mutableonrequest operations, so build it always
-        $engineState->model_props = $this->getModelPropsComponentTree($component);
-
-        // If only getting static content, then no need to add the mutableonrequest props
-        if ($datasourceselector === DataSourceSelectors::ONLYMODEL) {
-            $engineState->props = $engineState->model_props;
-        } else {
-            $engineState->props = $this->addRequestPropsComponentTree($component, $engineState->model_props);
+        // model_props/props are functions of (entry component, route) only — they
+        // do NOT depend on the current Multiple Query Execution operation. Under
+        // SEQUENTIAL_PASS MQE this method runs once per operation (often 100+);
+        // walking the component tree to build model_props/props for each op is
+        // pure waste. Compute once per route, reuse for every op in that route's
+        // per-op loop. The cache is also valid across the extra-routes loop
+        // because the route is the invalidation key.
+        //
+        // To make the cached values cover the *union* of all ops' fields (so
+        // every per-op call finds its components in the cached map), we
+        // temporarily clear the `multiple-query-execution-current-operation`
+        // app-state key so the API/GraphQL component processor's
+        // per-op filter falls back to "all ops". The cached values are then
+        // a superset of any single op's needs.
+        $currentRoute = App::getState('route');
+        $needToComputeProps = !$engineState->propsHaveBeenComputed || $engineState->propsComputedForRoute !== $currentRoute;
+        if ($needToComputeProps) {
+            $appStateManager = App::getAppStateManager();
+            $savedMQEOperation = $appStateManager->has('multiple-query-execution-current-operation')
+                ? $appStateManager->get('multiple-query-execution-current-operation')
+                : null;
+            try {
+                $appStateManager->override('multiple-query-execution-current-operation', null);
+                // Static props are needed for both static/mutableonrequest operations, so build it always
+                $engineState->model_props = $this->getModelPropsComponentTree($component);
+                // If only getting static content, then no need to add the mutableonrequest props
+                if ($datasourceselector === DataSourceSelectors::ONLYMODEL) {
+                    $engineState->props = $engineState->model_props;
+                } else {
+                    $engineState->props = $this->addRequestPropsComponentTree($component, $engineState->model_props);
+                }
+                // Same lifetime as props: dataset settings are a pure function
+                // of (component tree, model_props), so they're stable across
+                // per-op MQE iterations within the same route. Compute once
+                // for the union tree (with the per-op filter cleared above).
+                if (in_array(DataOutputItems::DATASET_COMPONENT_SETTINGS, $dataoutputitems)) {
+                    $engineState->componentDatasetSettings = $this->getComponentDatasetSettings($component, $engineState->model_props, $engineState->props);
+                } else {
+                    $engineState->componentDatasetSettings = [];
+                }
+            } finally {
+                $appStateManager->override('multiple-query-execution-current-operation', $savedMQEOperation);
+            }
+            $engineState->propsHaveBeenComputed = true;
+            $engineState->propsComputedForRoute = $currentRoute;
         }
 
         // Allow for extra operations (eg: calculate resources)
@@ -693,10 +745,10 @@ class Engine extends AbstractBasicService implements EngineInterface
 
         $data = [];
         if (in_array(DataOutputItems::DATASET_COMPONENT_SETTINGS, $dataoutputitems)) {
-            $data = array_merge(
-                $data,
-                $this->getComponentDatasetSettings($component, $engineState->model_props, $engineState->props)
-            );
+            // Reuse the route-cached dataset settings from the props block
+            // above. Each per-op call writes the same union snapshot here;
+            // `array_replace_recursive` into `engineState->data` is idempotent.
+            $data = array_merge($data, $engineState->componentDatasetSettings);
         }
 
         // Use the EngineState-resident feedback accumulators (initialized
@@ -756,15 +808,14 @@ class Engine extends AbstractBasicService implements EngineInterface
                     $engineState->messages,
                 );
 
-                // Re-format the (cumulative) accumulator on every call. The
-                // formatter is idempotent: each call produces the most-complete
-                // view so far. The subsequent `array_replace_recursive` into
-                // `engineState->data` writes the full snapshot, replacing the
-                // previous (less-complete) snapshot at the `databases` key.
-                $data = array_merge(
-                    $data,
-                    $this->formatAccumulatedDatabasesForOutput($engineState->databases, $engineState->unionTypeOutputKeyIDs)
-                );
+                // The databases/unionTypeOutputKeyIDs aren't formatted into
+                // `$data` here. Each per-op MQE drain would otherwise re-walk
+                // the cumulative accumulators and produce only the LAST
+                // call's output as part of the response. Instead,
+                // `generateData()` formats once after every per-op /
+                // extra-routes call has finished (see the
+                // `formatAccumulatedDatabasesForOutput()` call there),
+                // saving ~N redundant format passes for an N-op query.
             }
         }
 
@@ -1344,10 +1395,6 @@ class Engine extends AbstractBasicService implements EngineInterface
      */
     public function getComponentData(Component $root_component, array $root_model_props, array $root_props): array
     {
-        /** @var ModuleConfiguration */
-        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
-        $useCache = $moduleConfiguration->useComponentModelCache();
-        $root_processor = $this->getComponentProcessorManager()->getComponentProcessor($root_component);
         $engineState = App::getEngineState();
 
         // From the state we know if to process static/staful content or both
@@ -1388,6 +1435,11 @@ class Engine extends AbstractBasicService implements EngineInterface
             array(&$engineState->helperCalculations),
             $this
         );
+
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $useCache = $moduleConfiguration->useComponentModelCache();
+        $root_processor = $this->getComponentProcessorManager()->getComponentProcessor($root_component);
 
         // First check if there's a cache stored
         $immutable_data_properties = $mutableonmodel_data_properties = null;

--- a/layers/Engine/packages/component-model/src/Engine/EngineState.php
+++ b/layers/Engine/packages/component-model/src/Engine/EngineState.php
@@ -31,6 +31,9 @@ class EngineState
      * @param array<string,mixed> $messages Per-request inter-directive message bag, accumulated across drains.
      * @param array<string,array<string,array<string,SplObjectStorage<FieldInterface,array<string,mixed>>>>> $schemaFeedbackEntries Drain accumulator for schema-level feedback (errors/warnings/etc.) keyed by `FeedbackCategory => dbName => typeOutputKey => SplObjectStorage(FieldInterface => entry)`. Lives on EngineState because the leaf SplObjectStorage would otherwise be replaced (not merged) by `array_replace_recursive` between successive `processAndGenerateData()` calls under "Sequential Pass" MQE — meaning earlier ops' feedback would be clobbered by later ops writing empty stores at the same path.
      * @param array<string,array<string,array<string,SplObjectStorage<FieldInterface,array<string,mixed>>>>> $objectFeedbackEntries Same shape and reasoning as `$schemaFeedbackEntries`, but for object-level feedback.
+     * @param bool $propsHaveBeenComputed `false` until `model_props`/`props`/`componentDatasetSettings` have been computed at least once in this engine state's lifetime. Together with `$propsComputedForRoute` it determines whether the cached values are still valid for the current request iteration. A separate flag is used (rather than relying on `null` as a sentinel) because `null` is also a valid value for `'route'` app state.
+     * @param string|null $propsComputedForRoute Tracks the route value for which `$model_props`/`$props`/`$componentDatasetSettings` were last computed. Used by `processAndGenerateData()` to skip re-walking the (union) component tree on every per-operation MQE drain — under SEQUENTIAL_PASS the route doesn't change across the 100+ ops in one generateData(), so these are stable. Invalidates if the route changes (eg: across the extra-routes loop).
+     * @param array<string,mixed> $componentDatasetSettings Cached return value of `Engine::getComponentDatasetSettings()` for the current route (ditto). The computed tree-walk is identical for every per-op call, so it lives on EngineState and is reused.
      */
     public function __construct(
         public array $data = [],
@@ -54,6 +57,9 @@ class EngineState
         public array $messages = [],
         public array $schemaFeedbackEntries = [],
         public array $objectFeedbackEntries = [],
+        public bool $propsHaveBeenComputed = false,
+        public ?string $propsComputedForRoute = null,
+        public array $componentDatasetSettings = [],
     ) {
     }
 }


### PR DESCRIPTION
Cuts redundant per-op work from `processAndGenerateData()` under the "Sequential Pass" Multiple Query Execution strategy. Three changes, all gated on a route-equality check on EngineState — when the route doesn't change across the per-op iteration loop (the normal case), the heavy tree-walks run once per request instead of N times.

A. model_props / props: cached on EngineState, computed once per route
   with the per-op MQE filter cleared so the result is the union of
   every operation's components. Per-op calls reuse. (~1.57s on the
   polylang 107-op profile.)

B. getComponentDatasetSettings: bundled into the same cached block.
   Same shape and same lifetime. (~0.58s on the same profile.)

D. formatAccumulatedDatabasesForOutput: per-op calls no longer write
   the formatted databases into `$data` and merge into
   `engineState->data` — they accumulated cumulative SplObjectStorage
   leaves, so each format pass walked progressively-larger structures
   and only the LAST call's output won. Format once at the end of
   `generateData()` instead, with a single `array_replace_recursive`
   into `engineState->data`. (~0.5s on the same profile.)

Total expected: ~2.65s on a 107-op polylang query (~4–5% off a 60s baseline). Smaller than the 5.5s upper bound from the assessment because option C (caching the immutable data-properties tree) was attempted and reverted: even narrowed to the immutable piece alone, caching across ops broke the
ValidateDirectivesOnOperation::2-user-is-logged-in fixture in a way that suggests the data-properties tree has a non-obvious dependency on op-level state or hook mutation. Deferred for follow-up.
