### PR TITLE
Avoid conflict with BBQ Firewall plugin

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -415,7 +415,7 @@ Activate XDebug for a request by appending parameter `?XDEBUG_TRIGGER=1` to the 
 
 For instance:
 
-- `https://gatographql.lndo.site/wp-admin/edit.php?page=gatographql&action=execute_query&XDEBUG_TRIGGER=1`
+- `https://gatographql.lndo.site/wp-admin/edit.php?page=gatographql&action=run_query&XDEBUG_TRIGGER=1`
 - `https://gatographql.lndo.site/graphiql/?XDEBUG_TRIGGER=1`
 
 ### Debugging PHPUnit tests

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractAdminClientQueryExecutionFixtureWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractAdminClientQueryExecutionFixtureWebserverRequestTestCase.php
@@ -15,6 +15,6 @@ abstract class AbstractAdminClientQueryExecutionFixtureWebserverRequestTestCase 
      */
     protected static function getEndpoint(): string
     {
-        return 'wp-admin/edit.php?page=gatographql&action=execute_query';
+        return 'wp-admin/edit.php?page=gatographql&action=run_query';
     }
 }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractAdminPersistedQueryQueryExecutionFixtureWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractAdminPersistedQueryQueryExecutionFixtureWebserverRequestTestCase.php
@@ -15,6 +15,6 @@ abstract class AbstractAdminPersistedQueryQueryExecutionFixtureWebserverRequestT
      */
     protected static function getEndpoint(): string
     {
-        return 'wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=persistedQuery&persisted_query_id=65';
+        return 'wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=persistedQuery&persisted_query_id=65';
     }
 }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractDisableSchemaModulesOnPrivateEndpointTestOnCustomAdminEndpointsFixtureEndpointWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractDisableSchemaModulesOnPrivateEndpointTestOnCustomAdminEndpointsFixtureEndpointWebserverRequestTestCase.php
@@ -9,7 +9,7 @@ abstract class AbstractDisableSchemaModulesOnPrivateEndpointTestOnCustomAdminEnd
     protected static function getEndpoint(): string
     {
         return sprintf(
-            'wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=%s',
+            'wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=%s',
             static::getAdminEndpointGroup()
         );
     }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractSchemaEditingAccessModifyPluginSettingsFixtureEndpointWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractSchemaEditingAccessModifyPluginSettingsFixtureEndpointWebserverRequestTestCase.php
@@ -15,7 +15,7 @@ abstract class AbstractSchemaEditingAccessModifyPluginSettingsFixtureEndpointWeb
      */
     protected static function getEndpoint(): string
     {
-        return 'wp-admin/edit.php?page=gatographql&action=execute_query';
+        return 'wp-admin/edit.php?page=gatographql&action=run_query';
     }
 
     protected static function getFixtureFolder(): string

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractUnrestrictedBehaviorFixtureWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractUnrestrictedBehaviorFixtureWebserverRequestTestCase.php
@@ -33,8 +33,8 @@ abstract class AbstractUnrestrictedBehaviorFixtureWebserverRequestTestCase exten
      */
     final public static function provideEndpointEntries(): array
     {
-        $accessGrantedEndpoint = 'wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=pluginOwnUse';
-        $accessForbiddenEndpoint = 'wp-admin/edit.php?page=gatographql&action=execute_query';
+        $accessGrantedEndpoint = 'wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=pluginOwnUse';
+        $accessForbiddenEndpoint = 'wp-admin/edit.php?page=gatographql&action=run_query';
 
         $fixtureFolder = static::getFixtureFolder();
         $graphQLQueryFileNameFileInfos = static::findFilesInDirectory(

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AdminBlockEditorEndpointSchemaQueryExecutionFixtureWebserverRequestTest.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AdminBlockEditorEndpointSchemaQueryExecutionFixtureWebserverRequestTest.php
@@ -25,7 +25,7 @@ class AdminBlockEditorEndpointSchemaQueryExecutionFixtureWebserverRequestTest ex
     protected static function getEndpoint(): string
     {
         return sprintf(
-            'wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=%s',
+            'wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=%s',
             AdminGraphQLEndpointGroups::BLOCK_EDITOR
         );
     }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AdminEndpointSchemaQueryExecutionFixtureWebserverRequestTest.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AdminEndpointSchemaQueryExecutionFixtureWebserverRequestTest.php
@@ -25,7 +25,7 @@ class AdminEndpointSchemaQueryExecutionFixtureWebserverRequestTest extends Abstr
     protected static function getEndpoint(): string
     {
         return sprintf(
-            'wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=%s',
+            'wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=%s',
             AddDummyCustomAdminEndpointHook::ADMIN_ENDPOINT_GROUP
         );
     }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/DisableSchemaModulesOnPrivateEndpointTestOnAdminEndpointsFixtureEndpointWebserverRequestTest.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/DisableSchemaModulesOnPrivateEndpointTestOnAdminEndpointsFixtureEndpointWebserverRequestTest.php
@@ -10,6 +10,6 @@ class DisableSchemaModulesOnPrivateEndpointTestOnAdminEndpointsFixtureEndpointWe
 
     protected static function getEndpoint(): string
     {
-        return 'wp-admin/edit.php?page=gatographql&action=execute_query';
+        return 'wp-admin/edit.php?page=gatographql&action=run_query';
     }
 }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/SchemaConfigurationForPrivateEndpointQueryExecutionModifyPluginSettingsFixtureEndpointWebserverRequestTest.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/SchemaConfigurationForPrivateEndpointQueryExecutionModifyPluginSettingsFixtureEndpointWebserverRequestTest.php
@@ -15,7 +15,7 @@ class SchemaConfigurationForPrivateEndpointQueryExecutionModifyPluginSettingsFix
      */
     protected static function getEndpoint(): string
     {
-        return 'wp-admin/edit.php?page=gatographql&action=execute_query';
+        return 'wp-admin/edit.php?page=gatographql&action=run_query';
     }
 
     protected function getModuleID(string $dataName): string

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/WordPressAuthenticatedUserEndpoints.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/WordPressAuthenticatedUserEndpoints.php
@@ -7,7 +7,7 @@ namespace PHPUnitForGatoGraphQL\GatoGraphQL\Integration;
 class WordPressAuthenticatedUserEndpoints
 {
     public const ENDPOINTS = [
-        'admin-client' => 'wp-admin/edit.php?page=gatographql&action=execute_query',
-        'admin-unrestricted-client' => 'wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=pluginOwnUse',
+        'admin-client' => 'wp-admin/edit.php?page=gatographql&action=run_query',
+        'admin-unrestricted-client' => 'wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=pluginOwnUse',
     ];
 }

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractEnableDisableModuleWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractEnableDisableModuleWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -93,7 +93,7 @@ abstract class AbstractEnableDisableModuleWordPressAuthenticatedUserWebserverReq
      */
     protected static function getAdminEndpoint(): string
     {
-        return 'wp-admin/edit.php?page=gatographql&action=execute_query';
+        return 'wp-admin/edit.php?page=gatographql&action=run_query';
     }
 
     /**

--- a/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractUpdateCustomPostBeforeTestWordPressAuthenticatedUserWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/webserver-requests/tests/AbstractUpdateCustomPostBeforeTestWordPressAuthenticatedUserWebserverRequestTestCase.php
@@ -80,6 +80,6 @@ abstract class AbstractUpdateCustomPostBeforeTestWordPressAuthenticatedUserWebse
 
     protected static function getAdminEndpoint(): string
     {
-        return 'wp-admin/edit.php?page=gatographql&action=execute_query';
+        return 'wp-admin/edit.php?page=gatographql&action=run_query';
     }
 }

--- a/layers/GatoGraphQLForWP/phpunit-packages/wpfaker-schema/tests/Unit/WPFakerFixtureQueryExecutionGraphQLServerTestTrait.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/wpfaker-schema/tests/Unit/WPFakerFixtureQueryExecutionGraphQLServerTestTrait.php
@@ -6,7 +6,6 @@ namespace PHPUnitForGatoGraphQL\WPFakerSchema\Unit;
 
 use Brain\Faker\Providers;
 use Faker\Generator;
-use GraphQLByPoP\GraphQLServer\Unit\AbstractFixtureQueryExecutionGraphQLServerTestCase;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnitForGatoGraphQL\WPFakerSchema\DataParsing\WordPressDataParser;

--- a/layers/GatoGraphQLForWP/phpunit-plugins/gatographql-testing/src/Executers/GatoGraphQLAdminEndpointsTestExecuter.php
+++ b/layers/GatoGraphQLForWP/phpunit-plugins/gatographql-testing/src/Executers/GatoGraphQLAdminEndpointsTestExecuter.php
@@ -40,9 +40,9 @@ class GatoGraphQLAdminEndpointsTestExecuter
     public function testGatoGraphQLAdminEndpoints(): void
     {
         $methodToExpectedEndpoints = [
-            GatoGraphQL::getAdminEndpoint() => '/wp-admin/edit.php?page=gatographql&action=execute_query',
-            GatoGraphQL::getAdminBlockEditorEndpoint() => '/wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=blockEditor',
-            GatoGraphQL::getAdminCustomEndpoint('myCustomEndpointGroup') => '/wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=myCustomEndpointGroup',
+            GatoGraphQL::getAdminEndpoint() => '/wp-admin/edit.php?page=gatographql&action=run_query',
+            GatoGraphQL::getAdminBlockEditorEndpoint() => '/wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=blockEditor',
+            GatoGraphQL::getAdminCustomEndpoint('myCustomEndpointGroup') => '/wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=myCustomEndpointGroup',
         ];
 
         foreach ($methodToExpectedEndpoints as $methodEndpoint => $expectedEndpoint) {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -30,6 +30,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - Handle null response from license API (eg: when access is forbidden via network) (#3288)
 - In field `menus`, return no results when passing empty `filter.slugs` (#8773b1b)
+- Avoid conflict with BBQ Firewall plugin (#3308)
 - Non-nullable parameter in method definition (#0cbe33e2)
 
 ## 17.1.1 - 24/03/2026

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/1.0/en.md
@@ -1283,7 +1283,7 @@ An internal GraphQL endpoint, called `blockEditor`, has been made accessible wit
 It is accessible under URL:
 
 ```apacheconf
-https://mysite.com/wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=blockEditor
+https://mysite.com/wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=blockEditor
 ```
 
 This endpoint has a pre-defined configuration (i.e. it does not have the user preferences from the plugin applied to it), so its behavior is consistent.`
@@ -1296,7 +1296,7 @@ Inspecting the source code in the wp-admin, you will find the following HTML:
 
 ```html
 <script type="text/javascript">
-var GATOGRAPHQL_BLOCK_EDITOR_ADMIN_ENDPOINT = "https://mysite.com/wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=blockEditor"
+var GATOGRAPHQL_BLOCK_EDITOR_ADMIN_ENDPOINT = "https://mysite.com/wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=blockEditor"
 </script>
 ```
 
@@ -1371,7 +1371,7 @@ add_action('plugins_loaded', function () {
 Finally, the endpoint is accessed by replacing param `endpoint_group` with the chosen name:
 
 ```apacheconf
-https://mysite.com/wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=accessMyPortfolioData
+https://mysite.com/wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=accessMyPortfolioData
 ```
 
 ## Endpoints: Use 🟢 (green) to denote "public", 🟡 (yellow) to denote "private"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/18.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/18.0/en.md
@@ -24,4 +24,5 @@
 
 - Handle null response from license API (eg: when access is forbidden via network) ([#3288](https://github.com/GatoGraphQL/GatoGraphQL/pull/3288))
 - In field `menus`, return no results when passing empty `filter.slugs` ([#8773b1b](https://github.com/GatoGraphQL/GatoGraphQL/commit/8773b1b))
+- Avoid conflict with BBQ Firewall plugin ([#3308](https://github.com/GatoGraphQL/GatoGraphQL/pull/3308))
 - Non-nullable parameter in method definition ([#0cbe33e2](https://github.com/GatoGraphQL/GatoGraphQL/commit/0cbe33e2))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/tutorial/_feeding-data-to-blocks-in-the-editor/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/tutorial/_feeding-data-to-blocks-in-the-editor/en.md
@@ -11,7 +11,7 @@ Because blocks are used within the context of the WordPress editor, the user is 
 This internal `blockEditor` endpoint is accessible under:
 
 ```apacheconf
-https://mysite.com/wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=blockEditor
+https://mysite.com/wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=blockEditor
 ```
 
 This endpoint has a pre-defined configuration (i.e. it does not have the user preferences from the plugin applied to it), so its behavior is consistent.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/http-request-via-schema/docs/modules/http-request-via-schema/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/http-request-via-schema/docs/modules/http-request-via-schema/en.md
@@ -234,12 +234,12 @@ query {
     "_httpRequestScheme": "https",
     "_httpRequestHost": "gatographql-pro.lndo.site",
     "_httpRequestURL": "https://gatographql-pro.lndo.site/wp-admin/edit.php",
-    "_httpRequestFullURL": "https://gatographql-pro.lndo.site/wp-admin/edit.php?page=gatographql&action=execute_query",
+    "_httpRequestFullURL": "https://gatographql-pro.lndo.site/wp-admin/edit.php?page=gatographql&action=run_query",
     "_httpRequestURLPath": "/wp-admin/edit.php",
-    "_httpRequestQuery": "page=gatographql&action=execute_query",
+    "_httpRequestQuery": "page=gatographql&action=run_query",
     "_httpRequestParams": {
       "page": "gatographql",
-      "action": "execute_query"
+      "action": "run_query"
     },
     "existingParam": "gatographql",
     "caseInsensitiveExistingParam": null,

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -238,6 +238,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 * Improved - Allow disabling the "Block type '...' is not server-side registered" warning (#3307)
 * Fixed - Handle null response from license API (eg: when access is forbidden via network) (#3288)
 * Fixed - In field `menus`, return no results when passing empty `filter.slugs` (#8773b1b)
+* Fixed - Avoid conflict with BBQ Firewall plugin (#3308)
 * Fixed - Non-nullable parameter in method definition (#0cbe33e2)
 
 = 17.1.1 =

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/ConditionalOnContext/Admin/Services/EndpointExecuters/AdminEndpointExecuter.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/ConditionalOnContext/Admin/Services/EndpointExecuters/AdminEndpointExecuter.php
@@ -81,7 +81,7 @@ class AdminEndpointExecuter extends AbstractEndpointExecuter implements AdminEnd
 
     /**
      * Execute the GraphQL query when posting to:
-     * /wp-admin/edit.php?page=gatographql&action=execute_query
+     * /wp-admin/edit.php?page=gatographql&action=run_query
      */
     public function isEndpointBeingRequested(): bool
     {

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Constants/RequestParams.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Constants/RequestParams.php
@@ -11,7 +11,7 @@ class RequestParams
     public final const VIEW_GRAPHIQL = 'graphiql';
     public final const VIEW_SCHEMA = 'schema';
     public final const ACTION = 'action';
-    public final const ACTION_EXECUTE_QUERY = 'execute_query';
+    public final const ACTION_EXECUTE_QUERY = 'run_query';
     public final const CATEGORY = 'category';
     public final const TAB = 'tab';
     public final const TAB_DOCS = 'docs';
@@ -27,7 +27,7 @@ class RequestParams
      * "pluginOwnUse" to be used on the WordPress editor to
      * power this plugin's blocks. It shall be requested as:
      *
-     *   /wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=pluginOwnUse
+     *   /wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=pluginOwnUse
      *
      * If the endpointGroup is not provided, the default admin endpoint
      * configuration is applied.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/GatoGraphQL.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/GatoGraphQL.php
@@ -26,7 +26,7 @@ class GatoGraphQL
      * Obtain the URL of the private wp-admin endpoint
      * (which powers the GraphiQL/Interactive Schema clients):
      *
-     *   /wp-admin/edit.php?page=gatographql&action=execute_query
+     *   /wp-admin/edit.php?page=gatographql&action=run_query
      *
      * This endpoint is affected by the configuration selected in the
      * Settings page, for the selected Schema Configuration for the
@@ -42,7 +42,7 @@ class GatoGraphQL
      * WordPress block editor (allowing any application, theme
      * or plugin to use GraphQL to fetch data for their blocks):
      *
-     *   /wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=blockEditor
+     *   /wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=blockEditor
      *
      * This endpoint is NOT affected by the configuration selected in the
      * Settings page; it has a pre-defined non-restrictive configuration,
@@ -57,7 +57,7 @@ class GatoGraphQL
     /**
      * Obtain a custom private wp-admin endpoint:
      *
-     *   /wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group={customEndpointGroup}
+     *   /wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group={customEndpointGroup}
      *
      * This custom endpoint must be defined and configured via PHP code,
      * allowing the developer to expose a private endpoint that has a

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Hooks/ApplicationPasswordAuthorizationHookSet.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Hooks/ApplicationPasswordAuthorizationHookSet.php
@@ -84,7 +84,7 @@ class ApplicationPasswordAuthorizationHookSet extends AbstractHookSet
      * path (even if that specific endpoint is disabled).
      *
      * Notice this checks only for the publicly-exposed GraphQL
-     * endpoints (i.e. not for `wp-admin/edit.php?page=gatographql&action=execute_query`
+     * endpoints (i.e. not for `wp-admin/edit.php?page=gatographql&action=run_query`
      * or any of those).
      */
     public function isGraphQLAPIRequest(bool $isAPIRequest): bool

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/ExtensionHooks/AbstractAddCustomAdminEndpointHook.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/ExtensionHooks/AbstractAddCustomAdminEndpointHook.php
@@ -35,7 +35,7 @@ abstract class AbstractAddCustomAdminEndpointHook
      * Name of the endpointGroup to support, to provide
      * in the endpoint URL:
      *
-     * wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=${endpointGroupName}
+     * wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=${endpointGroupName}
      */
     abstract protected function getAdminEndpointGroup(): string;
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Request/PrematureRequestService.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Request/PrematureRequestService.php
@@ -56,7 +56,7 @@ class PrematureRequestService extends AbstractBasicService implements PrematureR
      * path (even if that specific endpoint is disabled).
      *
      * Notice this checks only for the publicly-exposed GraphQL
-     * endpoints (i.e. not for `wp-admin/edit.php?page=gatographql&action=execute_query`
+     * endpoints (i.e. not for `wp-admin/edit.php?page=gatographql&action=run_query`
      * or any of those).
      */
     public function isPubliclyExposedGraphQLAPIRequest(): bool

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Request/PrematureRequestServiceInterface.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Request/PrematureRequestServiceInterface.php
@@ -28,7 +28,7 @@ interface PrematureRequestServiceInterface
      * path (even if that specific endpoint is disabled).
      *
      * Notice this checks only for the publicly-exposed GraphQL
-     * endpoints (i.e. not for `wp-admin/edit.php?page=gatographql&action=execute_query`
+     * endpoints (i.e. not for `wp-admin/edit.php?page=gatographql&action=run_query`
      * or any of those).
      */
     public function isPubliclyExposedGraphQLAPIRequest(): bool;

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Helpers/EndpointHelpers.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Helpers/EndpointHelpers.php
@@ -37,7 +37,7 @@ class EndpointHelpers extends AbstractBasicService
      * by 3rd-party plugins and developers to fetch data for their
      * blocks on the WordPress editor, under:
      *
-     *   /wp-admin/edit.php?page=gatographql&action=execute_query
+     *   /wp-admin/edit.php?page=gatographql&action=run_query
      */
     public function isRequestingAdminGraphQLEndpoint(): bool
     {
@@ -52,7 +52,7 @@ class EndpointHelpers extends AbstractBasicService
      * used on the WordPress editor to power this plugin's blocks
      * (for the different CPTs: SchemaConfig, ACLs, CCLs, etc), under:
      *
-     *   /wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=pluginOwnUse
+     *   /wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=pluginOwnUse
      */
     public function isRequestingAdminPluginOwnUseGraphQLEndpoint(): bool
     {
@@ -65,7 +65,7 @@ class EndpointHelpers extends AbstractBasicService
      * used on the WordPress editor to power developer's blocks
      * for their own sites, under:
      *
-     *   /wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=blockEditor
+     *   /wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=blockEditor
      */
     public function isRequestingAdminBlockEditorGraphQLEndpoint(): bool
     {
@@ -77,7 +77,7 @@ class EndpointHelpers extends AbstractBasicService
      * Indicate if we are requesting the wp-admin endpoint that
      * fetches data for Persisted Queries, under:
      *
-     *   /wp-admin/edit.php?page=gatographql&action=execute_query&endpoint_group=persistedQuery&persisted_query_id=...
+     *   /wp-admin/edit.php?page=gatographql&action=run_query&endpoint_group=persistedQuery&persisted_query_id=...
      */
     public function isRequestingAdminPersistedQueryGraphQLEndpoint(): bool
     {

--- a/webservers/_shared/assets/gatographql-data.xml
+++ b/webservers/_shared/assets/gatographql-data.xml
@@ -1638,11 +1638,11 @@ https://wordpress.org/about/
 		</wp:postmeta>
 														</item>
 					<item>
-		<title><![CDATA[Wordpress-Logo]]></title>
+		<title><![CDATA[WordPress-Logo]]></title>
 		<link>https://gatographql-pro.lndo.site/wordpress-logo/</link>
 		<pubDate>Thu, 07 May 2026 06:14:35 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>
-		<guid isPermaLink="false">https://gatographql-pro.lndo.site/wp-content/uploads/Wordpress-Logo.svg</guid>
+		<guid isPermaLink="false">https://gatographql-pro.lndo.site/wp-content/uploads/WordPress-Logo.svg</guid>
 		<description></description>
 		<content:encoded><![CDATA[]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
@@ -1660,10 +1660,10 @@ https://wordpress.org/about/
 		<wp:post_type><![CDATA[attachment]]></wp:post_type>
 		<wp:post_password><![CDATA[]]></wp:post_password>
 		<wp:is_sticky>0</wp:is_sticky>
-						<wp:attachment_url><![CDATA[https://upload.wikimedia.org/wikipedia/commons/0/09/Wordpress-Logo.svg]]></wp:attachment_url>
+						<wp:attachment_url><![CDATA[https://upload.wikimedia.org/wikipedia/commons/0/09/WordPress-Logo.svg]]></wp:attachment_url>
 						<wp:postmeta>
 		<wp:meta_key><![CDATA[_wp_attached_file]]></wp:meta_key>
-		<wp:meta_value><![CDATA[Wordpress-Logo.svg]]></wp:meta_value>
+		<wp:meta_value><![CDATA[WordPress-Logo.svg]]></wp:meta_value>
 		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_wp_attachment_metadata]]></wp:meta_key>


### PR DESCRIPTION
Executing GraphQL queries produces a 403 when the BBQ Firewall plugin is active.

**Solution:**

Replace `execute_query` with `run_query` in the URL.

**Explanation:**

BBQ's blocklist (and the related 7G Firewall ruleset by the same author) flags execute as a request-string token, because attackers commonly use query patterns like ?action=execute&cmd=… for RCE attempts. The match is purely substring-based — it doesn't care that your slug is benign.