### PR TITLE
Add currentUserCan to UserStateTypeAPIInterface

### DIFF
--- a/layers/CMSSchema/packages/user-state-wp/src/TypeAPIs/UserStateTypeAPI.php
+++ b/layers/CMSSchema/packages/user-state-wp/src/TypeAPIs/UserStateTypeAPI.php
@@ -6,6 +6,7 @@ namespace PoPCMSSchema\UserStateWP\TypeAPIs;
 
 use PoPCMSSchema\UserState\TypeAPIs\UserStateTypeAPIInterface;
 
+use function current_user_can;
 use function get_current_user_id;
 use function is_user_logged_in;
 use function wp_get_current_user;
@@ -23,5 +24,12 @@ class UserStateTypeAPI implements UserStateTypeAPIInterface
     public function getCurrentUserID(): string|int|null
     {
         return get_current_user_id();
+    }
+    public function currentUserCan(string $capability): bool
+    {
+        if ($capability === '') {
+            return false;
+        }
+        return current_user_can($capability);
     }
 }

--- a/layers/CMSSchema/packages/user-state-wp/src/TypeAPIs/UserStateTypeAPI.php
+++ b/layers/CMSSchema/packages/user-state-wp/src/TypeAPIs/UserStateTypeAPI.php
@@ -27,7 +27,7 @@ class UserStateTypeAPI implements UserStateTypeAPIInterface
     }
     public function currentUserCan(string $capability): bool
     {
-        if ($capability === '') {
+        if ($capability === '' || !is_user_logged_in()) {
             return false;
         }
         return current_user_can($capability);

--- a/layers/CMSSchema/packages/user-state/src/TypeAPIs/UserStateTypeAPIInterface.php
+++ b/layers/CMSSchema/packages/user-state/src/TypeAPIs/UserStateTypeAPIInterface.php
@@ -9,4 +9,8 @@ interface UserStateTypeAPIInterface
     public function isUserLoggedIn(): bool;
     public function getCurrentUser(): ?object;
     public function getCurrentUserID(): string|int|null;
+    /**
+     * Whether the current user holds the given CMS capability.
+     */
+    public function currentUserCan(string $capability): bool;
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/StaticHelpers/CapabilityHelpers.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/StaticHelpers/CapabilityHelpers.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GatoGraphQL\GatoGraphQL\StaticHelpers;
 
+use function wp_roles;
+
 class CapabilityHelpers
 {
     public static function getSettingsMenuPageRequiredCapability(): string
@@ -33,7 +35,7 @@ class CapabilityHelpers
         }
         if (function_exists('wp_roles')) {
             $capabilityNames = [];
-            foreach (\wp_roles()->roles as $role) {
+            foreach (wp_roles()->roles as $role) {
                 if (!is_array($role['capabilities'] ?? null)) {
                     continue;
                 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/StaticHelpers/CapabilityHelpers.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/StaticHelpers/CapabilityHelpers.php
@@ -10,4 +10,51 @@ class CapabilityHelpers
     {
         return 'manage_options';
     }
+
+    /**
+     * Enumerate every capability declared by any registered WordPress
+     * role, so settings UIs can render a select instead of a free-form
+     * input (typos otherwise silently turn into "deny everyone").
+     *
+     * @param string|null $emptyOptionLabel If non-null, the resulting map
+     *                                       is prefixed with `'' => $emptyOptionLabel`
+     *                                       so the form can encode "no
+     *                                       capability required" (or the
+     *                                       caller's chosen synonym).
+     *                                       Pass null to omit the empty
+     *                                       option entirely.
+     * @return array<string,string>
+     */
+    public static function getAvailableCapabilities(?string $emptyOptionLabel = null): array
+    {
+        $values = [];
+        if ($emptyOptionLabel !== null) {
+            $values[''] = $emptyOptionLabel;
+        }
+        if (function_exists('wp_roles')) {
+            $capabilityNames = [];
+            foreach (\wp_roles()->roles as $role) {
+                if (!is_array($role['capabilities'] ?? null)) {
+                    continue;
+                }
+                foreach (array_keys($role['capabilities']) as $capabilityName) {
+                    if (!is_string($capabilityName) || $capabilityName === '') {
+                        continue;
+                    }
+                    $capabilityNames[$capabilityName] = true;
+                }
+            }
+            $capabilityNames = array_keys($capabilityNames);
+            sort($capabilityNames);
+            foreach ($capabilityNames as $capabilityName) {
+                $values[$capabilityName] = $capabilityName;
+            }
+        }
+        // Ensure the secure default is always selectable even if no role
+        // currently declares it (e.g. a stripped-down install).
+        if (!isset($values['manage_options'])) {
+            $values['manage_options'] = 'manage_options';
+        }
+        return $values;
+    }
 }


### PR DESCRIPTION
## Summary

Adds `currentUserCan(string \$capability): bool` to `UserStateTypeAPIInterface`, implemented by `UserStateWP\TypeAPIs\UserStateTypeAPI` via WordPress's `current_user_can`. Lets CMS-agnostic callers ask "does the current user have this capability?" without coupling to WordPress functions.

Needed by **leoloso/PRO** to gate internal-URL HTTP requests by capability (see [leoloso/PRO#2392](https://github.com/leoloso/PRO/pull/2392)).

## Test plan

- [ ] Confirm existing UserState tests still pass
- [ ] Confirm new method returns `false` on empty capability and delegates to `current_user_can` otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)