### PR TITLE
Add WordPress core block translation test data

### DIFF
--- a/webservers/_shared/assets/gatographql-data.xml
+++ b/webservers/_shared/assets/gatographql-data.xml
@@ -1947,7 +1947,87 @@ https://www.youtube.com/watch?v=7Nmz3IjtPh0
 
 <!-- wp:block {"ref":1136} /-->
 
-<!-- wp:breadcrumbs {"separator":"::"} /-->]]></content:encoded>
+<!-- wp:breadcrumbs {"separator":"::"} /-->
+
+<!-- wp:search {"label":"Search the site","showLabel":true,"placeholder":"Type your query here","buttonText":"Go!","buttonPosition":"button-outside"} /-->
+
+<!-- wp:categories {"label":"Browse categories","showLabel":true} /-->
+
+<!-- wp:read-more {"content":"Read the full story"} /-->
+
+<!-- wp:post-author {"byline":"Written by"} /-->
+
+<!-- wp:post-excerpt {"moreText":"Continue reading"} /-->
+
+<!-- wp:post-terms {"term":"category","prefix":"Filed under: ","suffix":" - thanks for reading!"} /-->
+
+<!-- wp:post-navigation-link {"type":"previous","label":"Previous article"} /-->
+
+<!-- wp:post-navigation-link {"type":"next","label":"Next article"} /-->
+
+<!-- wp:details -->
+<details class="wp-block-details"><summary>Click to expand this disclosure summary</summary>
+<!-- wp:paragraph -->
+<p>Hidden content inside the details block.</p>
+<!-- /wp:paragraph -->
+</details>
+<!-- /wp:details -->
+
+<!-- wp:accordion -->
+<div class="wp-block-accordion">
+<!-- wp:accordion-item -->
+<div class="wp-block-accordion-item">
+<!-- wp:accordion-heading {"level":3} -->
+<h3 class="wp-block-accordion-heading"><button class="wp-block-accordion-heading__toggle"><span class="wp-block-accordion-heading__toggle-title">Accordion heading to translate</span></button></h3>
+<!-- /wp:accordion-heading -->
+<!-- wp:accordion-panel -->
+<div class="wp-block-accordion-panel">
+<!-- wp:paragraph -->
+<p>Accordion panel content.</p>
+<!-- /wp:paragraph -->
+</div>
+<!-- /wp:accordion-panel -->
+</div>
+<!-- /wp:accordion-item -->
+</div>
+<!-- /wp:accordion -->
+
+<!-- wp:navigation -->
+<!-- wp:home-link {"label":"Home page"} /-->
+<!-- wp:navigation-link {"label":"About us","description":"Learn more about our company","title":"Go to the About page","url":"/about","kind":"custom"} /-->
+<!-- wp:navigation-submenu {"label":"Services","description":"Everything we offer","title":"Browse our services","url":"/services","kind":"custom"} -->
+<!-- wp:navigation-link {"label":"Consulting","url":"/consulting","kind":"custom"} /-->
+<!-- /wp:navigation-submenu -->
+<!-- wp:navigation-overlay-close {"text":"Close menu"} /-->
+<!-- /wp:navigation -->
+
+<!-- wp:social-links -->
+<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://twitter.com/gatographql","service":"x","label":"Follow us on X"} /--></ul>
+<!-- /wp:social-links -->
+
+<!-- wp:widget-group {"title":"Footer widgets"} -->
+<div class="wp-block-widget-group"><!-- wp:paragraph --><p>Widget content.</p><!-- /wp:paragraph --></div>
+<!-- /wp:widget-group -->
+
+<!-- wp:query {"queryId":42,"query":{"perPage":3,"postType":"post"}} -->
+<div class="wp-block-query"><!-- wp:query-pagination -->
+<!-- wp:query-pagination-previous {"label":"Newer posts"} /-->
+<!-- wp:query-pagination-next {"label":"Older posts"} /-->
+<!-- /wp:query-pagination -->
+</div>
+<!-- /wp:query -->
+
+<!-- wp:comments -->
+<div class="wp-block-comments"><!-- wp:comments-pagination -->
+<!-- wp:comments-pagination-previous {"label":"Older comments"} /-->
+<!-- wp:comments-pagination-next {"label":"Newer comments"} /-->
+<!-- /wp:comments-pagination -->
+</div>
+<!-- /wp:comments -->
+
+<!-- wp:terms-query {"termQuery":{"perPage":10,"taxonomy":"category","include":[1],"order":"asc","orderBy":"name"}} -->
+<div class="wp-block-terms-query"><!-- wp:paragraph --><p>Terms query.</p><!-- /wp:paragraph --></div>
+<!-- /wp:terms-query -->]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
 		<wp:post_id>1140</wp:post_id>
 		<wp:post_date><![CDATA[2023-06-12 09:20:44]]></wp:post_date>


### PR DESCRIPTION
Extends the **"single-post-with-a-lot-of-blocks"** demo post (1140) in `webservers/_shared/assets/gatographql-data.xml` with WordPress core blocks that exercise additional translatable attributes and a taxonomy-term reference, so the block-translation coverage can be validated end-to-end.

Blocks added to the post content:
- **search** (`label`, `placeholder`, `buttonText`), **categories** (`label`)
- **read-more** (`content`), **post-author** (`byline`), **post-excerpt** (`moreText`)
- **post-terms** (`prefix`, `suffix`), **post-navigation-link** (`label`)
- **details** (`summary`), **accordion** → accordion-heading (`title`)
- **navigation** → home-link (`label`), navigation-link / navigation-submenu (`description`, `title`), navigation-overlay-close (`text`)
- **social-links** → social-link (`label`), **widget-group** (`title`)
- **query** → query-pagination next/previous (`label`), **comments** → comments-pagination next/previous (`label`)
- **terms-query** (`termQuery.include` term IDs)

Verified: the XML is well-formed and every added attribute is matched by its block-translation regex within the post content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)