### PR TITLE
Rely on `.l10n.php` only for translations (drop `.mo` from plugin)

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/includes/startup.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/includes/startup.php
@@ -86,26 +86,26 @@ class Startup {
     }
 
     /**
-     * Load the .mo for the current locale into the 'gatographql' text domain,
+     * Load the .l10n.php for the current locale into the 'gatographql' text domain,
      * falling back to a shipped variant of the same base language when the exact
      * locale's file is absent (e.g. es_AR / es_MX reuse es_ES, fr_CA reuses fr_FR).
      */
     public static function loadTextdomainWithFallback(string $dir, string $prefix): void
     {
         $locale = determine_locale();
-        $mofile = $dir . $prefix . $locale . '.mo';
-        if (!is_readable($mofile)) {
+        $translationFile = $dir . $prefix . $locale . '.l10n.php';
+        if (!is_readable($translationFile)) {
             $base = (string) strtok($locale, '_');
-            $canonical = $dir . $prefix . $base . '_' . strtoupper($base) . '.mo';
+            $canonical = $dir . $prefix . $base . '_' . strtoupper($base) . '.l10n.php';
             if (is_readable($canonical)) {
-                $mofile = $canonical;
+                $translationFile = $canonical;
             } else {
-                $variants = glob($dir . $prefix . $base . '_*.mo') ?: [];
-                $mofile = $variants[0] ?? $mofile;
+                $variants = glob($dir . $prefix . $base . '_*.l10n.php') ?: [];
+                $translationFile = $variants[0] ?? $translationFile;
             }
         }
-        if (is_readable($mofile)) {
-            load_textdomain('gatographql', $mofile);
+        if (is_readable($translationFile)) {
+            load_textdomain('gatographql', $translationFile);
         }
     }
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Helpers/LocaleHelper.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/Helpers/LocaleHelper.php
@@ -25,7 +25,7 @@ class LocaleHelper
     /**
      * Language codes for which a translated version of the website exists. The
      * website is localized to the same set of languages as the plugin itself, so
-     * this is derived from the shipped translation files (gatographql-<locale>.mo)
+     * this is derived from the shipped translation files (gatographql-<locale>.l10n.php)
      * — staying in sync automatically as new locales are added.
      *
      * @return string[]
@@ -37,13 +37,13 @@ class LocaleHelper
         }
         $languages = [];
         $mainPlugin = PluginApp::getMainPlugin();
-        // The .mo files are named "<plugin-file-basename>-<locale>.mo" (matching the
-        // text-domain loading wiring in the plugin entry file).
+        // The .l10n.php files are named "<plugin-file-basename>-<locale>.l10n.php" (matching
+        // the text-domain loading wiring in the plugin entry file).
         $prefix = basename($mainPlugin->getPluginFile(), '.php') . '-';
         $languagesDir = $mainPlugin->getPluginDir() . '/languages/';
-        foreach (glob($languagesDir . $prefix . '*.mo') ?: [] as $moFile) {
-            // "gatographql-es_ES.mo" => locale "es_ES" => language "es"
-            $locale = substr(basename($moFile), strlen($prefix), -strlen('.mo'));
+        foreach (glob($languagesDir . $prefix . '*.l10n.php') ?: [] as $translationFile) {
+            // "gatographql-es_ES.l10n.php" => locale "es_ES" => language "es"
+            $locale = substr(basename($translationFile), strlen($prefix), -strlen('.l10n.php'));
             $language = explode('_', $locale)[0];
             $languages[$language] = $language;
         }

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
@@ -37,7 +37,7 @@ class PluginDataSource
                     'block-helpers/\*',
                     'docs/images/\*',
                     'extensions/*/docs/images/\*',
-                    
+
                     // i18n source/template files: not used at runtime (only the
                     // compiled .mo/.l10n.php/.json are). The .po lives in git as the
                     // translation source; the .pot is the extraction template.

--- a/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
+++ b/src/Config/Symplify/MonorepoBuilder/DataSources/PluginDataSource.php
@@ -37,11 +37,16 @@ class PluginDataSource
                     'block-helpers/\*',
                     'docs/images/\*',
                     'extensions/*/docs/images/\*',
+                    
                     // i18n source/template files: not used at runtime (only the
                     // compiled .mo/.l10n.php/.json are). The .po lives in git as the
                     // translation source; the .pot is the extraction template.
                     'languages/\*.po',
                     'languages/\*.pot',
+
+                    // Rely on .l10n.php only for translations (WP 6.5+)
+                    'languages/\*.mo',
+
                     ...$this->getExcludeGraphiQLAppFiles(),
                     sprintf($excludeJSBlockFilesPlaceholder, 'blocks'),
                     sprintf($excludeJSBlockFilesPlaceholder, 'editor-scripts'),


### PR DESCRIPTION
The plugin size is then smaller, but then the translation will only work with WP 6.5+. Worth the trade-off