### PR TITLE
Prevent a module from being initialized more than once

### DIFF
--- a/layers/Engine/packages/root/src/AppLoader.php
+++ b/layers/Engine/packages/root/src/AppLoader.php
@@ -324,8 +324,16 @@ class AppLoader implements AppLoaderInterface
                 );
             }
 
-            // We reached the bottom of the rung, add the module to the list
-            $this->orderedModuleClasses[] = $moduleClass;
+            // We reached the bottom of the rung, add the module to the list.
+            // Guard against adding a module that's already ordered: a module
+            // can be reached again (e.g. when its dependents are processed
+            // across an additional initialization pass) while not yet present
+            // in `$initializedModuleClasses`; without this guard it would be
+            // initialized twice, re-running its service registration and
+            // clobbering any overrides registered in between.
+            if (!in_array($moduleClass, $this->orderedModuleClasses, true)) {
+                $this->orderedModuleClasses[] = $moduleClass;
+            }
 
             /**
              * If this component satisfies the contracts for other

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -22,6 +22,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Fixed
 
+- Fixed a module being initialized more than once when booting an attached app (such as the Internal GraphQL Server), which could re-register its services and override others (#3331)
 - Fix lost styles in Extensions page (#3319)
 - Fix items not shown as active in Extensions page (#3320)
 - Replace non-standard spaces in block attributes when doing useHTML5Parser (#3313)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/18.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/18.1/en.md
@@ -16,6 +16,7 @@
 
 ## Fixed
 
+- Fixed a module being initialized more than once when booting an attached app (such as the Internal GraphQL Server), which could re-register its services and override others ([#3331](https://github.com/GatoGraphQL/GatoGraphQL/pull/3331))
 - Fix lost styles in Extensions page ([#3319](https://github.com/GatoGraphQL/GatoGraphQL/pull/3319))
 - Fix items not shown as active in Extensions page ([#3320](https://github.com/GatoGraphQL/GatoGraphQL/pull/3320))
 - Replace non-standard spaces in block attributes when doing useHTML5Parser ([#3313](https://github.com/GatoGraphQL/GatoGraphQL/pull/3313))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -236,6 +236,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 * Improved - Do not show All Inclusive bundle in Extension docs (#3321)
 * Improved - Upgraded GraphiQL to version 5.2.3 (#3323)
 * Improved - Added the Explorer plugin to the GraphiQL client, to build queries by point-and-click (#3327)
+* Fixed - Fixed a module being initialized more than once when booting an attached app (such as the Internal GraphQL Server), which could re-register its services and override others (#3331)
 * Fixed - Fix lost styles in Extensions page (#3319)
 * Fixed - Fix items not shown as active in Extensions page (#3320)
 * Fixed - Replace non-standard spaces in block attributes when doing useHTML5Parser (#3313)


### PR DESCRIPTION
## Problem

When an attached app is booted within a request — e.g. the **Internal GraphQL Server** (`InternalGraphQLServer->initializeApp()` → `AppLoader->initializeModules()`) — `addComponentsOrderedForInitialization()` could append the **same module class twice** to `orderedModuleClasses`.

The dedup `array_diff($moduleClasses, $this->initializedModuleClasses)` is computed **once at function entry**. A module that is both present in the init batch *and* reached as a transitive dependency of an earlier batch item during the loop gets added a second time (the entry-time diff didn't know it would be pulled in by the dependency recursion).

Because the boot loop iterates `orderedModuleClasses`, that module's `initializeContainerServices()` then runs **twice**, registering its container services a second time. The second registration **overwrites service overrides** (same service id, different class) that were registered in between — so the override silently loses.

## Fix

Guard `orderedModuleClasses` against duplicate entries, so each module is appended (and therefore initialized) exactly once per container.

## Tests

- PHPStan: green.
- Unit tests: green (456 tests, 1754 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)