### PR TITLE
[i18n] Harden the assisted-translation script against silent batch skips

### DIFF
--- a/ci/i18n/translate-po.php
+++ b/ci/i18n/translate-po.php
@@ -123,6 +123,7 @@ function buildPrompt(array $batch, string $language, string $locale): string
         Return ONLY a JSON object with the same keys and the translated values. No commentary, no markdown, no code fences.
 
         Rules:
+        - Return STRICTLY valid JSON (RFC 8259): escape every double quote inside a value as \\", and write newlines as \\n — never a raw line break inside a value.
         - Preserve every placeholder verbatim: %s, %d, %1\$s, %2\$s, etc.
         - Preserve HTML tags and entities (<code>…</code>, <a href="…">, &amp;, etc.) and any Markdown.
         - Do NOT translate the contents of <code>…</code>, code identifiers, GraphQL keywords, field/type names, or URLs.
@@ -143,10 +144,129 @@ function buildPluralPrompt(array $batch, string $language, string $locale, int $
 
         Return ONLY a JSON object with the same numeric keys, each mapping to an array of {$nplurals} translated string(s). No commentary, no markdown, no code fences.
 
-        Rules: preserve every placeholder verbatim (%s, %d, %1\$s, ...), HTML tags/entities, the contents of <code>…</code>, and leading/trailing whitespace.
+        Rules: return STRICTLY valid JSON (escape every double quote inside a value as \\", newlines as \\n); preserve every placeholder verbatim (%s, %d, %1\$s, ...), HTML tags/entities, the contents of <code>…</code>, and leading/trailing whitespace.
 
         {$input}
         PROMPT;
+}
+
+/**
+ * Last-resort prompt for a single entry that keeps breaking JSON parsing
+ * (typically because its translation contains double quotes the model fails to
+ * escape). Asks for the raw translated text only — no JSON to mis-escape.
+ */
+function buildRawPrompt(string $original, string $language, string $locale): string
+{
+    return <<<PROMPT
+        You are localizing the "Gato GraphQL" WordPress plugin (a GraphQL server for WordPress) into {$language} (locale {$locale}).
+
+        Translate the text delimited by the markers below from English to {$language}.
+
+        Output ONLY the translated text itself — no surrounding quotes, no JSON, no markdown, no code fences, no commentary.
+
+        Rules:
+        - Preserve every placeholder verbatim: %s, %d, %1\$s, %2\$s, etc.
+        - Preserve HTML tags and entities and any Markdown, including any double quotes that appear in the text.
+        - Do NOT translate the contents of <code>…</code>, code identifiers, GraphQL keywords, field/type names, or URLs.
+        - Preserve leading/trailing whitespace.
+
+        <text>{$original}</text>
+        PROMPT;
+}
+
+/**
+ * Translate one chunk of singular entries. A chunk whose model output won't
+ * parse (or that comes back missing entries) is BISECTED to isolate the
+ * offending entry, which is then retried on its own and finally via a raw
+ * (non-JSON) prompt — so one poison entry can no longer silently sink a batch.
+ * Returns the number of entries newly translated; entries that still fail are
+ * left untranslated (and reported by the caller).
+ *
+ * @param \Gettext\Translation[] $chunk
+ */
+function translateChunk(array $chunk, string $language, string $locale, string $model, callable $persist): int
+{
+    if ($chunk === []) {
+        return 0;
+    }
+
+    $batch = [];
+    foreach (array_values($chunk) as $i => $translation) {
+        $batch[(string) ($i + 1)] = $translation->getOriginal();
+    }
+
+    $result = null;
+    try {
+        $result = extractJsonObject(callClaude(buildPrompt($batch, $language, $locale), $model));
+    } catch (\RuntimeException $e) {
+        fwrite(STDERR, "  ! claude error: {$e->getMessage()}\n");
+    }
+
+    $done = 0;
+    /** @var \Gettext\Translation[] $failed */
+    $failed = [];
+    foreach (array_values($chunk) as $i => $translation) {
+        $key = (string) ($i + 1);
+        if (is_array($result) && isset($result[$key]) && (string) $result[$key] !== '') {
+            $translation->setTranslation((string) $result[$key]);
+            $done++;
+        } else {
+            $failed[] = $translation;
+        }
+    }
+    if ($done > 0) {
+        $persist();
+    }
+    if ($failed === []) {
+        return $done;
+    }
+
+    // More than one entry left: split to isolate the offender.
+    if (count($failed) > 1) {
+        $half = intdiv(count($failed), 2);
+        $done += translateChunk(array_slice($failed, 0, $half), $language, $locale, $model, $persist);
+        $done += translateChunk(array_slice($failed, $half), $language, $locale, $model, $persist);
+        return $done;
+    }
+
+    // A single entry still failing through JSON: fall back to a raw-text prompt.
+    $translation = $failed[0];
+    $raw = translateSingleRaw($translation->getOriginal(), $language, $locale, $model);
+    if ($raw !== null) {
+        $translation->setTranslation($raw);
+        $persist();
+        return $done + 1;
+    }
+    fwrite(STDERR, "  ! left untranslated: \"" . shortenForLog($translation->getOriginal()) . "\"\n");
+    return $done;
+}
+
+/**
+ * Translate a single string via the raw (non-JSON) prompt, with retries.
+ * Returns the translated text, or null if it could not be obtained.
+ */
+function translateSingleRaw(string $original, string $language, string $locale, string $model, int $maxAttempts = 2): ?string
+{
+    for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+        try {
+            $response = callClaude(buildRawPrompt($original, $language, $locale), $model);
+        } catch (\RuntimeException $e) {
+            return null;
+        }
+        // strip accidental code fences, then surrounding whitespace
+        $text = (string) preg_replace('/^```[a-z]*\s*|\s*```$/m', '', trim($response));
+        $text = trim($text);
+        if ($text !== '') {
+            return $text;
+        }
+    }
+    return null;
+}
+
+function shortenForLog(string $text): string
+{
+    $text = str_replace("\n", ' ', $text);
+    return mb_strlen($text) > 60 ? mb_substr($text, 0, 57) . '...' : $text;
 }
 
 // --- main ---------------------------------------------------------------
@@ -212,33 +332,15 @@ printf(
     $batchSize
 );
 
+// persist incrementally so a long run can be resumed
+$persist = static function () use ($translations, $poFile): void {
+    $translations->toPoFile($poFile);
+};
+
 $done = 0;
 foreach (array_chunk($pending, $batchSize) as $chunkIndex => $chunk) {
-    $batch = [];
-    foreach ($chunk as $i => $translation) {
-        $batch[(string) ($i + 1)] = $translation->getOriginal();
-    }
-    try {
-        $response = callClaude(buildPrompt($batch, $language, $locale), $model);
-    } catch (\RuntimeException $e) {
-        fwrite(STDERR, "  ! batch {$chunkIndex}: {$e->getMessage()}; skipping (retry next run)\n");
-        continue;
-    }
-    $result = extractJsonObject($response);
-    if ($result === null) {
-        fwrite(STDERR, "  ! batch {$chunkIndex}: could not parse Claude output; skipping\n");
-        continue;
-    }
-    foreach ($chunk as $i => $translation) {
-        $key = (string) ($i + 1);
-        if (isset($result[$key]) && $result[$key] !== '') {
-            $translation->setTranslation((string) $result[$key]);
-            $done++;
-        }
-    }
-    // persist incrementally so a long run can be resumed
-    $translations->toPoFile($poFile);
-    printf("  batch %d: %d translated (%d total)\n", $chunkIndex + 1, count($chunk), $done);
+    $done += translateChunk($chunk, $language, $locale, $model, $persist);
+    printf("  batch %d done (%d/%d translated so far)\n", $chunkIndex + 1, $done, count($pending));
 }
 
 // plural entries (skipped by --limit subsets, since they are few)
@@ -251,15 +353,18 @@ if ($limit === 0) {
                 'plural' => $translation->getPlural(),
             ];
         }
-        try {
-            $response = callClaude(buildPluralPrompt($batch, $language, $locale, $nplurals), $model);
-        } catch (\RuntimeException $e) {
-            fwrite(STDERR, "  ! plural batch {$chunkIndex}: {$e->getMessage()}; skipping (retry next run)\n");
-            continue;
+        $result = null;
+        for ($attempt = 1; $attempt <= 2 && $result === null; $attempt++) {
+            try {
+                $response = callClaude(buildPluralPrompt($batch, $language, $locale, $nplurals), $model);
+            } catch (\RuntimeException $e) {
+                fwrite(STDERR, "  ! plural batch {$chunkIndex}: {$e->getMessage()}\n");
+                break;
+            }
+            $result = extractJsonObject($response);
         }
-        $result = extractJsonObject($response);
         if ($result === null) {
-            fwrite(STDERR, "  ! plural batch {$chunkIndex}: could not parse Claude output; skipping\n");
+            fwrite(STDERR, "  ! plural batch {$chunkIndex}: could not parse Claude output; left for next run\n");
             continue;
         }
         foreach ($chunk as $i => $translation) {
@@ -279,3 +384,27 @@ if ($limit === 0) {
 }
 
 printf("Done: %d entries translated in %s\n", $done, basename($poFile));
+
+// Surface anything still untranslated so it can't slip through silently.
+$remaining = 0;
+foreach ($pending as $translation) {
+    if (!$translation->hasTranslation()) {
+        $remaining++;
+    }
+}
+if ($limit === 0) {
+    foreach ($pendingPlural as $translation) {
+        if (!$translation->hasTranslation()) {
+            $remaining++;
+        }
+    }
+}
+if ($remaining > 0) {
+    fwrite(STDERR, sprintf(
+        "WARNING: %d entr%s in %s still untranslated after all retries; re-run to retry.\n",
+        $remaining,
+        $remaining === 1 ? 'y' : 'ies',
+        basename($poFile)
+    ));
+    exit(3);
+}

--- a/ci/i18n/translate.sh
+++ b/ci/i18n/translate.sh
@@ -12,6 +12,7 @@ cd "$ROOT"
 LANG_DIR="layers/GatoGraphQLForWP/plugins/gatographql/languages"
 LOCALES_FILE="ci/i18n/locales.txt"
 
+failed=0
 while IFS= read -r locale; do
     [ -z "$locale" ] && continue
     po="$LANG_DIR/gatographql-$locale.po"
@@ -19,5 +20,13 @@ while IFS= read -r locale; do
         echo "SKIP $locale: $po not found — run 'composer i18n-extract' first."
         continue
     fi
-    php ci/i18n/translate-po.php "$po" --locale="$locale" "$@"
+    # Don't let one locale's residual-failure abort the whole loop (set -e).
+    if ! php ci/i18n/translate-po.php "$po" --locale="$locale" "$@"; then
+        failed=1
+    fi
 done < "$LOCALES_FILE"
+
+if [ "$failed" -ne 0 ]; then
+    echo "ERROR: some locales still have untranslated entries (see warnings above); re-run to retry." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Problem

`ci/i18n/translate-po.php` sends untranslated entries to Claude in JSON batches. When the model's reply failed to JSON-parse — most commonly because a translated value contained **unescaped double quotes** — the entire batch was logged and **silently skipped**, yet the script still exited `0`. Those entries stayed untranslated and only surfaced later at the release gate. Parse failures were never retried (`callClaude` retries only process-level errors).

## Fix

- **Bisect to isolate the offender.** A batch that won't parse (or comes back missing entries) is split in half and each half retried, recursively, so one poison entry can no longer sink its whole batch. Entries that *do* parse are kept.
- **Raw-text fallback for a lone failing entry.** Once bisected down to a single entry that still won't parse as JSON, it's retried via a raw (non-JSON) prompt that asks for just the translated text — sidestepping JSON escaping entirely (the quotes case).
- **No more silent success.** Anything still untranslated after all retries is reported, and the script exits non-zero. `translate.sh` no longer lets one locale's failure abort the loop (it continues, then fails at the end).
- **Stronger prompts.** The JSON prompts now explicitly require strictly valid JSON (escape `"` as `\"`, newlines as `\n`).

## Testing

Exercised end-to-end with a stubbed `claude` binary returning deliberately broken JSON for any batch containing a quoted value:
- A mixed batch (some clean entries + one entry with embedded quotes) → clean entries translated via JSON, the quoted entry isolated by bisection and resolved via the raw fallback; exit `0`.
- Raw fallback forced to fail → good entries still translated (partial progress kept), failing entry reported, exit non-zero.
- `php -l` and `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)