### PR TITLE
Register capabilities always first

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -42,6 +42,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Fix items not shown as active in Extensions page (#3320)
 - Replace non-standard spaces in block attributes when doing useHTML5Parser (#3313)
 - Fix the GraphiQL editor's Find box (Cmd/Ctrl+F) staying visible after being closed (#3326)
+- Register always first the capability to access the plugin (so it doesn't fail installing whenever the server does not have enough memory) (#3343)
 
 ## 18.0.0 - 20/05/2026
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.0/en.md
@@ -36,3 +36,4 @@
 - Fix items not shown as active in Extensions page ([#3320](https://github.com/GatoGraphQL/GatoGraphQL/pull/3320))
 - Replace non-standard spaces in block attributes when doing useHTML5Parser ([#3313](https://github.com/GatoGraphQL/GatoGraphQL/pull/3313))
 - Fix the GraphiQL editor's Find box (Cmd/Ctrl+F) staying visible after being closed ([#3326](https://github.com/GatoGraphQL/GatoGraphQL/pull/3326))
+- Register always first the capability to access the plugin (so it doesn't fail installing whenever the server does not have enough memory) ([#3343](https://github.com/GatoGraphQL/GatoGraphQL/pull/3343))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/gatographql.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/gatographql.php
@@ -50,6 +50,23 @@ if (class_exists(Plugin::class)) {
     return;
 }
 
+/**
+ * Execute always first, to guarantee the capability is registered even if the
+ * webserver doesn't have enough memory. Otherwise, once it fails, the capability
+ * won't be registered (even after increasing the memory limit), and the plugin
+ * will not be available on the menu.
+ *
+ * Can't use Composer to load this file, as "vendor/" is loaded only
+ * in the "plugins_loaded" hook, and that's too late to register
+ * the capabilities.
+ */
+require_once __DIR__ . '/includes/capabilities.php';
+require_once __DIR__ . '/includes/schema-editing-access-capabilities.php';
+\PoPIncludes\GatoGraphQL\SchemaEditingAccessCapabilities::registerGatoGraphQLSchemaEditingAccessCapabilities(
+    __FILE__,
+    constant('GATOGRAPHQL_CAPABILITY_MANAGE_GRAPHQL_SCHEMA')
+);
+
 // Validate that there is enough memory to run the plugin
 require_once __DIR__ . '/includes/startup.php';
 if (!Startup::checkGatoGraphQLMemoryRequirements($pluginName)) {
@@ -61,18 +78,6 @@ add_action('init', function (): void {
     Startup::registerScriptTranslationFileResolver();
     Startup::loadTextdomainWithFallback(__DIR__ . '/languages/', basename(__FILE__, '.php') . '-');
 }, PHP_INT_MIN);
-
-/**
- * Can't use Composer to load this file, as "vendor/" is loaded only
- * in the "plugins_loaded" hook, and that's too late to register
- * the capabilities.
- */
-require_once __DIR__ . '/includes/capabilities.php';
-require_once __DIR__ . '/includes/schema-editing-access-capabilities.php';
-\PoPIncludes\GatoGraphQL\SchemaEditingAccessCapabilities::registerGatoGraphQLSchemaEditingAccessCapabilities(
-    __FILE__,
-    constant('GATOGRAPHQL_CAPABILITY_MANAGE_GRAPHQL_SCHEMA')
-);
 
 /**
  * The commit hash is added to the plugin version 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -253,6 +253,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 * Fixed - Fix items not shown as active in Extensions page (#3320)
 * Fixed - Replace non-standard spaces in block attributes when doing useHTML5Parser (#3313)
 * Fixed - Fix the GraphiQL editor's Find box (Cmd/Ctrl+F) staying visible after being closed (#3326)
+* Fixed - Register always first the capability to access the plugin (so it doesn't fail installing whenever the server does not have enough memory) (#3343)
 
 = 18.0.0 =
 * Breaking changes - Changed namespace for packages in Gato GraphQL extensions (HTTP Client/PHP Constants and Environment Variables via Schema)


### PR DESCRIPTION
Register always first the capability to access the plugin (so it doesn't fail installing whenever the server does not have enough memory)