### PR TITLE
Surface Marketplace Provider error message on failed-HTTP license operations

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -43,6 +43,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Replace non-standard spaces in block attributes when doing useHTML5Parser (#3313)
 - Fix the GraphiQL editor's Find box (Cmd/Ctrl+F) staying visible after being closed (#3326)
 - Register always first the capability to access the plugin (so it doesn't fail installing whenever the server does not have enough memory) (#3343)
+- Show the Marketplace Provider's own error message when activating or validating a license fails with an error HTTP status code, such as when the license's activation limit has been reached, instead of a generic HTTP error (#3344)
 
 ## 18.0.0 - 20/05/2026
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.0/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.0/en.md
@@ -37,3 +37,4 @@
 - Replace non-standard spaces in block attributes when doing useHTML5Parser ([#3313](https://github.com/GatoGraphQL/GatoGraphQL/pull/3313))
 - Fix the GraphiQL editor's Find box (Cmd/Ctrl+F) staying visible after being closed ([#3326](https://github.com/GatoGraphQL/GatoGraphQL/pull/3326))
 - Register always first the capability to access the plugin (so it doesn't fail installing whenever the server does not have enough memory) ([#3343](https://github.com/GatoGraphQL/GatoGraphQL/pull/3343))
+- Show the Marketplace Provider's own error message when activating or validating a license fails with an error HTTP status code, such as when the license's activation limit has been reached, instead of a generic HTTP error ([#3344](https://github.com/GatoGraphQL/GatoGraphQL/pull/3344))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -254,6 +254,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 * Fixed - Replace non-standard spaces in block attributes when doing useHTML5Parser (#3313)
 * Fixed - Fix the GraphiQL editor's Find box (Cmd/Ctrl+F) staying visible after being closed (#3326)
 * Fixed - Register always first the capability to access the plugin (so it doesn't fail installing whenever the server does not have enough memory) (#3343)
+* Fixed - Show the Marketplace Provider's own error message when activating or validating a license fails with an error HTTP status code, such as when the license's activation limit has been reached, instead of a generic HTTP error (#3344)
 
 = 18.0.0 =
 * Breaking changes - Changed namespace for packages in Gato GraphQL extensions (HTTP Client/PHP Constants and Environment Variables via Schema)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/MarketplaceProviders/AbstractMarketplaceProviderCommercialExtensionActivationService.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/MarketplaceProviders/AbstractMarketplaceProviderCommercialExtensionActivationService.php
@@ -44,8 +44,25 @@ abstract class AbstractMarketplaceProviderCommercialExtensionActivationService e
             throw new HTTPRequestNotSuccessfulException($response->get_error_message());
         }
 
+        /** @var mixed $body */
+        $body = json_decode($response['body'], true);
+
         $statusCode = (int) wp_remote_retrieve_response_code($response);
         if ($statusCode < 200 || $statusCode >= 300) {
+            /**
+             * Even when the HTTP request failed (non-2xx status code), the
+             * Marketplace Provider may still return a JSON body with a
+             * meaningful error message (e.g. FluentCart returns a 422 with
+             * error_type "activation_limit_exceeded" when the license's
+             * activation limit has been reached). Surface that message
+             * instead of the generic HTTP status code error.
+             */
+            if (is_array($body)) {
+                $error = $this->getErrorFromResponseBody($body, $response);
+                if ($error !== null) {
+                    throw new LicenseOperationNotSuccessfulException($error);
+                }
+            }
             throw new HTTPRequestNotSuccessfulException(
                 sprintf(
                     $this->__('Request to "%s" failed with HTTP status code %d: %s', 'gatographql'),
@@ -55,9 +72,6 @@ abstract class AbstractMarketplaceProviderCommercialExtensionActivationService e
                 )
             );
         }
-
-        /** @var mixed $body */
-        $body = json_decode($response['body'], true);
 
         if (!is_array($body)) {
             throw new LicenseOperationNotSuccessfulException(


### PR DESCRIPTION
## Problem

When a license activation/validation request returns a non-2xx HTTP status code, `AbstractMarketplaceProviderCommercialExtensionActivationService::handleLicenseOperation()` threw a generic `HTTPRequestNotSuccessfulException` **before decoding the response body** — discarding any meaningful error the Marketplace Provider returned.

For example, FluentCart returns a **422** with a useful JSON body when a license's activation limit has been reached:

```json
{
    "message": "This license key has no activation limit. Please upgrade or purchase a new license.",
    "error_type": "activation_limit_exceeded",
    "success": false
}
```

…yet the user only saw:

> Activating license for "…" produced error: Request to "…=activate_license" failed with HTTP status code 422: Unprocessable Entity

## Fix

Decode the JSON body before the status-code check. On a non-2xx response, first try `getErrorFromResponseBody()` (already implemented per-provider) and throw `LicenseOperationNotSuccessfulException` with the provider's own message. Fall back to the generic HTTP error only when the body has no parseable provider error, preserving prior behavior for opaque failures.

The user now sees:

> Activating license for "…" produced error: This license key has no activation limit. Please upgrade or purchase a new license.

The fix lives in the base class, so every Marketplace Provider benefits — no subclass change needed.

## Verification

- `php -l` — no syntax errors
- PHPCS — passes
- PHPStan level 8 — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)