### PR TITLE
Harden i18n: msgfmt --check + guard translate script against non-string output

### DIFF
--- a/.github/workflows/i18n_check.yml
+++ b/.github/workflows/i18n_check.yml
@@ -32,6 +32,9 @@ jobs:
                 env:
                     COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+            -   name: Install gettext (provides msgfmt)
+                run: sudo apt-get update && sudo apt-get install -y gettext
+
             -   name: Install Composer dependencies
                 uses: ramsey/composer-install@v4
 

--- a/ci/i18n/check.sh
+++ b/ci/i18n/check.sh
@@ -44,6 +44,15 @@ while IFS= read -r locale; do
         echo "ERROR: $locale incomplete ($stats). Run: composer i18n-translate"
         fail=1
     fi
+    # Validate gettext correctness (format-spec / plural-header). GNU msgfmt on CI
+    # does this by default and fails when compiling; a lenient local msgfmt does
+    # not, so run it explicitly with --check to catch malformed translations up
+    # front, with the offending locale and line number.
+    if ! cerr=$(msgfmt --check -o /dev/null "$po" 2>&1); then
+        echo "ERROR: $locale has invalid gettext data:"
+        echo "$cerr"
+        fail=1
+    fi
 done < "$LOCALES_FILE"
 
 if [ "$fail" -eq 0 ]; then

--- a/ci/i18n/compile.sh
+++ b/ci/i18n/compile.sh
@@ -19,7 +19,10 @@ while IFS= read -r locale; do
     [ -z "$locale" ] && continue
     po="$LANG_DIR/gatographql-$locale.po"
     [ -f "$po" ] || continue
-    msgfmt "$po" -o "$LANG_DIR/gatographql-$locale.mo"
+    # --check mirrors GNU msgfmt's default-strict behavior on CI (format-spec
+    # and plural-header validation), so a lenient local msgfmt can't let a
+    # malformed catalog through that then fails when compiled on CI.
+    msgfmt --check "$po" -o "$LANG_DIR/gatographql-$locale.mo"
     wp_i18n i18n make-php "$po" "$LANG_DIR/" >/dev/null 2>&1 || true
     echo "  gatographql-$locale.mo"
 done < "$LOCALES_FILE"

--- a/ci/i18n/translate-po.php
+++ b/ci/i18n/translate-po.php
@@ -208,8 +208,8 @@ function translateChunk(array $chunk, string $language, string $locale, string $
     $failed = [];
     foreach (array_values($chunk) as $i => $translation) {
         $key = (string) ($i + 1);
-        if (is_array($result) && isset($result[$key]) && (string) $result[$key] !== '') {
-            $translation->setTranslation((string) $result[$key]);
+        if (is_array($result) && isset($result[$key]) && is_string($result[$key]) && $result[$key] !== '') {
+            $translation->setTranslation($result[$key]);
             $done++;
         } else {
             $failed[] = $translation;
@@ -370,14 +370,28 @@ if ($limit === 0) {
         }
         foreach ($chunk as $i => $translation) {
             $key = (string) ($i + 1);
-            if (isset($result[$key]) && is_array($result[$key]) && count($result[$key]) >= $nplurals) {
-                $forms = array_values(array_map('strval', $result[$key]));
-                $translation->setTranslation($forms[0]);
-                if ($nplurals > 1) {
-                    $translation->setPluralTranslations(array_slice($forms, 1, $nplurals - 1));
-                }
-                $done++;
+            if (!isset($result[$key]) || !is_array($result[$key])) {
+                continue;
             }
+            $forms = array_slice(array_values($result[$key]), 0, $nplurals);
+            if (count($forms) < $nplurals) {
+                continue;
+            }
+            $allStrings = true;
+            foreach ($forms as $form) {
+                if (!is_string($form) || $form === '') {
+                    $allStrings = false;
+                    break;
+                }
+            }
+            if (!$allStrings) {
+                continue;
+            }
+            $translation->setTranslation($forms[0]);
+            if ($nplurals > 1) {
+                $translation->setPluralTranslations(array_slice($forms, 1, $nplurals - 1));
+            }
+            $done++;
         }
         $translations->toPoFile($poFile);
         printf("  plural batch %d: %d entries (%d total)\n", $chunkIndex + 1, count($chunk), $done);


### PR DESCRIPTION
Two defensive fixes to the translation tooling under `ci/i18n/`.

## 1. msgfmt strictness parity

`compile.sh` compiled each catalog with a plain `msgfmt`, and `check.sh` only validated completeness (fuzzy/untranslated). A **lenient local `msgfmt`** (e.g. Homebrew's non-GNU `gettext` build) skips format-spec and plural-header checks, whereas **GNU `msgfmt` on CI runs them by default** and fails the compile — so a malformed catalog can pass locally yet break CI.

- `compile.sh` now uses `msgfmt --check` (parity with CI's default-strict behavior).
- `check.sh` adds a per-locale `msgfmt --check` validity pass that reports the offending **locale + line number** up front.

The current base catalogs already pass `--check`; this is preventative.

## 2. "Array" corruption guard in `translate-po.php`

When the model returned a nested array/object for a (plural) key, `array_map('strval', $result[$key])` cast each sub-value to the literal string `"Array"` and persisted it — silently corrupting the catalog and later failing `msgfmt`'s format checks. The singular path had the same unguarded `(string) $result[$key]` cast.

Both paths now require a **non-empty string** before writing; nested arrays, objects, and empty values are left untranslated and retried on the next run instead of being saved as `"Array"`.

Verified: a well-formed `["singular","plural"]` is written; nested `[["…"],["…"]]` and empty forms are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)