### PR TITLE
Make taxonomy term ordering deterministic with a term-ID tiebreaker

### DIFF
--- a/layers/CMSSchema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
+++ b/layers/CMSSchema/packages/categories-wp/src/TypeAPIs/AbstractCategoryTypeAPI.php
@@ -137,7 +137,9 @@ abstract class AbstractCategoryTypeAPI extends AbstractTaxonomyTypeAPI implement
             return [];
         }
 
-        return get_categories($query);
+        return $this->executeTermQueryWithStableOrder(
+            static fn () => get_categories($query)
+        );
     }
 
     /**

--- a/layers/CMSSchema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
+++ b/layers/CMSSchema/packages/tags-wp/src/TypeAPIs/AbstractTagTypeAPI.php
@@ -149,7 +149,9 @@ abstract class AbstractTagTypeAPI extends AbstractTaxonomyTypeAPI implements Tag
             return [];
         }
 
-        $tags = get_tags($query);
+        $tags = $this->executeTermQueryWithStableOrder(
+            static fn () => get_tags($query)
+        );
         if ($tags instanceof WP_Error) {
             return [];
         }

--- a/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/AbstractTaxonomyTypeAPI.php
+++ b/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/AbstractTaxonomyTypeAPI.php
@@ -15,17 +15,17 @@ use WP_Error;
 use WP_Post;
 use WP_Term;
 
-use function add_filter;
 use function esc_sql;
 use function get_term;
 use function get_term_by;
 use function get_term_link;
 use function get_terms;
-use function remove_filter;
 use function wp_get_post_terms;
 
 abstract class AbstractTaxonomyTypeAPI extends AbstractBasicService implements TaxonomyTypeAPIInterface
 {
+    use StableTaxonomyTermOrderTrait;
+
     public const HOOK_QUERY = __CLASS__ . ':query';
     public final const HOOK_ORDERBY_QUERY_ARG_VALUE = __CLASS__ . ':orderby-query-arg-value';
 
@@ -354,47 +354,6 @@ abstract class AbstractTaxonomyTypeAPI extends AbstractBasicService implements T
         }
 
         return (int) $count;
-    }
-
-    /**
-     * Execute a term-fetching callback with a deterministic secondary
-     * ordering by term ID, so that terms sharing the same primary sort
-     * value (eg: terms with a duplicate name) are always returned in a
-     * stable order, instead of relying on the database's arbitrary order
-     * for ties.
-     *
-     * The tiebreaker is applied via the `terms_clauses` filter, so it works
-     * for `get_terms()` and its wrappers (`get_categories()`, `get_tags()`),
-     * preserving the primary sort direction.
-     *
-     * @template T
-     * @param callable(): T $executeQueryCallback
-     * @return T
-     */
-    protected function executeTermQueryWithStableOrder(callable $executeQueryCallback): mixed
-    {
-        /**
-         * @param array<string,string> $clauses
-         * @return array<string,string>
-         */
-        $addTermIDTiebreaker = static function (array $clauses): array {
-            $orderby = $clauses['orderby'] ?? '';
-            if ($orderby === '' || str_contains($orderby, 't.term_id')) {
-                return $clauses;
-            }
-            $order = trim($clauses['order'] ?? '');
-            $columns = (string) preg_replace('/^ORDER BY\s+/i', '', $orderby);
-            $tiebreakerOrder = $order !== '' ? $order : 'ASC';
-            $clauses['orderby'] = sprintf('ORDER BY %s %s, t.term_id %s', $columns, $order, $tiebreakerOrder);
-            $clauses['order'] = '';
-            return $clauses;
-        };
-        add_filter('terms_clauses', $addTermIDTiebreaker);
-        try {
-            return $executeQueryCallback();
-        } finally {
-            remove_filter('terms_clauses', $addTermIDTiebreaker);
-        }
     }
 
     protected function getTaxonomyTerm(

--- a/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/AbstractTaxonomyTypeAPI.php
+++ b/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/AbstractTaxonomyTypeAPI.php
@@ -15,11 +15,13 @@ use WP_Error;
 use WP_Post;
 use WP_Term;
 
+use function add_filter;
 use function esc_sql;
 use function get_term;
 use function get_term_by;
 use function get_term_link;
 use function get_terms;
+use function remove_filter;
 use function wp_get_post_terms;
 
 abstract class AbstractTaxonomyTypeAPI extends AbstractBasicService implements TaxonomyTypeAPIInterface
@@ -352,6 +354,47 @@ abstract class AbstractTaxonomyTypeAPI extends AbstractBasicService implements T
         }
 
         return (int) $count;
+    }
+
+    /**
+     * Execute a term-fetching callback with a deterministic secondary
+     * ordering by term ID, so that terms sharing the same primary sort
+     * value (eg: terms with a duplicate name) are always returned in a
+     * stable order, instead of relying on the database's arbitrary order
+     * for ties.
+     *
+     * The tiebreaker is applied via the `terms_clauses` filter, so it works
+     * for `get_terms()` and its wrappers (`get_categories()`, `get_tags()`),
+     * preserving the primary sort direction.
+     *
+     * @template T
+     * @param callable(): T $executeQueryCallback
+     * @return T
+     */
+    protected function executeTermQueryWithStableOrder(callable $executeQueryCallback): mixed
+    {
+        /**
+         * @param array<string,string> $clauses
+         * @return array<string,string>
+         */
+        $addTermIDTiebreaker = static function (array $clauses): array {
+            $orderby = $clauses['orderby'] ?? '';
+            if ($orderby === '' || str_contains($orderby, 't.term_id')) {
+                return $clauses;
+            }
+            $order = trim($clauses['order'] ?? '');
+            $columns = (string) preg_replace('/^ORDER BY\s+/i', '', $orderby);
+            $tiebreakerOrder = $order !== '' ? $order : 'ASC';
+            $clauses['orderby'] = sprintf('ORDER BY %s %s, t.term_id %s', $columns, $order, $tiebreakerOrder);
+            $clauses['order'] = '';
+            return $clauses;
+        };
+        add_filter('terms_clauses', $addTermIDTiebreaker);
+        try {
+            return $executeQueryCallback();
+        } finally {
+            remove_filter('terms_clauses', $addTermIDTiebreaker);
+        }
     }
 
     protected function getTaxonomyTerm(

--- a/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/StableTaxonomyTermOrderTrait.php
+++ b/layers/CMSSchema/packages/taxonomies-wp/src/TypeAPIs/StableTaxonomyTermOrderTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\TaxonomiesWP\TypeAPIs;
+
+use function add_filter;
+use function remove_filter;
+
+trait StableTaxonomyTermOrderTrait
+{
+    /**
+     * Execute a term-fetching callback with a deterministic secondary
+     * ordering by term ID, so that terms sharing the same primary sort
+     * value (eg: terms with a duplicate name) are always returned in a
+     * stable order, instead of relying on the database's arbitrary order
+     * for ties.
+     *
+     * The tiebreaker is applied via the `terms_clauses` filter, so it works
+     * for `get_terms()` and its wrappers (`get_categories()`, `get_tags()`),
+     * preserving the primary sort direction.
+     *
+     * @template T
+     * @param callable(): T $executeQueryCallback
+     * @return T
+     */
+    protected function executeTermQueryWithStableOrder(callable $executeQueryCallback): mixed
+    {
+        /**
+         * @param array<string,string> $clauses
+         * @return array<string,string>
+         */
+        $addTermIDTiebreaker = static function (array $clauses): array {
+            $orderby = $clauses['orderby'] ?? '';
+            if ($orderby === '' || str_contains($orderby, 't.term_id')) {
+                return $clauses;
+            }
+            $order = trim($clauses['order'] ?? '');
+            $columns = (string) preg_replace('/^ORDER BY\s+/i', '', $orderby);
+            $tiebreakerOrder = $order !== '' ? $order : 'ASC';
+            $clauses['orderby'] = sprintf('ORDER BY %s %s, t.term_id %s', $columns, $order, $tiebreakerOrder);
+            $clauses['order'] = '';
+            return $clauses;
+        };
+        add_filter('terms_clauses', $addTermIDTiebreaker);
+        try {
+            return $executeQueryCallback();
+        } finally {
+            remove_filter('terms_clauses', $addTermIDTiebreaker);
+        }
+    }
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## 19.1.0 - DATE
 
+### Fixed
+
+- Made the ordering of taxonomy terms (eg: categories and tags) deterministic by adding a stable secondary sort by term ID, so that terms sharing the same primary sort value (eg: a duplicate name) are always returned in a consistent order when sorting and paginating (#3354)
+
 ## 19.0.2 - 13/07/2026
 
 ### Fixed

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
@@ -1,1 +1,5 @@
 # Release Notes: 19.1
+
+## Fixes
+
+- Made the ordering of taxonomy terms (such as categories and tags) deterministic by adding a stable secondary sort by term ID, so that terms sharing the same primary sort value (such as a duplicate name) are always returned in a consistent order when sorting and paginating.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -247,6 +247,9 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 == Changelog ==
 
+= 19.1.0 =
+* Fixed - Made the ordering of taxonomy terms (eg: categories and tags) deterministic by adding a stable secondary sort by term ID, so that terms sharing the same primary sort value (eg: a duplicate name) are always returned in a consistent order when sorting and paginating (#3354)
+
 = 19.0.1 =
 * Improved - Distribute Gato GraphQL plugin via the Gato Plugins store (instead of wordpress.org) (#3347)
 


### PR DESCRIPTION
## Problem

When fetching taxonomy terms (eg: categories, tags), terms that share the same primary sort value — for example, several categories with the same name — were returned in the database's arbitrary order for the tie. This made sorted and paginated term lists non-deterministic: the same query could return the tied terms in a different order across requests.

## Fix

Route the category and tag term queries through a shared helper (`AbstractTaxonomyTypeAPI::executeTermQueryWithStableOrder()`) that appends a secondary `ORDER BY …, t.term_id` via the `terms_clauses` filter, preserving the primary sort direction. Ties now resolve consistently by term ID.

The helper wraps the `get_categories()` and `get_tags()` calls (both of which run through `get_terms()`), so the tiebreaker applies to all taxonomy term list queries without changing their primary ordering.

## Notes

- No behavior change for queries whose primary sort has no ties.
- PHPStan (level 8) and PSR-12 pass on the changed files.