### PR TITLE
Add user create/update/delete mutations

### DIFF
--- a/layers/CMSSchema/packages/user-mutations-wp/src/Module.php
+++ b/layers/CMSSchema/packages/user-mutations-wp/src/Module.php
@@ -26,6 +26,7 @@ class Module extends AbstractModule
     {
         return [
             \PoPCMSSchema\UserMutations\Module::class,
+            \PoPCMSSchema\UsersWP\Module::class,
             \PoPCMSSchema\UserStateMutationsWP\Module::class,
         ];
     }

--- a/layers/CMSSchema/packages/user-mutations-wp/src/TypeAPIs/UserTypeMutationAPI.php
+++ b/layers/CMSSchema/packages/user-mutations-wp/src/TypeAPIs/UserTypeMutationAPI.php
@@ -4,11 +4,24 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserMutationsWP\TypeAPIs;
 
+use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
 use PoPCMSSchema\UserMutations\TypeAPIs\UserTypeMutationAPIInterface;
 use PoP\ComponentModel\App;
 use PoP\Root\Services\AbstractBasicService;
+use WP_Error;
+use WP_User;
 
+use function current_user_can;
+use function get_role;
+use function is_email;
+use function is_multisite;
+use function is_wp_error;
 use function user_can;
+use function wp_delete_user;
+use function wp_insert_user;
+use function wp_send_new_user_notifications;
+use function wp_slash;
+use function wp_update_user;
 
 class UserTypeMutationAPI extends AbstractBasicService implements UserTypeMutationAPIInterface
 {
@@ -17,5 +30,210 @@ class UserTypeMutationAPI extends AbstractBasicService implements UserTypeMutati
         $loggedInUserID = App::getState('current-user-id');
         return ((int) $loggedInUserID === (int) $userID)
             || user_can((int)$loggedInUserID, 'edit_users');
+    }
+
+    public function canLoggedInUserCreateUsers(): bool
+    {
+        return current_user_can('create_users');
+    }
+
+    public function canLoggedInUserDeleteUsers(): bool
+    {
+        return current_user_can('delete_users');
+    }
+
+    public function canLoggedInUserDeleteUser(string|int $userID): bool
+    {
+        return current_user_can('delete_user', (int) $userID);
+    }
+
+    public function canLoggedInUserPromoteUsers(): bool
+    {
+        return current_user_can('promote_users');
+    }
+
+    public function isMultisite(): bool
+    {
+        return is_multisite();
+    }
+
+    public function roleExists(string $role): bool
+    {
+        return get_role($role) !== null;
+    }
+
+    public function isValidEmail(string $email): bool
+    {
+        return is_email($email) !== false;
+    }
+
+    /**
+     * @throws UserCRUDMutationException In case of error
+     * @param array<string,mixed> $userData
+     */
+    public function createUser(
+        array $userData,
+    ): string|int {
+        $this->assertNotMultisite();
+
+        /** @var string[]|null */
+        $roles = $userData['roles'] ?? null;
+        /** @var bool */
+        $sendEmailNotification = $userData['sendEmailNotification'] ?? false;
+
+        $args = $this->convertUserData($userData);
+
+        $userIDOrError = wp_insert_user(wp_slash($args));
+        if (is_wp_error($userIDOrError)) {
+            /** @var WP_Error */
+            $wpError = $userIDOrError;
+            throw new UserCRUDMutationException(
+                $wpError->get_error_message()
+            );
+        }
+
+        /** @var int */
+        $userID = $userIDOrError;
+
+        $this->applyUserRoles($userID, $roles);
+
+        if ($sendEmailNotification) {
+            wp_send_new_user_notifications($userID, 'user');
+        }
+
+        return $userID;
+    }
+
+    /**
+     * @throws UserCRUDMutationException In case of error
+     * @param array<string,mixed> $userData
+     */
+    public function updateUser(
+        array $userData,
+    ): string|int {
+        $this->assertNotMultisite();
+
+        /** @var string|int */
+        $userID = $userData['id'];
+        /** @var string[]|null */
+        $roles = $userData['roles'] ?? null;
+        $rolesProvided = array_key_exists('roles', $userData);
+
+        $args = $this->convertUserData($userData);
+        $args['ID'] = $userID;
+
+        $userIDOrError = wp_update_user(wp_slash($args));
+        if (is_wp_error($userIDOrError)) {
+            /** @var WP_Error */
+            $wpError = $userIDOrError;
+            throw new UserCRUDMutationException(
+                $wpError->get_error_message()
+            );
+        }
+
+        if ($rolesProvided) {
+            $this->applyUserRoles($userID, $roles);
+        }
+
+        return $userID;
+    }
+
+    /**
+     * @throws UserCRUDMutationException In case of error
+     */
+    public function deleteUser(
+        string|int $userID,
+        string|int|null $reassignAuthorContentToUserID,
+    ): void {
+        $this->assertNotMultisite();
+
+        // `wp_delete_user` lives in the admin includes
+        // @phpstan-ignore-next-line
+        require_once ABSPATH . 'wp-admin/includes/user.php';
+
+        $reassign = $reassignAuthorContentToUserID === null
+            ? null
+            : (int) $reassignAuthorContentToUserID;
+
+        $deleted = wp_delete_user((int) $userID, $reassign);
+        if (!$deleted) {
+            throw new UserCRUDMutationException(
+                sprintf(
+                    $this->__('The user with ID \'%s\' could not be deleted', 'gatographql'),
+                    $userID
+                )
+            );
+        }
+    }
+
+    /**
+     * User CRUD mutations are not supported on a multisite network,
+     * where the user model (network-wide users, per-blog roles) differs.
+     *
+     * @throws UserCRUDMutationException If running on a multisite network
+     */
+    protected function assertNotMultisite(): void
+    {
+        if (!$this->isMultisite()) {
+            return;
+        }
+        throw new UserCRUDMutationException(
+            $this->__('User mutations are not supported on a multisite network', 'gatographql')
+        );
+    }
+
+    /**
+     * @param string[]|null $roles
+     */
+    protected function applyUserRoles(
+        string|int $userID,
+        ?array $roles,
+    ): void {
+        if ($roles === null) {
+            return;
+        }
+        $user = new WP_User((int) $userID);
+        if ($roles === []) {
+            $user->set_role('');
+            return;
+        }
+        $user->set_role($roles[0]);
+        foreach (array_slice($roles, 1) as $role) {
+            $user->add_role($role);
+        }
+    }
+
+    /**
+     * Convert the input data into the args expected by
+     * `wp_insert_user` / `wp_update_user`.
+     *
+     * @param array<string,mixed> $userData
+     * @return array<string,mixed>
+     */
+    protected function convertUserData(array $userData): array
+    {
+        $args = [];
+        foreach (
+            [
+            'username' => 'user_login',
+            'email' => 'user_email',
+            'password' => 'user_pass',
+            'slug' => 'user_nicename',
+            'websiteURL' => 'user_url',
+            'displayName' => 'display_name',
+            'firstName' => 'first_name',
+            'lastName' => 'last_name',
+            'nickname' => 'nickname',
+            'description' => 'description',
+            'locale' => 'locale',
+            'registeredDate' => 'user_registered',
+            ] as $inputKey => $wpKey
+        ) {
+            if (!array_key_exists($inputKey, $userData)) {
+                continue;
+            }
+            $args[$wpKey] = $userData[$inputKey];
+        }
+        return $args;
     }
 }

--- a/layers/CMSSchema/packages/user-mutations/config/schema-services.yaml
+++ b/layers/CMSSchema/packages/user-mutations/config/schema-services.yaml
@@ -3,8 +3,17 @@ services:
         public: true
         autowire: true
 
+    PoPCMSSchema\UserMutations\FieldResolvers\:
+        resource: '../src/FieldResolvers/*'
+
+    PoPCMSSchema\UserMutations\MutationResolvers\:
+        resource: '../src/MutationResolvers/*'
+
     PoPCMSSchema\UserMutations\TypeResolvers\:
         resource: '../src/TypeResolvers/*'
 
     PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\:
         resource: '../src/RelationalTypeDataLoaders/*'
+
+    PoPCMSSchema\UserMutations\ObjectTypeResolverPickers\:
+        resource: '../src/ObjectTypeResolverPickers/*'

--- a/layers/CMSSchema/packages/user-mutations/src/Constants/MutationInputProperties.php
+++ b/layers/CMSSchema/packages/user-mutations/src/Constants/MutationInputProperties.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\Constants;
+
+class MutationInputProperties
+{
+    public final const INPUT = 'input';
+    public final const ID = 'id';
+    public final const USERNAME = 'username';
+    public final const EMAIL = 'email';
+    public final const PASSWORD = 'password';
+    public final const ROLES = 'roles';
+    public final const FIRST_NAME = 'firstName';
+    public final const LAST_NAME = 'lastName';
+    public final const NICKNAME = 'nickname';
+    public final const DISPLAY_NAME = 'displayName';
+    public final const SLUG = 'slug';
+    public final const WEBSITE_URL = 'websiteURL';
+    public final const DESCRIPTION = 'description';
+    public final const LOCALE = 'locale';
+    public final const REGISTERED_DATE = 'registeredDate';
+    public final const SEND_EMAIL_NOTIFICATION = 'sendEmailNotification';
+    public final const REASSIGN_AUTHOR_CONTENT_TO = 'reassignAuthorContentTo';
+}

--- a/layers/CMSSchema/packages/user-mutations/src/Constants/UserCRUDHookNames.php
+++ b/layers/CMSSchema/packages/user-mutations/src/Constants/UserCRUDHookNames.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\Constants;
+
+class UserCRUDHookNames
+{
+    public final const CREATE_OR_UPDATE_USER = __CLASS__ . ':createOrUpdateUser';
+    public final const CREATE_USER = __CLASS__ . ':createUser';
+    public final const UPDATE_USER = __CLASS__ . ':updateUser';
+    public final const DELETE_USER = __CLASS__ . ':deleteUser';
+
+    public final const VALIDATE_CREATE_OR_UPDATE_USER = __CLASS__ . ':validateCreateOrUpdateUser';
+    public final const VALIDATE_CREATE_USER = __CLASS__ . ':validateCreateUser';
+    public final const VALIDATE_UPDATE_USER = __CLASS__ . ':validateUpdateUser';
+    public final const VALIDATE_DELETE_USER = __CLASS__ . ':validateDeleteUser';
+
+    public final const GET_CREATE_OR_UPDATE_USER_DATA = __CLASS__ . ':getCreateOrUpdateUserData';
+    public final const GET_CREATE_USER_DATA = __CLASS__ . ':getCreateUserData';
+    public final const GET_UPDATE_USER_DATA = __CLASS__ . ':getUpdateUserData';
+
+    public final const ERROR_PAYLOAD = __CLASS__ . ':errorPayload';
+}

--- a/layers/CMSSchema/packages/user-mutations/src/Environment.php
+++ b/layers/CMSSchema/packages/user-mutations/src/Environment.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations;
+
+class Environment
+{
+    public final const USE_PAYLOADABLE_USER_MUTATIONS = 'USE_PAYLOADABLE_USER_MUTATIONS';
+    public final const ADD_FIELDS_TO_QUERY_PAYLOADABLE_USER_MUTATIONS = 'ADD_FIELDS_TO_QUERY_PAYLOADABLE_USER_MUTATIONS';
+}

--- a/layers/CMSSchema/packages/user-mutations/src/Exception/UserCRUDMutationException.php
+++ b/layers/CMSSchema/packages/user-mutations/src/Exception/UserCRUDMutationException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\Exception;
+
+use PoPSchema\SchemaCommons\Exception\AbstractPayloadClientException;
+
+final class UserCRUDMutationException extends AbstractPayloadClientException
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/FeedbackItemProviders/MutationErrorFeedbackItemProvider.php
+++ b/layers/CMSSchema/packages/user-mutations/src/FeedbackItemProviders/MutationErrorFeedbackItemProvider.php
@@ -13,6 +13,16 @@ class MutationErrorFeedbackItemProvider extends AbstractFeedbackItemProvider
     public final const E2 = 'e2';
     public final const E3 = 'e3';
     public final const E4 = 'e4';
+    public final const E5 = 'e5';
+    public final const E7 = 'e7';
+    public final const E8 = 'e8';
+    public final const E9 = 'e9';
+    public final const E10 = 'e10';
+    public final const E11 = 'e11';
+    public final const E12 = 'e12';
+    public final const E13 = 'e13';
+    public final const E14 = 'e14';
+    public final const E15 = 'e15';
 
     /**
      * @return string[]
@@ -24,6 +34,16 @@ class MutationErrorFeedbackItemProvider extends AbstractFeedbackItemProvider
             self::E2,
             self::E3,
             self::E4,
+            self::E5,
+            self::E7,
+            self::E8,
+            self::E9,
+            self::E10,
+            self::E11,
+            self::E12,
+            self::E13,
+            self::E14,
+            self::E15,
         ];
     }
 
@@ -34,6 +54,16 @@ class MutationErrorFeedbackItemProvider extends AbstractFeedbackItemProvider
             self::E2 => $this->__('There is no user with username \'%s\'', 'gatographql'),
             self::E3 => $this->__('There is no user with email \'%s\'', 'gatographql'),
             self::E4 => $this->__('The logged-in user doesn\'t have the ability to edit user with ID \'%s\'', 'gatographql'),
+            self::E5 => $this->__('You must be logged in to perform this action', 'gatographql'),
+            self::E7 => $this->__('You don\'t have permission to create users', 'gatographql'),
+            self::E8 => $this->__('You don\'t have permission to delete user with ID \'%s\'', 'gatographql'),
+            self::E9 => $this->__('You don\'t have permission to edit user roles', 'gatographql'),
+            self::E10 => $this->__('The username \'%s\' already exists', 'gatographql'),
+            self::E11 => $this->__('The email \'%s\' already belongs to another user', 'gatographql'),
+            self::E12 => $this->__('The email \'%s\' is not valid', 'gatographql'),
+            self::E13 => $this->__('The user role \'%s\' does not exist', 'gatographql'),
+            self::E14 => $this->__('There is no user with ID \'%s\' to reassign the content to', 'gatographql'),
+            self::E15 => $this->__('You cannot delete your own user account', 'gatographql'),
             default => parent::getMessagePlaceholder($code),
         };
     }

--- a/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/RootCreateUserMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/RootCreateUserMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\FieldResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\RootCreateUserMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootCreateUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\FieldResolvers\ObjectType\AbstractErrorsFieldTransientOperationPayloadObjectTypeFieldResolver;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+
+class RootCreateUserMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver extends AbstractErrorsFieldTransientOperationPayloadObjectTypeFieldResolver
+{
+    private ?RootCreateUserMutationErrorPayloadUnionTypeResolver $rootCreateUserMutationErrorPayloadUnionTypeResolver = null;
+
+    final protected function getRootCreateUserMutationErrorPayloadUnionTypeResolver(): RootCreateUserMutationErrorPayloadUnionTypeResolver
+    {
+        if ($this->rootCreateUserMutationErrorPayloadUnionTypeResolver === null) {
+            /** @var RootCreateUserMutationErrorPayloadUnionTypeResolver */
+            $rootCreateUserMutationErrorPayloadUnionTypeResolver = $this->instanceManager->getInstance(RootCreateUserMutationErrorPayloadUnionTypeResolver::class);
+            $this->rootCreateUserMutationErrorPayloadUnionTypeResolver = $rootCreateUserMutationErrorPayloadUnionTypeResolver;
+        }
+        return $this->rootCreateUserMutationErrorPayloadUnionTypeResolver;
+    }
+
+    /**
+     * @return array<class-string<ObjectTypeResolverInterface>>
+     */
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            RootCreateUserMutationPayloadObjectTypeResolver::class,
+        ];
+    }
+
+    protected function getErrorsFieldFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return $this->getRootCreateUserMutationErrorPayloadUnionTypeResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/RootDeleteUserMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/RootDeleteUserMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\FieldResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\RootDeleteUserMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootDeleteUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\FieldResolvers\ObjectType\AbstractErrorsFieldTransientOperationPayloadObjectTypeFieldResolver;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+
+class RootDeleteUserMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver extends AbstractErrorsFieldTransientOperationPayloadObjectTypeFieldResolver
+{
+    private ?RootDeleteUserMutationErrorPayloadUnionTypeResolver $rootDeleteUserMutationErrorPayloadUnionTypeResolver = null;
+
+    final protected function getRootDeleteUserMutationErrorPayloadUnionTypeResolver(): RootDeleteUserMutationErrorPayloadUnionTypeResolver
+    {
+        if ($this->rootDeleteUserMutationErrorPayloadUnionTypeResolver === null) {
+            /** @var RootDeleteUserMutationErrorPayloadUnionTypeResolver */
+            $rootDeleteUserMutationErrorPayloadUnionTypeResolver = $this->instanceManager->getInstance(RootDeleteUserMutationErrorPayloadUnionTypeResolver::class);
+            $this->rootDeleteUserMutationErrorPayloadUnionTypeResolver = $rootDeleteUserMutationErrorPayloadUnionTypeResolver;
+        }
+        return $this->rootDeleteUserMutationErrorPayloadUnionTypeResolver;
+    }
+
+    /**
+     * @return array<class-string<ObjectTypeResolverInterface>>
+     */
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            RootDeleteUserMutationPayloadObjectTypeResolver::class,
+        ];
+    }
+
+    protected function getErrorsFieldFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return $this->getRootDeleteUserMutationErrorPayloadUnionTypeResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -1,0 +1,566 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\FieldResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\Module;
+use PoPCMSSchema\UserMutations\ModuleConfiguration;
+use PoPCMSSchema\UserMutations\MutationResolvers\CreateUserBulkOperationMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\CreateUserMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\DeleteUserBulkOperationMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\DeleteUserMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\PayloadableCreateUserBulkOperationMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\PayloadableCreateUserMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\PayloadableDeleteUserBulkOperationMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\PayloadableDeleteUserMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\PayloadableUpdateUserBulkOperationMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\PayloadableUpdateUserMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\UpdateUserBulkOperationMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\UpdateUserMutationResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType\RootCreateUserInputObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType\RootDeleteUserInputObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType\RootUpdateUserInputObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\RootCreateUserMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\RootDeleteUserMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\RootUpdateUserMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\Users\TypeResolvers\ObjectType\UserObjectTypeResolver;
+use PoPCMSSchema\SchemaCommons\FieldResolvers\ObjectType\BulkOperationDecoratorObjectTypeFieldResolverTrait;
+use PoPCMSSchema\SchemaCommons\FieldResolvers\ObjectType\MutationPayloadObjectsObjectTypeFieldResolverTrait;
+use PoPCMSSchema\UserState\Checkpoints\UserLoggedInCheckpoint;
+use PoP\ComponentModel\Checkpoints\CheckpointInterface;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
+use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
+use PoP\Engine\Module as EngineModule;
+use PoP\Engine\ModuleConfiguration as EngineModuleConfiguration;
+use PoP\Engine\TypeResolvers\ObjectType\RootObjectTypeResolver;
+use PoP\Root\App;
+
+class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
+{
+    use MutationPayloadObjectsObjectTypeFieldResolverTrait;
+    use BulkOperationDecoratorObjectTypeFieldResolverTrait;
+
+    private ?UserObjectTypeResolver $userObjectTypeResolver = null;
+    private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
+    private ?UserLoggedInCheckpoint $userLoggedInCheckpoint = null;
+    private ?CreateUserMutationResolver $createUserMutationResolver = null;
+    private ?CreateUserBulkOperationMutationResolver $createUserBulkOperationMutationResolver = null;
+    private ?UpdateUserMutationResolver $updateUserMutationResolver = null;
+    private ?UpdateUserBulkOperationMutationResolver $updateUserBulkOperationMutationResolver = null;
+    private ?DeleteUserMutationResolver $deleteUserMutationResolver = null;
+    private ?DeleteUserBulkOperationMutationResolver $deleteUserBulkOperationMutationResolver = null;
+    private ?PayloadableCreateUserMutationResolver $payloadableCreateUserMutationResolver = null;
+    private ?PayloadableCreateUserBulkOperationMutationResolver $payloadableCreateUserBulkOperationMutationResolver = null;
+    private ?PayloadableUpdateUserMutationResolver $payloadableUpdateUserMutationResolver = null;
+    private ?PayloadableUpdateUserBulkOperationMutationResolver $payloadableUpdateUserBulkOperationMutationResolver = null;
+    private ?PayloadableDeleteUserMutationResolver $payloadableDeleteUserMutationResolver = null;
+    private ?PayloadableDeleteUserBulkOperationMutationResolver $payloadableDeleteUserBulkOperationMutationResolver = null;
+    private ?RootCreateUserInputObjectTypeResolver $rootCreateUserInputObjectTypeResolver = null;
+    private ?RootUpdateUserInputObjectTypeResolver $rootUpdateUserInputObjectTypeResolver = null;
+    private ?RootDeleteUserInputObjectTypeResolver $rootDeleteUserInputObjectTypeResolver = null;
+    private ?RootCreateUserMutationPayloadObjectTypeResolver $rootCreateUserMutationPayloadObjectTypeResolver = null;
+    private ?RootUpdateUserMutationPayloadObjectTypeResolver $rootUpdateUserMutationPayloadObjectTypeResolver = null;
+    private ?RootDeleteUserMutationPayloadObjectTypeResolver $rootDeleteUserMutationPayloadObjectTypeResolver = null;
+
+    final protected function getUserObjectTypeResolver(): UserObjectTypeResolver
+    {
+        if ($this->userObjectTypeResolver === null) {
+            /** @var UserObjectTypeResolver */
+            $userObjectTypeResolver = $this->instanceManager->getInstance(UserObjectTypeResolver::class);
+            $this->userObjectTypeResolver = $userObjectTypeResolver;
+        }
+        return $this->userObjectTypeResolver;
+    }
+    final protected function getBooleanScalarTypeResolver(): BooleanScalarTypeResolver
+    {
+        if ($this->booleanScalarTypeResolver === null) {
+            /** @var BooleanScalarTypeResolver */
+            $booleanScalarTypeResolver = $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
+            $this->booleanScalarTypeResolver = $booleanScalarTypeResolver;
+        }
+        return $this->booleanScalarTypeResolver;
+    }
+    final protected function getUserLoggedInCheckpoint(): UserLoggedInCheckpoint
+    {
+        if ($this->userLoggedInCheckpoint === null) {
+            /** @var UserLoggedInCheckpoint */
+            $userLoggedInCheckpoint = $this->instanceManager->getInstance(UserLoggedInCheckpoint::class);
+            $this->userLoggedInCheckpoint = $userLoggedInCheckpoint;
+        }
+        return $this->userLoggedInCheckpoint;
+    }
+    final protected function getCreateUserMutationResolver(): CreateUserMutationResolver
+    {
+        if ($this->createUserMutationResolver === null) {
+            /** @var CreateUserMutationResolver */
+            $createUserMutationResolver = $this->instanceManager->getInstance(CreateUserMutationResolver::class);
+            $this->createUserMutationResolver = $createUserMutationResolver;
+        }
+        return $this->createUserMutationResolver;
+    }
+    final protected function getCreateUserBulkOperationMutationResolver(): CreateUserBulkOperationMutationResolver
+    {
+        if ($this->createUserBulkOperationMutationResolver === null) {
+            /** @var CreateUserBulkOperationMutationResolver */
+            $createUserBulkOperationMutationResolver = $this->instanceManager->getInstance(CreateUserBulkOperationMutationResolver::class);
+            $this->createUserBulkOperationMutationResolver = $createUserBulkOperationMutationResolver;
+        }
+        return $this->createUserBulkOperationMutationResolver;
+    }
+    final protected function getUpdateUserMutationResolver(): UpdateUserMutationResolver
+    {
+        if ($this->updateUserMutationResolver === null) {
+            /** @var UpdateUserMutationResolver */
+            $updateUserMutationResolver = $this->instanceManager->getInstance(UpdateUserMutationResolver::class);
+            $this->updateUserMutationResolver = $updateUserMutationResolver;
+        }
+        return $this->updateUserMutationResolver;
+    }
+    final protected function getUpdateUserBulkOperationMutationResolver(): UpdateUserBulkOperationMutationResolver
+    {
+        if ($this->updateUserBulkOperationMutationResolver === null) {
+            /** @var UpdateUserBulkOperationMutationResolver */
+            $updateUserBulkOperationMutationResolver = $this->instanceManager->getInstance(UpdateUserBulkOperationMutationResolver::class);
+            $this->updateUserBulkOperationMutationResolver = $updateUserBulkOperationMutationResolver;
+        }
+        return $this->updateUserBulkOperationMutationResolver;
+    }
+    final protected function getDeleteUserMutationResolver(): DeleteUserMutationResolver
+    {
+        if ($this->deleteUserMutationResolver === null) {
+            /** @var DeleteUserMutationResolver */
+            $deleteUserMutationResolver = $this->instanceManager->getInstance(DeleteUserMutationResolver::class);
+            $this->deleteUserMutationResolver = $deleteUserMutationResolver;
+        }
+        return $this->deleteUserMutationResolver;
+    }
+    final protected function getDeleteUserBulkOperationMutationResolver(): DeleteUserBulkOperationMutationResolver
+    {
+        if ($this->deleteUserBulkOperationMutationResolver === null) {
+            /** @var DeleteUserBulkOperationMutationResolver */
+            $deleteUserBulkOperationMutationResolver = $this->instanceManager->getInstance(DeleteUserBulkOperationMutationResolver::class);
+            $this->deleteUserBulkOperationMutationResolver = $deleteUserBulkOperationMutationResolver;
+        }
+        return $this->deleteUserBulkOperationMutationResolver;
+    }
+    final protected function getPayloadableCreateUserMutationResolver(): PayloadableCreateUserMutationResolver
+    {
+        if ($this->payloadableCreateUserMutationResolver === null) {
+            /** @var PayloadableCreateUserMutationResolver */
+            $payloadableCreateUserMutationResolver = $this->instanceManager->getInstance(PayloadableCreateUserMutationResolver::class);
+            $this->payloadableCreateUserMutationResolver = $payloadableCreateUserMutationResolver;
+        }
+        return $this->payloadableCreateUserMutationResolver;
+    }
+    final protected function getPayloadableCreateUserBulkOperationMutationResolver(): PayloadableCreateUserBulkOperationMutationResolver
+    {
+        if ($this->payloadableCreateUserBulkOperationMutationResolver === null) {
+            /** @var PayloadableCreateUserBulkOperationMutationResolver */
+            $payloadableCreateUserBulkOperationMutationResolver = $this->instanceManager->getInstance(PayloadableCreateUserBulkOperationMutationResolver::class);
+            $this->payloadableCreateUserBulkOperationMutationResolver = $payloadableCreateUserBulkOperationMutationResolver;
+        }
+        return $this->payloadableCreateUserBulkOperationMutationResolver;
+    }
+    final protected function getPayloadableUpdateUserMutationResolver(): PayloadableUpdateUserMutationResolver
+    {
+        if ($this->payloadableUpdateUserMutationResolver === null) {
+            /** @var PayloadableUpdateUserMutationResolver */
+            $payloadableUpdateUserMutationResolver = $this->instanceManager->getInstance(PayloadableUpdateUserMutationResolver::class);
+            $this->payloadableUpdateUserMutationResolver = $payloadableUpdateUserMutationResolver;
+        }
+        return $this->payloadableUpdateUserMutationResolver;
+    }
+    final protected function getPayloadableUpdateUserBulkOperationMutationResolver(): PayloadableUpdateUserBulkOperationMutationResolver
+    {
+        if ($this->payloadableUpdateUserBulkOperationMutationResolver === null) {
+            /** @var PayloadableUpdateUserBulkOperationMutationResolver */
+            $payloadableUpdateUserBulkOperationMutationResolver = $this->instanceManager->getInstance(PayloadableUpdateUserBulkOperationMutationResolver::class);
+            $this->payloadableUpdateUserBulkOperationMutationResolver = $payloadableUpdateUserBulkOperationMutationResolver;
+        }
+        return $this->payloadableUpdateUserBulkOperationMutationResolver;
+    }
+    final protected function getPayloadableDeleteUserMutationResolver(): PayloadableDeleteUserMutationResolver
+    {
+        if ($this->payloadableDeleteUserMutationResolver === null) {
+            /** @var PayloadableDeleteUserMutationResolver */
+            $payloadableDeleteUserMutationResolver = $this->instanceManager->getInstance(PayloadableDeleteUserMutationResolver::class);
+            $this->payloadableDeleteUserMutationResolver = $payloadableDeleteUserMutationResolver;
+        }
+        return $this->payloadableDeleteUserMutationResolver;
+    }
+    final protected function getPayloadableDeleteUserBulkOperationMutationResolver(): PayloadableDeleteUserBulkOperationMutationResolver
+    {
+        if ($this->payloadableDeleteUserBulkOperationMutationResolver === null) {
+            /** @var PayloadableDeleteUserBulkOperationMutationResolver */
+            $payloadableDeleteUserBulkOperationMutationResolver = $this->instanceManager->getInstance(PayloadableDeleteUserBulkOperationMutationResolver::class);
+            $this->payloadableDeleteUserBulkOperationMutationResolver = $payloadableDeleteUserBulkOperationMutationResolver;
+        }
+        return $this->payloadableDeleteUserBulkOperationMutationResolver;
+    }
+    final protected function getRootCreateUserInputObjectTypeResolver(): RootCreateUserInputObjectTypeResolver
+    {
+        if ($this->rootCreateUserInputObjectTypeResolver === null) {
+            /** @var RootCreateUserInputObjectTypeResolver */
+            $rootCreateUserInputObjectTypeResolver = $this->instanceManager->getInstance(RootCreateUserInputObjectTypeResolver::class);
+            $this->rootCreateUserInputObjectTypeResolver = $rootCreateUserInputObjectTypeResolver;
+        }
+        return $this->rootCreateUserInputObjectTypeResolver;
+    }
+    final protected function getRootUpdateUserInputObjectTypeResolver(): RootUpdateUserInputObjectTypeResolver
+    {
+        if ($this->rootUpdateUserInputObjectTypeResolver === null) {
+            /** @var RootUpdateUserInputObjectTypeResolver */
+            $rootUpdateUserInputObjectTypeResolver = $this->instanceManager->getInstance(RootUpdateUserInputObjectTypeResolver::class);
+            $this->rootUpdateUserInputObjectTypeResolver = $rootUpdateUserInputObjectTypeResolver;
+        }
+        return $this->rootUpdateUserInputObjectTypeResolver;
+    }
+    final protected function getRootDeleteUserInputObjectTypeResolver(): RootDeleteUserInputObjectTypeResolver
+    {
+        if ($this->rootDeleteUserInputObjectTypeResolver === null) {
+            /** @var RootDeleteUserInputObjectTypeResolver */
+            $rootDeleteUserInputObjectTypeResolver = $this->instanceManager->getInstance(RootDeleteUserInputObjectTypeResolver::class);
+            $this->rootDeleteUserInputObjectTypeResolver = $rootDeleteUserInputObjectTypeResolver;
+        }
+        return $this->rootDeleteUserInputObjectTypeResolver;
+    }
+    final protected function getRootCreateUserMutationPayloadObjectTypeResolver(): RootCreateUserMutationPayloadObjectTypeResolver
+    {
+        if ($this->rootCreateUserMutationPayloadObjectTypeResolver === null) {
+            /** @var RootCreateUserMutationPayloadObjectTypeResolver */
+            $rootCreateUserMutationPayloadObjectTypeResolver = $this->instanceManager->getInstance(RootCreateUserMutationPayloadObjectTypeResolver::class);
+            $this->rootCreateUserMutationPayloadObjectTypeResolver = $rootCreateUserMutationPayloadObjectTypeResolver;
+        }
+        return $this->rootCreateUserMutationPayloadObjectTypeResolver;
+    }
+    final protected function getRootUpdateUserMutationPayloadObjectTypeResolver(): RootUpdateUserMutationPayloadObjectTypeResolver
+    {
+        if ($this->rootUpdateUserMutationPayloadObjectTypeResolver === null) {
+            /** @var RootUpdateUserMutationPayloadObjectTypeResolver */
+            $rootUpdateUserMutationPayloadObjectTypeResolver = $this->instanceManager->getInstance(RootUpdateUserMutationPayloadObjectTypeResolver::class);
+            $this->rootUpdateUserMutationPayloadObjectTypeResolver = $rootUpdateUserMutationPayloadObjectTypeResolver;
+        }
+        return $this->rootUpdateUserMutationPayloadObjectTypeResolver;
+    }
+    final protected function getRootDeleteUserMutationPayloadObjectTypeResolver(): RootDeleteUserMutationPayloadObjectTypeResolver
+    {
+        if ($this->rootDeleteUserMutationPayloadObjectTypeResolver === null) {
+            /** @var RootDeleteUserMutationPayloadObjectTypeResolver */
+            $rootDeleteUserMutationPayloadObjectTypeResolver = $this->instanceManager->getInstance(RootDeleteUserMutationPayloadObjectTypeResolver::class);
+            $this->rootDeleteUserMutationPayloadObjectTypeResolver = $rootDeleteUserMutationPayloadObjectTypeResolver;
+        }
+        return $this->rootDeleteUserMutationPayloadObjectTypeResolver;
+    }
+
+    /**
+     * @return array<class-string<ObjectTypeResolverInterface>>
+     */
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            RootObjectTypeResolver::class,
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFieldNamesToResolve(): array
+    {
+        /** @var EngineModuleConfiguration */
+        $engineModuleConfiguration = App::getModule(EngineModule::class)->getConfiguration();
+        $disableRedundantRootTypeMutationFields = $engineModuleConfiguration->disableRedundantRootTypeMutationFields();
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $addFieldsToQueryPayloadableUserMutations = $moduleConfiguration->addFieldsToQueryPayloadableUserMutations();
+        return array_merge(
+            [
+                'createUser',
+                'createUsers',
+            ],
+            !$disableRedundantRootTypeMutationFields ? [
+                'updateUser',
+                'updateUsers',
+                'deleteUser',
+                'deleteUsers',
+            ] : [],
+            $addFieldsToQueryPayloadableUserMutations ? [
+                'createUserMutationPayloadObjects',
+            ] : [],
+            $addFieldsToQueryPayloadableUserMutations && !$disableRedundantRootTypeMutationFields ? [
+                'updateUserMutationPayloadObjects',
+                'deleteUserMutationPayloadObjects',
+            ] : [],
+        );
+    }
+
+    public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
+    {
+        return match ($fieldName) {
+            'createUser' => $this->__('Create a user', 'gatographql'),
+            'createUsers' => $this->__('Create users', 'gatographql'),
+            'updateUser' => $this->__('Update a user', 'gatographql'),
+            'updateUsers' => $this->__('Update users', 'gatographql'),
+            'deleteUser' => $this->__('Delete a user', 'gatographql'),
+            'deleteUsers' => $this->__('Delete users', 'gatographql'),
+            'createUserMutationPayloadObjects' => $this->__('Retrieve the payload objects from a recently-executed `createUser` mutation', 'gatographql'),
+            'updateUserMutationPayloadObjects' => $this->__('Retrieve the payload objects from a recently-executed `updateUser` mutation', 'gatographql'),
+            'deleteUserMutationPayloadObjects' => $this->__('Retrieve the payload objects from a recently-executed `deleteUser` mutation', 'gatographql'),
+            default => parent::getFieldDescription($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
+    {
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $usePayloadableUserMutations = $moduleConfiguration->usePayloadableUserMutations();
+        if (!$usePayloadableUserMutations) {
+            return match ($fieldName) {
+                'createUser',
+                'updateUser'
+                    => SchemaTypeModifiers::NONE,
+                'deleteUser'
+                    => SchemaTypeModifiers::NON_NULLABLE,
+                'createUsers',
+                'updateUsers'
+                    => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY,
+                'deleteUsers'
+                    => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
+                default
+                    => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
+            };
+        }
+
+        if (
+            in_array($fieldName, [
+            'createUserMutationPayloadObjects',
+            'updateUserMutationPayloadObjects',
+            'deleteUserMutationPayloadObjects',
+            ])
+        ) {
+            return $this->getMutationPayloadObjectsFieldTypeModifiers();
+        }
+
+        return match ($fieldName) {
+            'createUser',
+            'updateUser',
+            'deleteUser'
+                => SchemaTypeModifiers::NON_NULLABLE,
+            'createUsers',
+            'updateUsers',
+            'deleteUsers'
+                => SchemaTypeModifiers::NON_NULLABLE | SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
+            default
+                => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @return array<string,InputTypeResolverInterface>
+     */
+    public function getFieldArgNameTypeResolvers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): array
+    {
+        return match ($fieldName) {
+            'createUser' => [
+                'input' => $this->getRootCreateUserInputObjectTypeResolver(),
+            ],
+            'createUsers' => $this->getBulkOperationFieldArgNameTypeResolvers($this->getRootCreateUserInputObjectTypeResolver()),
+            'updateUser' => [
+                'input' => $this->getRootUpdateUserInputObjectTypeResolver(),
+            ],
+            'updateUsers' => $this->getBulkOperationFieldArgNameTypeResolvers($this->getRootUpdateUserInputObjectTypeResolver()),
+            'deleteUser' => [
+                'input' => $this->getRootDeleteUserInputObjectTypeResolver(),
+            ],
+            'deleteUsers' => $this->getBulkOperationFieldArgNameTypeResolvers($this->getRootDeleteUserInputObjectTypeResolver()),
+            'createUserMutationPayloadObjects',
+            'updateUserMutationPayloadObjects',
+            'deleteUserMutationPayloadObjects'
+                => $this->getMutationPayloadObjectsFieldArgNameTypeResolvers(),
+            default
+                => parent::getFieldArgNameTypeResolvers($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldArgTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): int
+    {
+        if (
+            in_array($fieldName, [
+            'createUserMutationPayloadObjects',
+            'updateUserMutationPayloadObjects',
+            'deleteUserMutationPayloadObjects',
+            ])
+        ) {
+            return $this->getMutationPayloadObjectsFieldArgTypeModifiers($fieldArgName)
+                ?? parent::getFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName);
+        }
+
+        if (
+            in_array($fieldName, [
+            'createUsers',
+            'updateUsers',
+            'deleteUsers',
+            ])
+        ) {
+            return $this->getBulkOperationFieldArgTypeModifiers($fieldArgName)
+                ?? parent::getFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName);
+        }
+
+        return match ([$fieldName => $fieldArgName]) {
+            ['createUser' => 'input'],
+            ['updateUser' => 'input'],
+            ['deleteUser' => 'input']
+                => SchemaTypeModifiers::MANDATORY,
+            default => parent::getFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName),
+        };
+    }
+
+    public function getFieldArgDefaultValue(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): mixed
+    {
+        if (
+            in_array($fieldName, [
+            'createUsers',
+            'updateUsers',
+            'deleteUsers',
+            ])
+        ) {
+            return $this->getBulkOperationFieldArgDefaultValue($fieldArgName)
+                ?? parent::getFieldArgDefaultValue($objectTypeResolver, $fieldName, $fieldArgName);
+        }
+
+        return parent::getFieldArgDefaultValue($objectTypeResolver, $fieldName, $fieldArgName);
+    }
+
+    public function getFieldMutationResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?MutationResolverInterface
+    {
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $usePayloadableUserMutations = $moduleConfiguration->usePayloadableUserMutations();
+        return match ($fieldName) {
+            'createUser' => $usePayloadableUserMutations
+                ? $this->getPayloadableCreateUserMutationResolver()
+                : $this->getCreateUserMutationResolver(),
+            'createUsers' => $usePayloadableUserMutations
+                ? $this->getPayloadableCreateUserBulkOperationMutationResolver()
+                : $this->getCreateUserBulkOperationMutationResolver(),
+            'updateUser' => $usePayloadableUserMutations
+                ? $this->getPayloadableUpdateUserMutationResolver()
+                : $this->getUpdateUserMutationResolver(),
+            'updateUsers' => $usePayloadableUserMutations
+                ? $this->getPayloadableUpdateUserBulkOperationMutationResolver()
+                : $this->getUpdateUserBulkOperationMutationResolver(),
+            'deleteUser' => $usePayloadableUserMutations
+                ? $this->getPayloadableDeleteUserMutationResolver()
+                : $this->getDeleteUserMutationResolver(),
+            'deleteUsers' => $usePayloadableUserMutations
+                ? $this->getPayloadableDeleteUserBulkOperationMutationResolver()
+                : $this->getDeleteUserBulkOperationMutationResolver(),
+            default => parent::getFieldMutationResolver($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $usePayloadableUserMutations = $moduleConfiguration->usePayloadableUserMutations();
+        if ($usePayloadableUserMutations) {
+            return match ($fieldName) {
+                'createUser',
+                'createUsers',
+                'createUserMutationPayloadObjects'
+                    => $this->getRootCreateUserMutationPayloadObjectTypeResolver(),
+                'updateUser',
+                'updateUsers',
+                'updateUserMutationPayloadObjects'
+                    => $this->getRootUpdateUserMutationPayloadObjectTypeResolver(),
+                'deleteUser',
+                'deleteUsers',
+                'deleteUserMutationPayloadObjects'
+                    => $this->getRootDeleteUserMutationPayloadObjectTypeResolver(),
+                default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+            };
+        }
+        return match ($fieldName) {
+            'createUser',
+            'createUsers',
+            'updateUser',
+            'updateUsers'
+                => $this->getUserObjectTypeResolver(),
+            'deleteUser',
+            'deleteUsers'
+                => $this->getBooleanScalarTypeResolver(),
+            default
+                => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @return CheckpointInterface[]
+     */
+    public function getValidationCheckpoints(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        object $object,
+    ): array {
+        $validationCheckpoints = parent::getValidationCheckpoints(
+            $objectTypeResolver,
+            $fieldDataAccessor,
+            $object,
+        );
+
+        /**
+         * For Payloadable: The "User Logged-in" checkpoint validation is not added,
+         * instead this validation is executed inside the mutation, so the error
+         * shows up in the Payload
+         *
+         * @var ModuleConfiguration
+         */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $usePayloadableUserMutations = $moduleConfiguration->usePayloadableUserMutations();
+        if ($usePayloadableUserMutations) {
+            return $validationCheckpoints;
+        }
+
+        switch ($fieldDataAccessor->getFieldName()) {
+            case 'createUser':
+            case 'createUsers':
+            case 'updateUser':
+            case 'updateUsers':
+            case 'deleteUser':
+            case 'deleteUsers':
+                $validationCheckpoints[] = $this->getUserLoggedInCheckpoint();
+                break;
+        }
+        return $validationCheckpoints;
+    }
+
+    public function resolveValue(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        object $object,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
+        $fieldName = $fieldDataAccessor->getFieldName();
+        switch ($fieldName) {
+            case 'createUserMutationPayloadObjects':
+            case 'updateUserMutationPayloadObjects':
+            case 'deleteUserMutationPayloadObjects':
+                return $this->resolveMutationPayloadObjectsValue(
+                    $objectTypeResolver,
+                    $fieldDataAccessor,
+                );
+        }
+
+        return parent::resolveValue($objectTypeResolver, $object, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/RootUpdateUserMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/RootUpdateUserMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\FieldResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\RootUpdateUserMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\FieldResolvers\ObjectType\AbstractErrorsFieldTransientOperationPayloadObjectTypeFieldResolver;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+
+class RootUpdateUserMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver extends AbstractErrorsFieldTransientOperationPayloadObjectTypeFieldResolver
+{
+    private ?RootUpdateUserMutationErrorPayloadUnionTypeResolver $rootUpdateUserMutationErrorPayloadUnionTypeResolver = null;
+
+    final protected function getRootUpdateUserMutationErrorPayloadUnionTypeResolver(): RootUpdateUserMutationErrorPayloadUnionTypeResolver
+    {
+        if ($this->rootUpdateUserMutationErrorPayloadUnionTypeResolver === null) {
+            /** @var RootUpdateUserMutationErrorPayloadUnionTypeResolver */
+            $rootUpdateUserMutationErrorPayloadUnionTypeResolver = $this->instanceManager->getInstance(RootUpdateUserMutationErrorPayloadUnionTypeResolver::class);
+            $this->rootUpdateUserMutationErrorPayloadUnionTypeResolver = $rootUpdateUserMutationErrorPayloadUnionTypeResolver;
+        }
+        return $this->rootUpdateUserMutationErrorPayloadUnionTypeResolver;
+    }
+
+    /**
+     * @return array<class-string<ObjectTypeResolverInterface>>
+     */
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            RootUpdateUserMutationPayloadObjectTypeResolver::class,
+        ];
+    }
+
+    protected function getErrorsFieldFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return $this->getRootUpdateUserMutationErrorPayloadUnionTypeResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/UserDeleteMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/UserDeleteMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\FieldResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\UserDeleteMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\UserDeleteMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\FieldResolvers\ObjectType\AbstractErrorsFieldTransientOperationPayloadObjectTypeFieldResolver;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+
+class UserDeleteMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver extends AbstractErrorsFieldTransientOperationPayloadObjectTypeFieldResolver
+{
+    private ?UserDeleteMutationErrorPayloadUnionTypeResolver $userDeleteMutationErrorPayloadUnionTypeResolver = null;
+
+    final protected function getUserDeleteMutationErrorPayloadUnionTypeResolver(): UserDeleteMutationErrorPayloadUnionTypeResolver
+    {
+        if ($this->userDeleteMutationErrorPayloadUnionTypeResolver === null) {
+            /** @var UserDeleteMutationErrorPayloadUnionTypeResolver */
+            $userDeleteMutationErrorPayloadUnionTypeResolver = $this->instanceManager->getInstance(UserDeleteMutationErrorPayloadUnionTypeResolver::class);
+            $this->userDeleteMutationErrorPayloadUnionTypeResolver = $userDeleteMutationErrorPayloadUnionTypeResolver;
+        }
+        return $this->userDeleteMutationErrorPayloadUnionTypeResolver;
+    }
+
+    /**
+     * @return array<class-string<ObjectTypeResolverInterface>>
+     */
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            UserDeleteMutationPayloadObjectTypeResolver::class,
+        ];
+    }
+
+    protected function getErrorsFieldFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return $this->getUserDeleteMutationErrorPayloadUnionTypeResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/UserMutationPayloadObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/UserMutationPayloadObjectTypeFieldResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\FieldResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\RootCreateUserMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\RootUpdateUserMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\UserUpdateMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\Users\TypeResolvers\ObjectType\UserObjectTypeResolver;
+use PoPSchema\SchemaCommons\FieldResolvers\ObjectType\AbstractObjectMutationPayloadObjectTypeFieldResolver;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+
+class UserMutationPayloadObjectTypeFieldResolver extends AbstractObjectMutationPayloadObjectTypeFieldResolver
+{
+    private ?UserObjectTypeResolver $userObjectTypeResolver = null;
+
+    final protected function getUserObjectTypeResolver(): UserObjectTypeResolver
+    {
+        if ($this->userObjectTypeResolver === null) {
+            /** @var UserObjectTypeResolver */
+            $userObjectTypeResolver = $this->instanceManager->getInstance(UserObjectTypeResolver::class);
+            $this->userObjectTypeResolver = $userObjectTypeResolver;
+        }
+        return $this->userObjectTypeResolver;
+    }
+
+    /**
+     * @return array<class-string<ObjectTypeResolverInterface>>
+     */
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            RootCreateUserMutationPayloadObjectTypeResolver::class,
+            RootUpdateUserMutationPayloadObjectTypeResolver::class,
+            UserUpdateMutationPayloadObjectTypeResolver::class,
+        ];
+    }
+
+    protected function getObjectFieldName(): string
+    {
+        return 'user';
+    }
+
+    public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return match ($fieldName) {
+            $this->getObjectFieldName() => $this->getUserObjectTypeResolver(),
+            default
+                => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/UserMutationTransientEntityOperationPayloadObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/UserMutationTransientEntityOperationPayloadObjectTypeFieldResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\FieldResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\RootCreateUserMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\RootUpdateUserMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\UserUpdateMutationPayloadObjectTypeResolver;
+use PoPSchema\SchemaCommons\FieldResolvers\ObjectType\AbstractTransientEntityOperationPayloadObjectTypeFieldResolver;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+
+class UserMutationTransientEntityOperationPayloadObjectTypeFieldResolver extends AbstractTransientEntityOperationPayloadObjectTypeFieldResolver
+{
+    protected function getObjectIDFieldName(): string
+    {
+        return 'userID';
+    }
+
+    /**
+     * @return array<class-string<ObjectTypeResolverInterface>>
+     */
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            RootCreateUserMutationPayloadObjectTypeResolver::class,
+            RootUpdateUserMutationPayloadObjectTypeResolver::class,
+            UserUpdateMutationPayloadObjectTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/UserObjectTypeFieldResolver.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\FieldResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\Constants\MutationInputProperties;
+use PoPCMSSchema\UserMutations\Module;
+use PoPCMSSchema\UserMutations\ModuleConfiguration;
+use PoPCMSSchema\UserMutations\MutationResolvers\DeleteUserMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\PayloadableDeleteUserMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\PayloadableUpdateUserMutationResolver;
+use PoPCMSSchema\UserMutations\MutationResolvers\UpdateUserMutationResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType\UserDeleteInputObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType\UserUpdateInputObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\UserDeleteMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\UserUpdateMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\Users\TypeResolvers\ObjectType\UserObjectTypeResolver;
+use PoPCMSSchema\UserState\Checkpoints\UserLoggedInCheckpoint;
+use PoP\ComponentModel\App;
+use PoP\ComponentModel\Checkpoints\CheckpointInterface;
+use PoP\ComponentModel\FieldResolvers\ObjectType\AbstractObjectTypeFieldResolver;
+use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
+use PoP\GraphQLParser\Spec\Parser\Ast\FieldInterface;
+use stdClass;
+
+class UserObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
+{
+    private ?UserObjectTypeResolver $userObjectTypeResolver = null;
+    private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
+    private ?UserLoggedInCheckpoint $userLoggedInCheckpoint = null;
+    private ?UpdateUserMutationResolver $updateUserMutationResolver = null;
+    private ?PayloadableUpdateUserMutationResolver $payloadableUpdateUserMutationResolver = null;
+    private ?UserUpdateInputObjectTypeResolver $userUpdateInputObjectTypeResolver = null;
+    private ?UserUpdateMutationPayloadObjectTypeResolver $userUpdateMutationPayloadObjectTypeResolver = null;
+    private ?DeleteUserMutationResolver $deleteUserMutationResolver = null;
+    private ?PayloadableDeleteUserMutationResolver $payloadableDeleteUserMutationResolver = null;
+    private ?UserDeleteInputObjectTypeResolver $userDeleteInputObjectTypeResolver = null;
+    private ?UserDeleteMutationPayloadObjectTypeResolver $userDeleteMutationPayloadObjectTypeResolver = null;
+
+    final protected function getUserObjectTypeResolver(): UserObjectTypeResolver
+    {
+        if ($this->userObjectTypeResolver === null) {
+            /** @var UserObjectTypeResolver */
+            $userObjectTypeResolver = $this->instanceManager->getInstance(UserObjectTypeResolver::class);
+            $this->userObjectTypeResolver = $userObjectTypeResolver;
+        }
+        return $this->userObjectTypeResolver;
+    }
+    final protected function getBooleanScalarTypeResolver(): BooleanScalarTypeResolver
+    {
+        if ($this->booleanScalarTypeResolver === null) {
+            /** @var BooleanScalarTypeResolver */
+            $booleanScalarTypeResolver = $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
+            $this->booleanScalarTypeResolver = $booleanScalarTypeResolver;
+        }
+        return $this->booleanScalarTypeResolver;
+    }
+    final protected function getUserLoggedInCheckpoint(): UserLoggedInCheckpoint
+    {
+        if ($this->userLoggedInCheckpoint === null) {
+            /** @var UserLoggedInCheckpoint */
+            $userLoggedInCheckpoint = $this->instanceManager->getInstance(UserLoggedInCheckpoint::class);
+            $this->userLoggedInCheckpoint = $userLoggedInCheckpoint;
+        }
+        return $this->userLoggedInCheckpoint;
+    }
+    final protected function getUpdateUserMutationResolver(): UpdateUserMutationResolver
+    {
+        if ($this->updateUserMutationResolver === null) {
+            /** @var UpdateUserMutationResolver */
+            $updateUserMutationResolver = $this->instanceManager->getInstance(UpdateUserMutationResolver::class);
+            $this->updateUserMutationResolver = $updateUserMutationResolver;
+        }
+        return $this->updateUserMutationResolver;
+    }
+    final protected function getPayloadableUpdateUserMutationResolver(): PayloadableUpdateUserMutationResolver
+    {
+        if ($this->payloadableUpdateUserMutationResolver === null) {
+            /** @var PayloadableUpdateUserMutationResolver */
+            $payloadableUpdateUserMutationResolver = $this->instanceManager->getInstance(PayloadableUpdateUserMutationResolver::class);
+            $this->payloadableUpdateUserMutationResolver = $payloadableUpdateUserMutationResolver;
+        }
+        return $this->payloadableUpdateUserMutationResolver;
+    }
+    final protected function getUserUpdateInputObjectTypeResolver(): UserUpdateInputObjectTypeResolver
+    {
+        if ($this->userUpdateInputObjectTypeResolver === null) {
+            /** @var UserUpdateInputObjectTypeResolver */
+            $userUpdateInputObjectTypeResolver = $this->instanceManager->getInstance(UserUpdateInputObjectTypeResolver::class);
+            $this->userUpdateInputObjectTypeResolver = $userUpdateInputObjectTypeResolver;
+        }
+        return $this->userUpdateInputObjectTypeResolver;
+    }
+    final protected function getUserUpdateMutationPayloadObjectTypeResolver(): UserUpdateMutationPayloadObjectTypeResolver
+    {
+        if ($this->userUpdateMutationPayloadObjectTypeResolver === null) {
+            /** @var UserUpdateMutationPayloadObjectTypeResolver */
+            $userUpdateMutationPayloadObjectTypeResolver = $this->instanceManager->getInstance(UserUpdateMutationPayloadObjectTypeResolver::class);
+            $this->userUpdateMutationPayloadObjectTypeResolver = $userUpdateMutationPayloadObjectTypeResolver;
+        }
+        return $this->userUpdateMutationPayloadObjectTypeResolver;
+    }
+    final protected function getDeleteUserMutationResolver(): DeleteUserMutationResolver
+    {
+        if ($this->deleteUserMutationResolver === null) {
+            /** @var DeleteUserMutationResolver */
+            $deleteUserMutationResolver = $this->instanceManager->getInstance(DeleteUserMutationResolver::class);
+            $this->deleteUserMutationResolver = $deleteUserMutationResolver;
+        }
+        return $this->deleteUserMutationResolver;
+    }
+    final protected function getPayloadableDeleteUserMutationResolver(): PayloadableDeleteUserMutationResolver
+    {
+        if ($this->payloadableDeleteUserMutationResolver === null) {
+            /** @var PayloadableDeleteUserMutationResolver */
+            $payloadableDeleteUserMutationResolver = $this->instanceManager->getInstance(PayloadableDeleteUserMutationResolver::class);
+            $this->payloadableDeleteUserMutationResolver = $payloadableDeleteUserMutationResolver;
+        }
+        return $this->payloadableDeleteUserMutationResolver;
+    }
+    final protected function getUserDeleteInputObjectTypeResolver(): UserDeleteInputObjectTypeResolver
+    {
+        if ($this->userDeleteInputObjectTypeResolver === null) {
+            /** @var UserDeleteInputObjectTypeResolver */
+            $userDeleteInputObjectTypeResolver = $this->instanceManager->getInstance(UserDeleteInputObjectTypeResolver::class);
+            $this->userDeleteInputObjectTypeResolver = $userDeleteInputObjectTypeResolver;
+        }
+        return $this->userDeleteInputObjectTypeResolver;
+    }
+    final protected function getUserDeleteMutationPayloadObjectTypeResolver(): UserDeleteMutationPayloadObjectTypeResolver
+    {
+        if ($this->userDeleteMutationPayloadObjectTypeResolver === null) {
+            /** @var UserDeleteMutationPayloadObjectTypeResolver */
+            $userDeleteMutationPayloadObjectTypeResolver = $this->instanceManager->getInstance(UserDeleteMutationPayloadObjectTypeResolver::class);
+            $this->userDeleteMutationPayloadObjectTypeResolver = $userDeleteMutationPayloadObjectTypeResolver;
+        }
+        return $this->userDeleteMutationPayloadObjectTypeResolver;
+    }
+
+    /**
+     * @return array<class-string<ObjectTypeResolverInterface>>
+     */
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            UserObjectTypeResolver::class,
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getFieldNamesToResolve(): array
+    {
+        return [
+            'update',
+            'delete',
+        ];
+    }
+
+    public function getFieldDescription(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?string
+    {
+        return match ($fieldName) {
+            'update' => $this->__('Update the user', 'gatographql'),
+            'delete' => $this->__('Delete the user', 'gatographql'),
+            default => parent::getFieldDescription($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): int
+    {
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $usePayloadableUserMutations = $moduleConfiguration->usePayloadableUserMutations();
+        if (!$usePayloadableUserMutations) {
+            return match ($fieldName) {
+                'update' => SchemaTypeModifiers::NONE,
+                'delete' => SchemaTypeModifiers::NON_NULLABLE,
+                default => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
+            };
+        }
+        return match ($fieldName) {
+            'update',
+            'delete' => SchemaTypeModifiers::NON_NULLABLE,
+            default => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @return array<string,InputTypeResolverInterface>
+     */
+    public function getFieldArgNameTypeResolvers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): array
+    {
+        return match ($fieldName) {
+            'update' => [
+                'input' => $this->getUserUpdateInputObjectTypeResolver(),
+            ],
+            'delete' => [
+                'input' => $this->getUserDeleteInputObjectTypeResolver(),
+            ],
+            default => parent::getFieldArgNameTypeResolvers($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldArgTypeModifiers(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName, string $fieldArgName): int
+    {
+        return match ([$fieldName => $fieldArgName]) {
+            ['update' => 'input'] => SchemaTypeModifiers::MANDATORY,
+            default => parent::getFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName),
+        };
+    }
+
+    /**
+     * Validated the mutation on the object because the ID
+     * is obtained from the same object, so it's not originally
+     * present in the field argument in the query
+     */
+    public function validateMutationOnObject(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): bool
+    {
+        return match ($fieldName) {
+            'update',
+            'delete' => true,
+            default => parent::validateMutationOnObject($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @param array<string,mixed> $fieldArgsForMutationForObject
+     * @return array<string,mixed>
+     */
+    public function prepareFieldArgsForMutationForObject(
+        array $fieldArgsForMutationForObject,
+        ObjectTypeResolverInterface $objectTypeResolver,
+        FieldInterface $field,
+        object $object,
+    ): array {
+        $fieldArgsForMutationForObject = parent::prepareFieldArgsForMutationForObject(
+            $fieldArgsForMutationForObject,
+            $objectTypeResolver,
+            $field,
+            $object,
+        );
+        $user = $object;
+        switch ($field->getName()) {
+            case 'update':
+                /** @var stdClass */
+                $input = &$fieldArgsForMutationForObject['input'];
+                $input->{MutationInputProperties::ID} = $objectTypeResolver->getID($user);
+                break;
+            case 'delete':
+                /**
+                 * The "input" is optional, as it only carries the
+                 * `reassignAuthorContentTo` input field. Hence create it
+                 * if it was not provided.
+                 */
+                if (!isset($fieldArgsForMutationForObject['input'])) {
+                    $fieldArgsForMutationForObject['input'] = new stdClass();
+                }
+                $fieldArgsForMutationForObject['input']->{MutationInputProperties::ID} = $objectTypeResolver->getID($user);
+                break;
+        }
+        return $fieldArgsForMutationForObject;
+    }
+
+    public function getFieldMutationResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ?MutationResolverInterface
+    {
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $usePayloadableUserMutations = $moduleConfiguration->usePayloadableUserMutations();
+        return match ($fieldName) {
+            'update' => $usePayloadableUserMutations
+                ? $this->getPayloadableUpdateUserMutationResolver()
+                : $this->getUpdateUserMutationResolver(),
+            'delete' => $usePayloadableUserMutations
+                ? $this->getPayloadableDeleteUserMutationResolver()
+                : $this->getDeleteUserMutationResolver(),
+            default => parent::getFieldMutationResolver($objectTypeResolver, $fieldName),
+        };
+    }
+
+    public function getFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $usePayloadableUserMutations = $moduleConfiguration->usePayloadableUserMutations();
+        return match ($fieldName) {
+            'update' => $usePayloadableUserMutations
+                ? $this->getUserUpdateMutationPayloadObjectTypeResolver()
+                : $this->getUserObjectTypeResolver(),
+            'delete' => $usePayloadableUserMutations
+                ? $this->getUserDeleteMutationPayloadObjectTypeResolver()
+                : $this->getBooleanScalarTypeResolver(),
+            default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
+        };
+    }
+
+    /**
+     * @return CheckpointInterface[]
+     */
+    public function getValidationCheckpoints(
+        ObjectTypeResolverInterface $objectTypeResolver,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        object $object,
+    ): array {
+        $validationCheckpoints = parent::getValidationCheckpoints(
+            $objectTypeResolver,
+            $fieldDataAccessor,
+            $object,
+        );
+
+        /** @var ModuleConfiguration */
+        $moduleConfiguration = App::getModule(Module::class)->getConfiguration();
+        $usePayloadableUserMutations = $moduleConfiguration->usePayloadableUserMutations();
+        if ($usePayloadableUserMutations) {
+            return $validationCheckpoints;
+        }
+
+        switch ($fieldDataAccessor->getFieldName()) {
+            case 'update':
+            case 'delete':
+                $validationCheckpoints[] = $this->getUserLoggedInCheckpoint();
+                break;
+        }
+        return $validationCheckpoints;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/UserUpdateMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/FieldResolvers/ObjectType/UserUpdateMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\FieldResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\UserUpdateMutationPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\UserUpdateMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\FieldResolvers\ObjectType\AbstractErrorsFieldTransientOperationPayloadObjectTypeFieldResolver;
+use PoP\ComponentModel\TypeResolvers\ConcreteTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+
+class UserUpdateMutationPayloadErrorsFieldTransientOperationPayloadObjectTypeFieldResolver extends AbstractErrorsFieldTransientOperationPayloadObjectTypeFieldResolver
+{
+    private ?UserUpdateMutationErrorPayloadUnionTypeResolver $userUpdateMutationErrorPayloadUnionTypeResolver = null;
+
+    final protected function getUserUpdateMutationErrorPayloadUnionTypeResolver(): UserUpdateMutationErrorPayloadUnionTypeResolver
+    {
+        if ($this->userUpdateMutationErrorPayloadUnionTypeResolver === null) {
+            /** @var UserUpdateMutationErrorPayloadUnionTypeResolver */
+            $userUpdateMutationErrorPayloadUnionTypeResolver = $this->instanceManager->getInstance(UserUpdateMutationErrorPayloadUnionTypeResolver::class);
+            $this->userUpdateMutationErrorPayloadUnionTypeResolver = $userUpdateMutationErrorPayloadUnionTypeResolver;
+        }
+        return $this->userUpdateMutationErrorPayloadUnionTypeResolver;
+    }
+
+    /**
+     * @return array<class-string<ObjectTypeResolverInterface>>
+     */
+    public function getObjectTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            UserUpdateMutationPayloadObjectTypeResolver::class,
+        ];
+    }
+
+    protected function getErrorsFieldFieldTypeResolver(ObjectTypeResolverInterface $objectTypeResolver, string $fieldName): ConcreteTypeResolverInterface
+    {
+        return $this->getUserUpdateMutationErrorPayloadUnionTypeResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/Module.php
+++ b/layers/CMSSchema/packages/user-mutations/src/Module.php
@@ -20,6 +20,7 @@ class Module extends AbstractModule
     public function getDependedModuleClasses(): array
     {
         return [
+            \PoPCMSSchema\Users\Module::class,
             \PoPCMSSchema\UserStateMutations\Module::class,
         ];
     }

--- a/layers/CMSSchema/packages/user-mutations/src/ModuleConfiguration.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ModuleConfiguration.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations;
+
+use PoP\Root\Module\AbstractModuleConfiguration;
+use PoP\Root\Module\EnvironmentValueHelpers;
+
+class ModuleConfiguration extends AbstractModuleConfiguration
+{
+    /**
+     * Indicate if to return the errors in an ObjectMutationPayload
+     * object in the response, or if to use the top-level errors.
+     */
+    public function usePayloadableUserMutations(): bool
+    {
+        $envVariable = Environment::USE_PAYLOADABLE_USER_MUTATIONS;
+        $defaultValue = true;
+        $callback = EnvironmentValueHelpers::toBool(...);
+
+        return $this->retrieveConfigurationValueOrUseDefault(
+            $envVariable,
+            $defaultValue,
+            $callback,
+        );
+    }
+
+    public function addFieldsToQueryPayloadableUserMutations(): bool
+    {
+        if (!$this->usePayloadableUserMutations()) {
+            return false;
+        }
+
+        $envVariable = Environment::ADD_FIELDS_TO_QUERY_PAYLOADABLE_USER_MUTATIONS;
+        $defaultValue = false;
+        $callback = EnvironmentValueHelpers::toBool(...);
+
+        return $this->retrieveConfigurationValueOrUseDefault(
+            $envVariable,
+            $defaultValue,
+            $callback,
+        );
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/AbstractCreateOrUpdateUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/AbstractCreateOrUpdateUserMutationResolver.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use DateTime;
+use PoPCMSSchema\UserMutations\Constants\MutationInputProperties;
+use PoPCMSSchema\UserMutations\Constants\UserCRUDHookNames;
+use PoPCMSSchema\UserMutations\FeedbackItemProviders\MutationErrorFeedbackItemProvider;
+use PoPCMSSchema\UserMutations\TypeAPIs\UserTypeMutationAPIInterface;
+use PoPCMSSchema\Users\TypeAPIs\UserTypeAPIInterface;
+use PoPCMSSchema\UserStateMutations\MutationResolvers\ValidateUserLoggedInMutationResolverTrait;
+use PoP\ComponentModel\Feedback\FeedbackItemResolution;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedback;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\MutationResolvers\AbstractMutationResolver;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\Root\App;
+
+abstract class AbstractCreateOrUpdateUserMutationResolver extends AbstractMutationResolver
+{
+    use ValidateUserLoggedInMutationResolverTrait;
+    use UserMutationResolverTrait;
+
+    private ?UserTypeAPIInterface $userTypeAPI = null;
+    private ?UserTypeMutationAPIInterface $userTypeMutationAPI = null;
+
+    final protected function getUserTypeAPI(): UserTypeAPIInterface
+    {
+        if ($this->userTypeAPI === null) {
+            /** @var UserTypeAPIInterface */
+            $userTypeAPI = $this->instanceManager->getInstance(UserTypeAPIInterface::class);
+            $this->userTypeAPI = $userTypeAPI;
+        }
+        return $this->userTypeAPI;
+    }
+
+    final protected function getUserTypeMutationAPI(): UserTypeMutationAPIInterface
+    {
+        if ($this->userTypeMutationAPI === null) {
+            /** @var UserTypeMutationAPIInterface */
+            $userTypeMutationAPI = $this->instanceManager->getInstance(UserTypeMutationAPIInterface::class);
+            $this->userTypeMutationAPI = $userTypeMutationAPI;
+        }
+        return $this->userTypeMutationAPI;
+    }
+
+    protected function getUserNotLoggedInError(): FeedbackItemResolution
+    {
+        return new FeedbackItemResolution(
+            MutationErrorFeedbackItemProvider::class,
+            MutationErrorFeedbackItemProvider::E5,
+        );
+    }
+
+    abstract protected function addUserInputField(): bool;
+
+    public function validate(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        $errorCount = $objectTypeFieldResolutionFeedbackStore->getErrorCount();
+
+        // Check that the user is logged-in
+        $this->validateIsUserLoggedIn($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+        if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+            return;
+        }
+
+        // If updating, check that the user exists
+        if ($this->addUserInputField()) {
+            $userID = $this->getUserID($fieldDataAccessor);
+            $this->validateUserByIDExists($userID, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+            if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+                return;
+            }
+        }
+
+        // Check that the logged-in user has the capability to execute the mutation
+        $this->validateUserCanExecuteMutation($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+        if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+            return;
+        }
+
+        $this->validateEmail($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+        $this->validateRoles($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+
+        // Allow components to inject their own validations
+        App::doAction(
+            UserCRUDHookNames::VALIDATE_CREATE_OR_UPDATE_USER,
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore,
+        );
+    }
+
+    abstract protected function validateUserCanExecuteMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void;
+
+    protected function validateEmail(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        if (!$fieldDataAccessor->hasValue(MutationInputProperties::EMAIL)) {
+            return;
+        }
+        /** @var string|null */
+        $email = $fieldDataAccessor->getValue(MutationInputProperties::EMAIL);
+        if ($email === null || $email === '') {
+            return;
+        }
+
+        if (!$this->getUserTypeMutationAPI()->isValidEmail($email)) {
+            $objectTypeFieldResolutionFeedbackStore->addError(
+                new ObjectTypeFieldResolutionFeedback(
+                    new FeedbackItemResolution(
+                        MutationErrorFeedbackItemProvider::class,
+                        MutationErrorFeedbackItemProvider::E12,
+                        [
+                            $email,
+                        ]
+                    ),
+                    $fieldDataAccessor->getField(),
+                )
+            );
+            return;
+        }
+
+        $existingUser = $this->getUserTypeAPI()->getUserByEmail($email);
+        if ($existingUser === null) {
+            return;
+        }
+        $existingUserID = $this->getUserTypeAPI()->getUserID($existingUser);
+        $currentUserID = $this->addUserInputField() ? $this->getUserID($fieldDataAccessor) : null;
+        if ($currentUserID !== null && (int) $existingUserID === (int) $currentUserID) {
+            return;
+        }
+        $objectTypeFieldResolutionFeedbackStore->addError(
+            new ObjectTypeFieldResolutionFeedback(
+                new FeedbackItemResolution(
+                    MutationErrorFeedbackItemProvider::class,
+                    MutationErrorFeedbackItemProvider::E11,
+                    [
+                        $email,
+                    ]
+                ),
+                $fieldDataAccessor->getField(),
+            )
+        );
+    }
+
+    protected function validateRoles(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        if (!$fieldDataAccessor->hasValue(MutationInputProperties::ROLES)) {
+            return;
+        }
+        /** @var string[]|null */
+        $roles = $fieldDataAccessor->getValue(MutationInputProperties::ROLES);
+        if ($roles === null || $roles === []) {
+            return;
+        }
+
+        $errorCount = $objectTypeFieldResolutionFeedbackStore->getErrorCount();
+        foreach ($roles as $role) {
+            if ($this->getUserTypeMutationAPI()->roleExists($role)) {
+                continue;
+            }
+            $objectTypeFieldResolutionFeedbackStore->addError(
+                new ObjectTypeFieldResolutionFeedback(
+                    new FeedbackItemResolution(
+                        MutationErrorFeedbackItemProvider::class,
+                        MutationErrorFeedbackItemProvider::E13,
+                        [
+                            $role,
+                        ]
+                    ),
+                    $fieldDataAccessor->getField(),
+                )
+            );
+        }
+        if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+            return;
+        }
+
+        // Assigning roles requires the capability to promote users
+        if ($this->getUserTypeMutationAPI()->canLoggedInUserPromoteUsers()) {
+            return;
+        }
+        $objectTypeFieldResolutionFeedbackStore->addError(
+            new ObjectTypeFieldResolutionFeedback(
+                new FeedbackItemResolution(
+                    MutationErrorFeedbackItemProvider::class,
+                    MutationErrorFeedbackItemProvider::E9,
+                ),
+                $fieldDataAccessor->getField(),
+            )
+        );
+    }
+
+    protected function additionals(string|int $userID, FieldDataAccessorInterface $fieldDataAccessor): void
+    {
+        App::doAction(UserCRUDHookNames::CREATE_OR_UPDATE_USER, $userID, $fieldDataAccessor);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getUserData(FieldDataAccessorInterface $fieldDataAccessor): array
+    {
+        $userData = [];
+
+        foreach (
+            [
+            MutationInputProperties::USERNAME => 'username',
+            MutationInputProperties::EMAIL => 'email',
+            MutationInputProperties::PASSWORD => 'password',
+            MutationInputProperties::FIRST_NAME => 'firstName',
+            MutationInputProperties::LAST_NAME => 'lastName',
+            MutationInputProperties::NICKNAME => 'nickname',
+            MutationInputProperties::DISPLAY_NAME => 'displayName',
+            MutationInputProperties::SLUG => 'slug',
+            MutationInputProperties::WEBSITE_URL => 'websiteURL',
+            MutationInputProperties::DESCRIPTION => 'description',
+            MutationInputProperties::LOCALE => 'locale',
+            MutationInputProperties::ROLES => 'roles',
+            MutationInputProperties::SEND_EMAIL_NOTIFICATION => 'sendEmailNotification',
+            ] as $inputFieldName => $userDataKey
+        ) {
+            if (!$fieldDataAccessor->hasValue($inputFieldName)) {
+                continue;
+            }
+            $userData[$userDataKey] = $fieldDataAccessor->getValue($inputFieldName);
+        }
+
+        if ($fieldDataAccessor->hasValue(MutationInputProperties::REGISTERED_DATE)) {
+            /** @var DateTime|null */
+            $registeredDate = $fieldDataAccessor->getValue(MutationInputProperties::REGISTERED_DATE);
+            if ($registeredDate !== null) {
+                $userData['registeredDate'] = $registeredDate->format('Y-m-d H:i:s');
+            }
+        }
+
+        if ($this->addUserInputField()) {
+            $userData['id'] = $this->getUserID($fieldDataAccessor);
+        }
+
+        return App::applyFilters(
+            UserCRUDHookNames::GET_CREATE_OR_UPDATE_USER_DATA,
+            $userData,
+            $fieldDataAccessor,
+        );
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/AbstractCreateOrUpdateUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/AbstractCreateOrUpdateUserMutationResolver.php
@@ -203,7 +203,19 @@ abstract class AbstractCreateOrUpdateUserMutationResolver extends AbstractMutati
 
     protected function additionals(string|int $userID, FieldDataAccessorInterface $fieldDataAccessor): void
     {
-        App::doAction(UserCRUDHookNames::CREATE_OR_UPDATE_USER, $userID, $fieldDataAccessor);
+    }
+
+    protected function triggerExecuteCreateOrUpdateHook(
+        string|int $userID,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        App::doAction(
+            UserCRUDHookNames::CREATE_OR_UPDATE_USER,
+            $userID,
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore,
+        );
     }
 
     /**

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/AbstractDeleteUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/AbstractDeleteUserMutationResolver.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\UserMutations\Constants\MutationInputProperties;
+use PoPCMSSchema\UserMutations\Constants\UserCRUDHookNames;
+use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
+use PoPCMSSchema\UserMutations\FeedbackItemProviders\MutationErrorFeedbackItemProvider;
+use PoPCMSSchema\UserMutations\TypeAPIs\UserTypeMutationAPIInterface;
+use PoPCMSSchema\Users\TypeAPIs\UserTypeAPIInterface;
+use PoPCMSSchema\UserStateMutations\MutationResolvers\ValidateUserLoggedInMutationResolverTrait;
+use PoP\ComponentModel\Feedback\FeedbackItemResolution;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedback;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\MutationResolvers\AbstractMutationResolver;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\Root\App;
+
+abstract class AbstractDeleteUserMutationResolver extends AbstractMutationResolver
+{
+    use DeleteUserMutationResolverTrait;
+    use ValidateUserLoggedInMutationResolverTrait;
+    use UserMutationResolverTrait;
+
+    private ?UserTypeAPIInterface $userTypeAPI = null;
+    private ?UserTypeMutationAPIInterface $userTypeMutationAPI = null;
+
+    final protected function getUserTypeAPI(): UserTypeAPIInterface
+    {
+        if ($this->userTypeAPI === null) {
+            /** @var UserTypeAPIInterface */
+            $userTypeAPI = $this->instanceManager->getInstance(UserTypeAPIInterface::class);
+            $this->userTypeAPI = $userTypeAPI;
+        }
+        return $this->userTypeAPI;
+    }
+
+    final protected function getUserTypeMutationAPI(): UserTypeMutationAPIInterface
+    {
+        if ($this->userTypeMutationAPI === null) {
+            /** @var UserTypeMutationAPIInterface */
+            $userTypeMutationAPI = $this->instanceManager->getInstance(UserTypeMutationAPIInterface::class);
+            $this->userTypeMutationAPI = $userTypeMutationAPI;
+        }
+        return $this->userTypeMutationAPI;
+    }
+
+    protected function getUserNotLoggedInError(): FeedbackItemResolution
+    {
+        return new FeedbackItemResolution(
+            MutationErrorFeedbackItemProvider::class,
+            MutationErrorFeedbackItemProvider::E5,
+        );
+    }
+
+    protected function validateDeleteErrors(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        $errorCount = $objectTypeFieldResolutionFeedbackStore->getErrorCount();
+
+        $userID = $this->getUserID($fieldDataAccessor);
+
+        $this->validateIsUserLoggedIn($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+        if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+            return;
+        }
+
+        // Type-level capability, checked before existence so as not to leak it
+        $this->validateCanLoggedInUserDeleteUsers($userID, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+        if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+            return;
+        }
+
+        $this->validateUserByIDExists($userID, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+        if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+            return;
+        }
+
+        /** @var string|int */
+        $userID = $userID;
+
+        $this->validateUserIsNotDeletingThemselves($userID, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+        if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+            return;
+        }
+
+        $this->validateCanLoggedInUserDeleteUser($userID, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+        if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+            return;
+        }
+
+        $this->validateReassignUserExists($userID, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+        if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+            return;
+        }
+
+        // Allow components to inject their own validations
+        App::doAction(
+            UserCRUDHookNames::VALIDATE_DELETE_USER,
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore,
+        );
+    }
+
+    protected function validateCanLoggedInUserDeleteUsers(
+        string|int|null $userID,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        if ($this->getUserTypeMutationAPI()->canLoggedInUserDeleteUsers()) {
+            return;
+        }
+        $objectTypeFieldResolutionFeedbackStore->addError(
+            new ObjectTypeFieldResolutionFeedback(
+                new FeedbackItemResolution(
+                    MutationErrorFeedbackItemProvider::class,
+                    MutationErrorFeedbackItemProvider::E8,
+                    [
+                        $userID ?? '',
+                    ]
+                ),
+                $fieldDataAccessor->getField(),
+            )
+        );
+    }
+
+    protected function validateUserIsNotDeletingThemselves(
+        string|int $userID,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        $loggedInUserID = App::getState('current-user-id');
+        if ((int) $loggedInUserID !== (int) $userID) {
+            return;
+        }
+        $objectTypeFieldResolutionFeedbackStore->addError(
+            new ObjectTypeFieldResolutionFeedback(
+                new FeedbackItemResolution(
+                    MutationErrorFeedbackItemProvider::class,
+                    MutationErrorFeedbackItemProvider::E15,
+                ),
+                $fieldDataAccessor->getField(),
+            )
+        );
+    }
+
+    protected function validateCanLoggedInUserDeleteUser(
+        string|int $userID,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        if ($this->getUserTypeMutationAPI()->canLoggedInUserDeleteUser($userID)) {
+            return;
+        }
+        $objectTypeFieldResolutionFeedbackStore->addError(
+            new ObjectTypeFieldResolutionFeedback(
+                new FeedbackItemResolution(
+                    MutationErrorFeedbackItemProvider::class,
+                    MutationErrorFeedbackItemProvider::E8,
+                    [
+                        $userID,
+                    ]
+                ),
+                $fieldDataAccessor->getField(),
+            )
+        );
+    }
+
+    protected function validateReassignUserExists(
+        string|int $userID,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        if (!$fieldDataAccessor->hasValue(MutationInputProperties::REASSIGN_AUTHOR_CONTENT_TO)) {
+            return;
+        }
+        /** @var string|int|null */
+        $reassignUserID = $fieldDataAccessor->getValue(MutationInputProperties::REASSIGN_AUTHOR_CONTENT_TO);
+        if ($reassignUserID === null) {
+            return;
+        }
+        if (
+            (int) $reassignUserID !== (int) $userID
+            && $this->getUserTypeAPI()->getUserByID($reassignUserID) !== null
+        ) {
+            return;
+        }
+        $objectTypeFieldResolutionFeedbackStore->addError(
+            new ObjectTypeFieldResolutionFeedback(
+                new FeedbackItemResolution(
+                    MutationErrorFeedbackItemProvider::class,
+                    MutationErrorFeedbackItemProvider::E14,
+                    [
+                        $reassignUserID,
+                    ]
+                ),
+                $fieldDataAccessor->getField(),
+            )
+        );
+    }
+
+    /**
+     * @return bool Whether the user was deleted
+     * @throws UserCRUDMutationException If there was an error (eg: User does not exist)
+     */
+    protected function delete(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): bool {
+        /** @var string|int */
+        $userID = $this->getUserID($fieldDataAccessor);
+
+        /** @var string|int|null */
+        $reassignUserID = $fieldDataAccessor->hasValue(MutationInputProperties::REASSIGN_AUTHOR_CONTENT_TO)
+            ? $fieldDataAccessor->getValue(MutationInputProperties::REASSIGN_AUTHOR_CONTENT_TO)
+            : null;
+
+        $this->getUserTypeMutationAPI()->deleteUser($userID, $reassignUserID);
+
+        App::doAction(
+            UserCRUDHookNames::DELETE_USER,
+            $userID,
+            $fieldDataAccessor,
+        );
+
+        return true;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/CreateUserBulkOperationMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/CreateUserBulkOperationMutationResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\SchemaCommons\MutationResolvers\AbstractBulkOperationDecoratorMutationResolver;
+use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+
+class CreateUserBulkOperationMutationResolver extends AbstractBulkOperationDecoratorMutationResolver
+{
+    private ?CreateUserMutationResolver $createUserMutationResolver = null;
+
+    final protected function getCreateUserMutationResolver(): CreateUserMutationResolver
+    {
+        if ($this->createUserMutationResolver === null) {
+            /** @var CreateUserMutationResolver */
+            $createUserMutationResolver = $this->instanceManager->getInstance(CreateUserMutationResolver::class);
+            $this->createUserMutationResolver = $createUserMutationResolver;
+        }
+        return $this->createUserMutationResolver;
+    }
+
+    protected function getDecoratedOperationMutationResolver(): MutationResolverInterface
+    {
+        return $this->getCreateUserMutationResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/CreateUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/CreateUserMutationResolver.php
@@ -6,7 +6,6 @@ namespace PoPCMSSchema\UserMutations\MutationResolvers;
 
 use PoPCMSSchema\UserMutations\Constants\MutationInputProperties;
 use PoPCMSSchema\UserMutations\Constants\UserCRUDHookNames;
-use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
 use PoPCMSSchema\UserMutations\FeedbackItemProviders\MutationErrorFeedbackItemProvider;
 use PoP\ComponentModel\Feedback\FeedbackItemResolution;
 use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedback;

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/CreateUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/CreateUserMutationResolver.php
@@ -106,6 +106,7 @@ class CreateUserMutationResolver extends AbstractCreateOrUpdateUserMutationResol
 
         // Allow for additional operations
         $this->additionals($userID, $fieldDataAccessor);
+        $this->triggerExecuteCreateOrUpdateHook($userID, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
 
         return $userID;
     }

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/CreateUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/CreateUserMutationResolver.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\UserMutations\Constants\MutationInputProperties;
+use PoPCMSSchema\UserMutations\Constants\UserCRUDHookNames;
+use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
+use PoPCMSSchema\UserMutations\FeedbackItemProviders\MutationErrorFeedbackItemProvider;
+use PoP\ComponentModel\Feedback\FeedbackItemResolution;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedback;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\Root\App;
+use PoP\Root\Exception\AbstractException;
+
+class CreateUserMutationResolver extends AbstractCreateOrUpdateUserMutationResolver
+{
+    protected function addUserInputField(): bool
+    {
+        return false;
+    }
+
+    protected function validateUserCanExecuteMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        if ($this->getUserTypeMutationAPI()->canLoggedInUserCreateUsers()) {
+            return;
+        }
+        $objectTypeFieldResolutionFeedbackStore->addError(
+            new ObjectTypeFieldResolutionFeedback(
+                new FeedbackItemResolution(
+                    MutationErrorFeedbackItemProvider::class,
+                    MutationErrorFeedbackItemProvider::E7,
+                ),
+                $fieldDataAccessor->getField(),
+            )
+        );
+    }
+
+    public function validate(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        $errorCount = $objectTypeFieldResolutionFeedbackStore->getErrorCount();
+
+        parent::validate($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+        if ($objectTypeFieldResolutionFeedbackStore->getErrorCount() > $errorCount) {
+            return;
+        }
+
+        $this->validateUsernameDoesNotExist($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+
+        // Allow components to inject their own validations
+        App::doAction(
+            UserCRUDHookNames::VALIDATE_CREATE_USER,
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore,
+        );
+    }
+
+    protected function validateUsernameDoesNotExist(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        /** @var string|null */
+        $username = $fieldDataAccessor->getValue(MutationInputProperties::USERNAME);
+        if ($username === null || $username === '') {
+            return;
+        }
+        if ($this->getUserTypeAPI()->getUserByLogin($username) === null) {
+            return;
+        }
+        $objectTypeFieldResolutionFeedbackStore->addError(
+            new ObjectTypeFieldResolutionFeedback(
+                new FeedbackItemResolution(
+                    MutationErrorFeedbackItemProvider::class,
+                    MutationErrorFeedbackItemProvider::E10,
+                    [
+                        $username,
+                    ]
+                ),
+                $fieldDataAccessor->getField(),
+            )
+        );
+    }
+
+    protected function additionals(string|int $userID, FieldDataAccessorInterface $fieldDataAccessor): void
+    {
+        parent::additionals($userID, $fieldDataAccessor);
+        App::doAction(UserCRUDHookNames::CREATE_USER, $userID, $fieldDataAccessor);
+    }
+
+    /**
+     * @throws AbstractException In case of error
+     */
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
+        $userData = $this->getUserData($fieldDataAccessor);
+
+        $userID = $this->getUserTypeMutationAPI()->createUser($userData);
+
+        // Allow for additional operations
+        $this->additionals($userID, $fieldDataAccessor);
+
+        return $userID;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/DeleteUserBulkOperationMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/DeleteUserBulkOperationMutationResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\SchemaCommons\MutationResolvers\AbstractBulkOperationDecoratorMutationResolver;
+use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+
+class DeleteUserBulkOperationMutationResolver extends AbstractBulkOperationDecoratorMutationResolver
+{
+    private ?DeleteUserMutationResolver $deleteUserMutationResolver = null;
+
+    final protected function getDeleteUserMutationResolver(): DeleteUserMutationResolver
+    {
+        if ($this->deleteUserMutationResolver === null) {
+            /** @var DeleteUserMutationResolver */
+            $deleteUserMutationResolver = $this->instanceManager->getInstance(DeleteUserMutationResolver::class);
+            $this->deleteUserMutationResolver = $deleteUserMutationResolver;
+        }
+        return $this->deleteUserMutationResolver;
+    }
+
+    protected function getDecoratedOperationMutationResolver(): MutationResolverInterface
+    {
+        return $this->getDeleteUserMutationResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/DeleteUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/DeleteUserMutationResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+class DeleteUserMutationResolver extends AbstractDeleteUserMutationResolver
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/DeleteUserMutationResolverTrait.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/DeleteUserMutationResolverTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\Root\Exception\AbstractException;
+
+trait DeleteUserMutationResolverTrait
+{
+    /**
+     * @throws AbstractException In case of error
+     */
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
+        return $this->delete(
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore,
+        );
+    }
+
+    /**
+     * @return bool Whether the user was deleted
+     * @throws UserCRUDMutationException If there was an error (eg: User does not exist)
+     */
+    abstract protected function delete(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): bool;
+
+    /**
+     * Validate the app-level errors in top-level "errors" entry.
+     */
+    public function validate(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        $this->validateDeleteErrors($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+    }
+
+    abstract protected function validateDeleteErrors(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void;
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableCreateUserBulkOperationMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableCreateUserBulkOperationMutationResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\SchemaCommons\MutationResolvers\AbstractBulkOperationDecoratorMutationResolver;
+use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+
+class PayloadableCreateUserBulkOperationMutationResolver extends AbstractBulkOperationDecoratorMutationResolver
+{
+    private ?PayloadableCreateUserMutationResolver $payloadableCreateUserMutationResolver = null;
+
+    final protected function getPayloadableCreateUserMutationResolver(): PayloadableCreateUserMutationResolver
+    {
+        if ($this->payloadableCreateUserMutationResolver === null) {
+            /** @var PayloadableCreateUserMutationResolver */
+            $payloadableCreateUserMutationResolver = $this->instanceManager->getInstance(PayloadableCreateUserMutationResolver::class);
+            $this->payloadableCreateUserMutationResolver = $payloadableCreateUserMutationResolver;
+        }
+        return $this->payloadableCreateUserMutationResolver;
+    }
+
+    protected function getDecoratedOperationMutationResolver(): MutationResolverInterface
+    {
+        return $this->getPayloadableCreateUserMutationResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableCreateUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableCreateUserMutationResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\UserMutations\Constants\UserCRUDHookNames;
+use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
+use PoPSchema\SchemaCommons\MutationResolvers\PayloadableMutationResolverTrait;
+use PoPSchema\SchemaCommons\ObjectModels\ErrorPayloadInterface;
+use PoPSchema\SchemaCommons\ObjectModels\GenericErrorPayload;
+use PoP\ComponentModel\App;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackInterface;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\Root\Exception\AbstractException;
+
+class PayloadableCreateUserMutationResolver extends CreateUserMutationResolver
+{
+    use PayloadableMutationResolverTrait;
+
+    /**
+     * Validate the app-level errors when executing the mutation,
+     * return them in the Payload.
+     *
+     * @throws AbstractException In case of error
+     */
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
+        $separateObjectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
+        parent::validate($fieldDataAccessor, $separateObjectTypeFieldResolutionFeedbackStore);
+        if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
+            return $this->createFailureObjectMutationPayload(
+                array_map(
+                    $this->createErrorPayloadFromObjectTypeFieldResolutionFeedback(...),
+                    $separateObjectTypeFieldResolutionFeedbackStore->getErrors()
+                )
+            )->getID();
+        }
+
+        try {
+            /** @var string|int */
+            $userID = parent::executeMutation(
+                $fieldDataAccessor,
+                $separateObjectTypeFieldResolutionFeedbackStore,
+            );
+        } catch (UserCRUDMutationException $userCRUDMutationException) {
+            return $this->createFailureObjectMutationPayload(
+                [
+                    $this->createGenericErrorPayloadFromPayloadClientException($userCRUDMutationException),
+                ]
+            )->getID();
+        }
+
+        return $this->createSuccessObjectMutationPayload($userID)->getID();
+    }
+
+    protected function createErrorPayloadFromObjectTypeFieldResolutionFeedback(
+        ObjectTypeFieldResolutionFeedbackInterface $objectTypeFieldResolutionFeedback
+    ): ErrorPayloadInterface {
+        $feedbackItemResolution = $objectTypeFieldResolutionFeedback->getFeedbackItemResolution();
+        // Allow components to inject their own error payloads
+        return App::applyFilters(
+            UserCRUDHookNames::ERROR_PAYLOAD,
+            $this->createCreateOrUpdateUserErrorPayloadFromObjectTypeFieldResolutionFeedback(
+                $objectTypeFieldResolutionFeedback,
+            ) ?? new GenericErrorPayload(
+                $feedbackItemResolution->getMessage(),
+                $feedbackItemResolution->getNamespacedCode(),
+            ),
+            $objectTypeFieldResolutionFeedback,
+        );
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableDeleteUserBulkOperationMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableDeleteUserBulkOperationMutationResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\SchemaCommons\MutationResolvers\AbstractBulkOperationDecoratorMutationResolver;
+use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+
+class PayloadableDeleteUserBulkOperationMutationResolver extends AbstractBulkOperationDecoratorMutationResolver
+{
+    private ?PayloadableDeleteUserMutationResolver $payloadableDeleteUserMutationResolver = null;
+
+    final protected function getPayloadableDeleteUserMutationResolver(): PayloadableDeleteUserMutationResolver
+    {
+        if ($this->payloadableDeleteUserMutationResolver === null) {
+            /** @var PayloadableDeleteUserMutationResolver */
+            $payloadableDeleteUserMutationResolver = $this->instanceManager->getInstance(PayloadableDeleteUserMutationResolver::class);
+            $this->payloadableDeleteUserMutationResolver = $payloadableDeleteUserMutationResolver;
+        }
+        return $this->payloadableDeleteUserMutationResolver;
+    }
+
+    protected function getDecoratedOperationMutationResolver(): MutationResolverInterface
+    {
+        return $this->getPayloadableDeleteUserMutationResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableDeleteUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableDeleteUserMutationResolver.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+class PayloadableDeleteUserMutationResolver extends DeleteUserMutationResolver
+{
+    use PayloadableDeleteUserMutationResolverTrait;
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableDeleteUserMutationResolverTrait.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableDeleteUserMutationResolverTrait.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
+use PoPCMSSchema\UserMutations\FeedbackItemProviders\MutationErrorFeedbackItemProvider;
+use PoPCMSSchema\UserMutations\ObjectModels\CannotDeleteYourselfErrorPayload;
+use PoPCMSSchema\UserMutations\ObjectModels\LoggedInUserHasNoPermissionToDeleteUserErrorPayload;
+use PoPCMSSchema\UserMutations\ObjectModels\ReassignUserDoesNotExistErrorPayload;
+use PoPCMSSchema\UserMutations\ObjectModels\UserDoesNotExistErrorPayload;
+use PoPCMSSchema\UserStateMutations\ObjectModels\UserIsNotLoggedInErrorPayload;
+use PoPSchema\SchemaCommons\MutationResolvers\PayloadableMutationResolverTrait;
+use PoPSchema\SchemaCommons\ObjectModels\ErrorPayloadInterface;
+use PoPSchema\SchemaCommons\ObjectModels\GenericErrorPayload;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackInterface;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\Root\Exception\AbstractException;
+
+trait PayloadableDeleteUserMutationResolverTrait
+{
+    use PayloadableMutationResolverTrait, DeleteUserMutationResolverTrait {
+        DeleteUserMutationResolverTrait::executeMutation as upstreamExecuteMutation;
+        PayloadableMutationResolverTrait::validate insteadof DeleteUserMutationResolverTrait;
+    }
+
+    /**
+     * Validate the app-level errors when executing the mutation,
+     * return them in the Payload.
+     *
+     * @throws AbstractException In case of error
+     */
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
+        $separateObjectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
+        $this->validateDeleteErrors($fieldDataAccessor, $separateObjectTypeFieldResolutionFeedbackStore);
+        if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
+            return $this->createFailureObjectMutationPayload(
+                array_map(
+                    $this->createErrorPayloadFromObjectTypeFieldResolutionFeedback(...),
+                    $separateObjectTypeFieldResolutionFeedbackStore->getErrors()
+                )
+            )->getID();
+        }
+
+        /** @var string|int */
+        $userID = $this->getUserID($fieldDataAccessor);
+
+        /**
+         * Deleting the user either succeeds, or throws an exception.
+         * Hence there are no errors to collect after executing the mutation.
+         */
+        try {
+            $this->upstreamExecuteMutation(
+                $fieldDataAccessor,
+                $separateObjectTypeFieldResolutionFeedbackStore,
+            );
+        } catch (UserCRUDMutationException $userCRUDMutationException) {
+            return $this->createFailureObjectMutationPayload(
+                [
+                    $this->createGenericErrorPayloadFromPayloadClientException($userCRUDMutationException),
+                ]
+            )->getID();
+        }
+
+        return $this->createSuccessObjectMutationPayload($userID)->getID();
+    }
+
+    protected function createErrorPayloadFromObjectTypeFieldResolutionFeedback(
+        ObjectTypeFieldResolutionFeedbackInterface $objectTypeFieldResolutionFeedback
+    ): ErrorPayloadInterface {
+        $feedbackItemResolution = $objectTypeFieldResolutionFeedback->getFeedbackItemResolution();
+        return match (
+            [
+            $feedbackItemResolution->getFeedbackProviderServiceClass(),
+            $feedbackItemResolution->getCode()
+            ]
+        ) {
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E5,
+            ] => new UserIsNotLoggedInErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E1,
+            ] => new UserDoesNotExistErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E8,
+            ] => new LoggedInUserHasNoPermissionToDeleteUserErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E14,
+            ] => new ReassignUserDoesNotExistErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E15,
+            ] => new CannotDeleteYourselfErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            default => new GenericErrorPayload(
+                $feedbackItemResolution->getMessage(),
+                $feedbackItemResolution->getNamespacedCode(),
+            ),
+        };
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableUpdateUserBulkOperationMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableUpdateUserBulkOperationMutationResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\SchemaCommons\MutationResolvers\AbstractBulkOperationDecoratorMutationResolver;
+use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+
+class PayloadableUpdateUserBulkOperationMutationResolver extends AbstractBulkOperationDecoratorMutationResolver
+{
+    private ?PayloadableUpdateUserMutationResolver $payloadableUpdateUserMutationResolver = null;
+
+    final protected function getPayloadableUpdateUserMutationResolver(): PayloadableUpdateUserMutationResolver
+    {
+        if ($this->payloadableUpdateUserMutationResolver === null) {
+            /** @var PayloadableUpdateUserMutationResolver */
+            $payloadableUpdateUserMutationResolver = $this->instanceManager->getInstance(PayloadableUpdateUserMutationResolver::class);
+            $this->payloadableUpdateUserMutationResolver = $payloadableUpdateUserMutationResolver;
+        }
+        return $this->payloadableUpdateUserMutationResolver;
+    }
+
+    protected function getDecoratedOperationMutationResolver(): MutationResolverInterface
+    {
+        return $this->getPayloadableUpdateUserMutationResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableUpdateUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/PayloadableUpdateUserMutationResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\UserMutations\Constants\UserCRUDHookNames;
+use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
+use PoPSchema\SchemaCommons\MutationResolvers\PayloadableMutationResolverTrait;
+use PoPSchema\SchemaCommons\ObjectModels\ErrorPayloadInterface;
+use PoPSchema\SchemaCommons\ObjectModels\GenericErrorPayload;
+use PoP\ComponentModel\App;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackInterface;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\Root\Exception\AbstractException;
+
+class PayloadableUpdateUserMutationResolver extends UpdateUserMutationResolver
+{
+    use PayloadableMutationResolverTrait;
+
+    /**
+     * Validate the app-level errors when executing the mutation,
+     * return them in the Payload.
+     *
+     * @throws AbstractException In case of error
+     */
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
+        $separateObjectTypeFieldResolutionFeedbackStore = new ObjectTypeFieldResolutionFeedbackStore();
+        parent::validate($fieldDataAccessor, $separateObjectTypeFieldResolutionFeedbackStore);
+        if ($separateObjectTypeFieldResolutionFeedbackStore->getErrors() !== []) {
+            return $this->createFailureObjectMutationPayload(
+                array_map(
+                    $this->createErrorPayloadFromObjectTypeFieldResolutionFeedback(...),
+                    $separateObjectTypeFieldResolutionFeedbackStore->getErrors()
+                )
+            )->getID();
+        }
+
+        try {
+            /** @var string|int */
+            $userID = parent::executeMutation(
+                $fieldDataAccessor,
+                $separateObjectTypeFieldResolutionFeedbackStore,
+            );
+        } catch (UserCRUDMutationException $userCRUDMutationException) {
+            return $this->createFailureObjectMutationPayload(
+                [
+                    $this->createGenericErrorPayloadFromPayloadClientException($userCRUDMutationException),
+                ]
+            )->getID();
+        }
+
+        return $this->createSuccessObjectMutationPayload($userID)->getID();
+    }
+
+    protected function createErrorPayloadFromObjectTypeFieldResolutionFeedback(
+        ObjectTypeFieldResolutionFeedbackInterface $objectTypeFieldResolutionFeedback
+    ): ErrorPayloadInterface {
+        $feedbackItemResolution = $objectTypeFieldResolutionFeedback->getFeedbackItemResolution();
+        // Allow components to inject their own error payloads
+        return App::applyFilters(
+            UserCRUDHookNames::ERROR_PAYLOAD,
+            $this->createCreateOrUpdateUserErrorPayloadFromObjectTypeFieldResolutionFeedback(
+                $objectTypeFieldResolutionFeedback,
+            ) ?? new GenericErrorPayload(
+                $feedbackItemResolution->getMessage(),
+                $feedbackItemResolution->getNamespacedCode(),
+            ),
+            $objectTypeFieldResolutionFeedback,
+        );
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/UpdateUserBulkOperationMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/UpdateUserBulkOperationMutationResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\SchemaCommons\MutationResolvers\AbstractBulkOperationDecoratorMutationResolver;
+use PoP\ComponentModel\MutationResolvers\MutationResolverInterface;
+
+class UpdateUserBulkOperationMutationResolver extends AbstractBulkOperationDecoratorMutationResolver
+{
+    private ?UpdateUserMutationResolver $updateUserMutationResolver = null;
+
+    final protected function getUpdateUserMutationResolver(): UpdateUserMutationResolver
+    {
+        if ($this->updateUserMutationResolver === null) {
+            /** @var UpdateUserMutationResolver */
+            $updateUserMutationResolver = $this->instanceManager->getInstance(UpdateUserMutationResolver::class);
+            $this->updateUserMutationResolver = $updateUserMutationResolver;
+        }
+        return $this->updateUserMutationResolver;
+    }
+
+    protected function getDecoratedOperationMutationResolver(): MutationResolverInterface
+    {
+        return $this->getUpdateUserMutationResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/UpdateUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/UpdateUserMutationResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PoPCMSSchema\UserMutations\MutationResolvers;
 
 use PoPCMSSchema\UserMutations\Constants\UserCRUDHookNames;
-use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
 use PoPCMSSchema\UserMutations\FeedbackItemProviders\MutationErrorFeedbackItemProvider;
 use PoP\ComponentModel\Feedback\FeedbackItemResolution;
 use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedback;

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/UpdateUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/UpdateUserMutationResolver.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\UserMutations\Constants\UserCRUDHookNames;
+use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
+use PoPCMSSchema\UserMutations\FeedbackItemProviders\MutationErrorFeedbackItemProvider;
+use PoP\ComponentModel\Feedback\FeedbackItemResolution;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedback;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+use PoP\Root\App;
+use PoP\Root\Exception\AbstractException;
+
+class UpdateUserMutationResolver extends AbstractCreateOrUpdateUserMutationResolver
+{
+    protected function addUserInputField(): bool
+    {
+        return true;
+    }
+
+    protected function validateUserCanExecuteMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        /** @var string|int */
+        $userID = $this->getUserID($fieldDataAccessor);
+        if ($this->getUserTypeMutationAPI()->canLoggedInUserEditUser($userID)) {
+            return;
+        }
+        $objectTypeFieldResolutionFeedbackStore->addError(
+            new ObjectTypeFieldResolutionFeedback(
+                new FeedbackItemResolution(
+                    MutationErrorFeedbackItemProvider::class,
+                    MutationErrorFeedbackItemProvider::E4,
+                    [
+                        $userID,
+                    ]
+                ),
+                $fieldDataAccessor->getField(),
+            )
+        );
+    }
+
+    public function validate(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        parent::validate($fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+
+        // Allow components to inject their own validations
+        App::doAction(
+            UserCRUDHookNames::VALIDATE_UPDATE_USER,
+            $fieldDataAccessor,
+            $objectTypeFieldResolutionFeedbackStore,
+        );
+    }
+
+    protected function additionals(string|int $userID, FieldDataAccessorInterface $fieldDataAccessor): void
+    {
+        parent::additionals($userID, $fieldDataAccessor);
+        App::doAction(UserCRUDHookNames::UPDATE_USER, $userID, $fieldDataAccessor);
+    }
+
+    /**
+     * @throws AbstractException In case of error
+     */
+    public function executeMutation(
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): mixed {
+        $userData = $this->getUserData($fieldDataAccessor);
+
+        $userID = $this->getUserTypeMutationAPI()->updateUser($userData);
+
+        // Allow for additional operations
+        $this->additionals($userID, $fieldDataAccessor);
+
+        return $userID;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/UpdateUserMutationResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/UpdateUserMutationResolver.php
@@ -77,6 +77,7 @@ class UpdateUserMutationResolver extends AbstractCreateOrUpdateUserMutationResol
 
         // Allow for additional operations
         $this->additionals($userID, $fieldDataAccessor);
+        $this->triggerExecuteCreateOrUpdateHook($userID, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
 
         return $userID;
     }

--- a/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/UserMutationResolverTrait.php
+++ b/layers/CMSSchema/packages/user-mutations/src/MutationResolvers/UserMutationResolverTrait.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\MutationResolvers;
+
+use PoPCMSSchema\UserMutations\Constants\MutationInputProperties;
+use PoPCMSSchema\UserMutations\FeedbackItemProviders\MutationErrorFeedbackItemProvider;
+use PoPCMSSchema\UserMutations\ObjectModels\EmailAlreadyExistsErrorPayload;
+use PoPCMSSchema\UserMutations\ObjectModels\InvalidEmailErrorPayload;
+use PoPCMSSchema\UserMutations\ObjectModels\LoggedInUserHasNoPermissionToCreateUsersErrorPayload;
+use PoPCMSSchema\UserMutations\ObjectModels\LoggedInUserHasNoPermissionToEditUserErrorPayload;
+use PoPCMSSchema\UserMutations\ObjectModels\LoggedInUserHasNoPermissionToEditUserRolesErrorPayload;
+use PoPCMSSchema\UserMutations\ObjectModels\UserDoesNotExistErrorPayload;
+use PoPCMSSchema\UserMutations\ObjectModels\UserRoleDoesNotExistErrorPayload;
+use PoPCMSSchema\UserMutations\ObjectModels\UsernameAlreadyExistsErrorPayload;
+use PoPCMSSchema\UserMutations\TypeAPIs\UserTypeMutationAPIInterface;
+use PoPCMSSchema\Users\TypeAPIs\UserTypeAPIInterface;
+use PoPCMSSchema\UserStateMutations\ObjectModels\UserIsNotLoggedInErrorPayload;
+use PoPSchema\SchemaCommons\ObjectModels\ErrorPayloadInterface;
+use PoP\ComponentModel\Feedback\FeedbackItemResolution;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedback;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackInterface;
+use PoP\ComponentModel\Feedback\ObjectTypeFieldResolutionFeedbackStore;
+use PoP\ComponentModel\QueryResolution\FieldDataAccessorInterface;
+
+trait UserMutationResolverTrait
+{
+    abstract protected function getUserTypeAPI(): UserTypeAPIInterface;
+
+    abstract protected function getUserTypeMutationAPI(): UserTypeMutationAPIInterface;
+
+    /**
+     * Validate that the user exists.
+     */
+    protected function validateUserByIDExists(
+        string|int|null $userID,
+        FieldDataAccessorInterface $fieldDataAccessor,
+        ObjectTypeFieldResolutionFeedbackStore $objectTypeFieldResolutionFeedbackStore,
+    ): void {
+        if (!$userID || $this->getUserTypeAPI()->getUserByID($userID) === null) {
+            $objectTypeFieldResolutionFeedbackStore->addError(
+                new ObjectTypeFieldResolutionFeedback(
+                    new FeedbackItemResolution(
+                        MutationErrorFeedbackItemProvider::class,
+                        MutationErrorFeedbackItemProvider::E1,
+                        [
+                            $userID ?? '',
+                        ]
+                    ),
+                    $fieldDataAccessor->getField(),
+                )
+            );
+        }
+    }
+
+    protected function createCreateOrUpdateUserErrorPayloadFromObjectTypeFieldResolutionFeedback(
+        ObjectTypeFieldResolutionFeedbackInterface $objectTypeFieldResolutionFeedback,
+    ): ?ErrorPayloadInterface {
+        $feedbackItemResolution = $objectTypeFieldResolutionFeedback->getFeedbackItemResolution();
+        return match (
+            [
+            $feedbackItemResolution->getFeedbackProviderServiceClass(),
+            $feedbackItemResolution->getCode()
+            ]
+        ) {
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E5,
+            ] => new UserIsNotLoggedInErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E7,
+            ] => new LoggedInUserHasNoPermissionToCreateUsersErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E1,
+            ] => new UserDoesNotExistErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E4,
+            ] => new LoggedInUserHasNoPermissionToEditUserErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E9,
+            ] => new LoggedInUserHasNoPermissionToEditUserRolesErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E10,
+            ] => new UsernameAlreadyExistsErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E11,
+            ] => new EmailAlreadyExistsErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E12,
+            ] => new InvalidEmailErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            [
+                MutationErrorFeedbackItemProvider::class,
+                MutationErrorFeedbackItemProvider::E13,
+            ] => new UserRoleDoesNotExistErrorPayload(
+                $feedbackItemResolution->getMessage(),
+            ),
+            default => null,
+        };
+    }
+
+    protected function getUserID(FieldDataAccessorInterface $fieldDataAccessor): string|int|null
+    {
+        /** @var string|int|null */
+        return $fieldDataAccessor->getValue(MutationInputProperties::ID);
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectModels/CannotDeleteYourselfErrorPayload.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectModels/CannotDeleteYourselfErrorPayload.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectModels;
+
+use PoPSchema\SchemaCommons\ObjectModels\AbstractErrorPayload;
+
+final class CannotDeleteYourselfErrorPayload extends AbstractErrorPayload
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectModels/EmailAlreadyExistsErrorPayload.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectModels/EmailAlreadyExistsErrorPayload.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectModels;
+
+use PoPSchema\SchemaCommons\ObjectModels\AbstractErrorPayload;
+
+final class EmailAlreadyExistsErrorPayload extends AbstractErrorPayload
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectModels/InvalidEmailErrorPayload.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectModels/InvalidEmailErrorPayload.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectModels;
+
+use PoPSchema\SchemaCommons\ObjectModels\AbstractErrorPayload;
+
+final class InvalidEmailErrorPayload extends AbstractErrorPayload
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectModels/LoggedInUserHasNoPermissionToCreateUsersErrorPayload.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectModels/LoggedInUserHasNoPermissionToCreateUsersErrorPayload.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectModels;
+
+use PoPSchema\SchemaCommons\ObjectModels\AbstractErrorPayload;
+
+final class LoggedInUserHasNoPermissionToCreateUsersErrorPayload extends AbstractErrorPayload
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectModels/LoggedInUserHasNoPermissionToDeleteUserErrorPayload.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectModels/LoggedInUserHasNoPermissionToDeleteUserErrorPayload.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectModels;
+
+use PoPSchema\SchemaCommons\ObjectModels\AbstractErrorPayload;
+
+final class LoggedInUserHasNoPermissionToDeleteUserErrorPayload extends AbstractErrorPayload
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectModels/LoggedInUserHasNoPermissionToEditUserRolesErrorPayload.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectModels/LoggedInUserHasNoPermissionToEditUserRolesErrorPayload.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectModels;
+
+use PoPSchema\SchemaCommons\ObjectModels\AbstractErrorPayload;
+
+final class LoggedInUserHasNoPermissionToEditUserRolesErrorPayload extends AbstractErrorPayload
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectModels/ReassignUserDoesNotExistErrorPayload.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectModels/ReassignUserDoesNotExistErrorPayload.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectModels;
+
+use PoPSchema\SchemaCommons\ObjectModels\AbstractErrorPayload;
+
+final class ReassignUserDoesNotExistErrorPayload extends AbstractErrorPayload
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectModels/UserRoleDoesNotExistErrorPayload.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectModels/UserRoleDoesNotExistErrorPayload.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectModels;
+
+use PoPSchema\SchemaCommons\ObjectModels\AbstractErrorPayload;
+
+final class UserRoleDoesNotExistErrorPayload extends AbstractErrorPayload
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectModels/UsernameAlreadyExistsErrorPayload.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectModels/UsernameAlreadyExistsErrorPayload.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectModels;
+
+use PoPSchema\SchemaCommons\ObjectModels\AbstractErrorPayload;
+
+final class UsernameAlreadyExistsErrorPayload extends AbstractErrorPayload
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/CannotDeleteYourselfErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/CannotDeleteYourselfErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\ObjectModels\CannotDeleteYourselfErrorPayload;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\CannotDeleteYourselfErrorPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractDeleteUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\ObjectTypeResolverPickers\AbstractErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class CannotDeleteYourselfErrorPayloadObjectTypeResolverPicker extends AbstractErrorPayloadObjectTypeResolverPicker
+{
+    private ?CannotDeleteYourselfErrorPayloadObjectTypeResolver $cannotDeleteYourselfErrorPayloadObjectTypeResolver = null;
+
+    final protected function getCannotDeleteYourselfErrorPayloadObjectTypeResolver(): CannotDeleteYourselfErrorPayloadObjectTypeResolver
+    {
+        if ($this->cannotDeleteYourselfErrorPayloadObjectTypeResolver === null) {
+            /** @var CannotDeleteYourselfErrorPayloadObjectTypeResolver */
+            $cannotDeleteYourselfErrorPayloadObjectTypeResolver = $this->instanceManager->getInstance(CannotDeleteYourselfErrorPayloadObjectTypeResolver::class);
+            $this->cannotDeleteYourselfErrorPayloadObjectTypeResolver = $cannotDeleteYourselfErrorPayloadObjectTypeResolver;
+        }
+        return $this->cannotDeleteYourselfErrorPayloadObjectTypeResolver;
+    }
+
+    public function getObjectTypeResolver(): ObjectTypeResolverInterface
+    {
+        return $this->getCannotDeleteYourselfErrorPayloadObjectTypeResolver();
+    }
+
+    protected function getTargetObjectClass(): string
+    {
+        return CannotDeleteYourselfErrorPayload::class;
+    }
+
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractDeleteUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/EmailAlreadyExistsErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/EmailAlreadyExistsErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\ObjectModels\EmailAlreadyExistsErrorPayload;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\EmailAlreadyExistsErrorPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\ObjectTypeResolverPickers\AbstractErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class EmailAlreadyExistsErrorPayloadObjectTypeResolverPicker extends AbstractErrorPayloadObjectTypeResolverPicker
+{
+    private ?EmailAlreadyExistsErrorPayloadObjectTypeResolver $emailAlreadyExistsErrorPayloadObjectTypeResolver = null;
+
+    final protected function getEmailAlreadyExistsErrorPayloadObjectTypeResolver(): EmailAlreadyExistsErrorPayloadObjectTypeResolver
+    {
+        if ($this->emailAlreadyExistsErrorPayloadObjectTypeResolver === null) {
+            /** @var EmailAlreadyExistsErrorPayloadObjectTypeResolver */
+            $emailAlreadyExistsErrorPayloadObjectTypeResolver = $this->instanceManager->getInstance(EmailAlreadyExistsErrorPayloadObjectTypeResolver::class);
+            $this->emailAlreadyExistsErrorPayloadObjectTypeResolver = $emailAlreadyExistsErrorPayloadObjectTypeResolver;
+        }
+        return $this->emailAlreadyExistsErrorPayloadObjectTypeResolver;
+    }
+
+    public function getObjectTypeResolver(): ObjectTypeResolverInterface
+    {
+        return $this->getEmailAlreadyExistsErrorPayloadObjectTypeResolver();
+    }
+
+    protected function getTargetObjectClass(): string
+    {
+        return EmailAlreadyExistsErrorPayload::class;
+    }
+
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/GenericErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/GenericErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractDeleteUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\ObjectTypeResolverPickers\AbstractGenericErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class GenericErrorPayloadObjectTypeResolverPicker extends AbstractGenericErrorPayloadObjectTypeResolverPicker
+{
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver::class,
+            AbstractDeleteUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/InvalidEmailErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/InvalidEmailErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\ObjectModels\InvalidEmailErrorPayload;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\InvalidEmailErrorPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\ObjectTypeResolverPickers\AbstractErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class InvalidEmailErrorPayloadObjectTypeResolverPicker extends AbstractErrorPayloadObjectTypeResolverPicker
+{
+    private ?InvalidEmailErrorPayloadObjectTypeResolver $invalidEmailErrorPayloadObjectTypeResolver = null;
+
+    final protected function getInvalidEmailErrorPayloadObjectTypeResolver(): InvalidEmailErrorPayloadObjectTypeResolver
+    {
+        if ($this->invalidEmailErrorPayloadObjectTypeResolver === null) {
+            /** @var InvalidEmailErrorPayloadObjectTypeResolver */
+            $invalidEmailErrorPayloadObjectTypeResolver = $this->instanceManager->getInstance(InvalidEmailErrorPayloadObjectTypeResolver::class);
+            $this->invalidEmailErrorPayloadObjectTypeResolver = $invalidEmailErrorPayloadObjectTypeResolver;
+        }
+        return $this->invalidEmailErrorPayloadObjectTypeResolver;
+    }
+
+    public function getObjectTypeResolver(): ObjectTypeResolverInterface
+    {
+        return $this->getInvalidEmailErrorPayloadObjectTypeResolver();
+    }
+
+    protected function getTargetObjectClass(): string
+    {
+        return InvalidEmailErrorPayload::class;
+    }
+
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\ObjectModels\LoggedInUserHasNoPermissionToCreateUsersErrorPayload;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractCreateUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\ObjectTypeResolverPickers\AbstractErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolverPicker extends AbstractErrorPayloadObjectTypeResolverPicker
+{
+    private ?LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver $loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver = null;
+
+    final protected function getLoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver(): LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver
+    {
+        if ($this->loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver === null) {
+            /** @var LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver */
+            $loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver = $this->instanceManager->getInstance(LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver::class);
+            $this->loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver = $loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver;
+        }
+        return $this->loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver;
+    }
+
+    public function getObjectTypeResolver(): ObjectTypeResolverInterface
+    {
+        return $this->getLoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver();
+    }
+
+    protected function getTargetObjectClass(): string
+    {
+        return LoggedInUserHasNoPermissionToCreateUsersErrorPayload::class;
+    }
+
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractCreateUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\ObjectModels\LoggedInUserHasNoPermissionToDeleteUserErrorPayload;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractDeleteUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\ObjectTypeResolverPickers\AbstractErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolverPicker extends AbstractErrorPayloadObjectTypeResolverPicker
+{
+    private ?LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver $loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver = null;
+
+    final protected function getLoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver(): LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver
+    {
+        if ($this->loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver === null) {
+            /** @var LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver */
+            $loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver = $this->instanceManager->getInstance(LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver::class);
+            $this->loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver = $loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver;
+        }
+        return $this->loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver;
+    }
+
+    public function getObjectTypeResolver(): ObjectTypeResolverInterface
+    {
+        return $this->getLoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver();
+    }
+
+    protected function getTargetObjectClass(): string
+    {
+        return LoggedInUserHasNoPermissionToDeleteUserErrorPayload::class;
+    }
+
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractDeleteUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/LoggedInUserHasNoPermissionToEditUserErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/LoggedInUserHasNoPermissionToEditUserErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class LoggedInUserHasNoPermissionToEditUserErrorPayloadObjectTypeResolverPicker extends AbstractLoggedInUserHasNoPermissionToEditUserErrorPayloadObjectTypeResolverPicker
+{
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractUpdateUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\ObjectModels\LoggedInUserHasNoPermissionToEditUserRolesErrorPayload;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\ObjectTypeResolverPickers\AbstractErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolverPicker extends AbstractErrorPayloadObjectTypeResolverPicker
+{
+    private ?LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver $loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver = null;
+
+    final protected function getLoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver(): LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver
+    {
+        if ($this->loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver === null) {
+            /** @var LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver */
+            $loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver = $this->instanceManager->getInstance(LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver::class);
+            $this->loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver = $loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver;
+        }
+        return $this->loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver;
+    }
+
+    public function getObjectTypeResolver(): ObjectTypeResolverInterface
+    {
+        return $this->getLoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver();
+    }
+
+    protected function getTargetObjectClass(): string
+    {
+        return LoggedInUserHasNoPermissionToEditUserRolesErrorPayload::class;
+    }
+
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/ReassignUserDoesNotExistErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/ReassignUserDoesNotExistErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\ObjectModels\ReassignUserDoesNotExistErrorPayload;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\ReassignUserDoesNotExistErrorPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractDeleteUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\ObjectTypeResolverPickers\AbstractErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class ReassignUserDoesNotExistErrorPayloadObjectTypeResolverPicker extends AbstractErrorPayloadObjectTypeResolverPicker
+{
+    private ?ReassignUserDoesNotExistErrorPayloadObjectTypeResolver $reassignUserDoesNotExistErrorPayloadObjectTypeResolver = null;
+
+    final protected function getReassignUserDoesNotExistErrorPayloadObjectTypeResolver(): ReassignUserDoesNotExistErrorPayloadObjectTypeResolver
+    {
+        if ($this->reassignUserDoesNotExistErrorPayloadObjectTypeResolver === null) {
+            /** @var ReassignUserDoesNotExistErrorPayloadObjectTypeResolver */
+            $reassignUserDoesNotExistErrorPayloadObjectTypeResolver = $this->instanceManager->getInstance(ReassignUserDoesNotExistErrorPayloadObjectTypeResolver::class);
+            $this->reassignUserDoesNotExistErrorPayloadObjectTypeResolver = $reassignUserDoesNotExistErrorPayloadObjectTypeResolver;
+        }
+        return $this->reassignUserDoesNotExistErrorPayloadObjectTypeResolver;
+    }
+
+    public function getObjectTypeResolver(): ObjectTypeResolverInterface
+    {
+        return $this->getReassignUserDoesNotExistErrorPayloadObjectTypeResolver();
+    }
+
+    protected function getTargetObjectClass(): string
+    {
+        return ReassignUserDoesNotExistErrorPayload::class;
+    }
+
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractDeleteUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/UserDoesNotExistErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/UserDoesNotExistErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractDeleteUserMutationErrorPayloadUnionTypeResolver;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class UserDoesNotExistErrorPayloadObjectTypeResolverPicker extends AbstractUserDoesNotExistErrorPayloadObjectTypeResolverPicker
+{
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractUpdateUserMutationErrorPayloadUnionTypeResolver::class,
+            AbstractDeleteUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/UserIsNotLoggedInErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/UserIsNotLoggedInErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractDeleteUserMutationErrorPayloadUnionTypeResolver;
+use PoPCMSSchema\UserStateMutations\ObjectTypeResolverPickers\AbstractUserIsNotLoggedInErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class UserIsNotLoggedInErrorPayloadObjectTypeResolverPicker extends AbstractUserIsNotLoggedInErrorPayloadObjectTypeResolverPicker
+{
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver::class,
+            AbstractDeleteUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/UserRoleDoesNotExistErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/UserRoleDoesNotExistErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\ObjectModels\UserRoleDoesNotExistErrorPayload;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\UserRoleDoesNotExistErrorPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\ObjectTypeResolverPickers\AbstractErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class UserRoleDoesNotExistErrorPayloadObjectTypeResolverPicker extends AbstractErrorPayloadObjectTypeResolverPicker
+{
+    private ?UserRoleDoesNotExistErrorPayloadObjectTypeResolver $userRoleDoesNotExistErrorPayloadObjectTypeResolver = null;
+
+    final protected function getUserRoleDoesNotExistErrorPayloadObjectTypeResolver(): UserRoleDoesNotExistErrorPayloadObjectTypeResolver
+    {
+        if ($this->userRoleDoesNotExistErrorPayloadObjectTypeResolver === null) {
+            /** @var UserRoleDoesNotExistErrorPayloadObjectTypeResolver */
+            $userRoleDoesNotExistErrorPayloadObjectTypeResolver = $this->instanceManager->getInstance(UserRoleDoesNotExistErrorPayloadObjectTypeResolver::class);
+            $this->userRoleDoesNotExistErrorPayloadObjectTypeResolver = $userRoleDoesNotExistErrorPayloadObjectTypeResolver;
+        }
+        return $this->userRoleDoesNotExistErrorPayloadObjectTypeResolver;
+    }
+
+    public function getObjectTypeResolver(): ObjectTypeResolverInterface
+    {
+        return $this->getUserRoleDoesNotExistErrorPayloadObjectTypeResolver();
+    }
+
+    protected function getTargetObjectClass(): string
+    {
+        return UserRoleDoesNotExistErrorPayload::class;
+    }
+
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/UsernameAlreadyExistsErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/user-mutations/src/ObjectTypeResolverPickers/UsernameAlreadyExistsErrorPayloadObjectTypeResolverPicker.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\ObjectTypeResolverPickers;
+
+use PoPCMSSchema\UserMutations\ObjectModels\UsernameAlreadyExistsErrorPayload;
+use PoPCMSSchema\UserMutations\TypeResolvers\ObjectType\UsernameAlreadyExistsErrorPayloadObjectTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\AbstractCreateUserMutationErrorPayloadUnionTypeResolver;
+use PoPSchema\SchemaCommons\ObjectTypeResolverPickers\AbstractErrorPayloadObjectTypeResolverPicker;
+use PoP\ComponentModel\TypeResolvers\ObjectType\ObjectTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class UsernameAlreadyExistsErrorPayloadObjectTypeResolverPicker extends AbstractErrorPayloadObjectTypeResolverPicker
+{
+    private ?UsernameAlreadyExistsErrorPayloadObjectTypeResolver $usernameAlreadyExistsErrorPayloadObjectTypeResolver = null;
+
+    final protected function getUsernameAlreadyExistsErrorPayloadObjectTypeResolver(): UsernameAlreadyExistsErrorPayloadObjectTypeResolver
+    {
+        if ($this->usernameAlreadyExistsErrorPayloadObjectTypeResolver === null) {
+            /** @var UsernameAlreadyExistsErrorPayloadObjectTypeResolver */
+            $usernameAlreadyExistsErrorPayloadObjectTypeResolver = $this->instanceManager->getInstance(UsernameAlreadyExistsErrorPayloadObjectTypeResolver::class);
+            $this->usernameAlreadyExistsErrorPayloadObjectTypeResolver = $usernameAlreadyExistsErrorPayloadObjectTypeResolver;
+        }
+        return $this->usernameAlreadyExistsErrorPayloadObjectTypeResolver;
+    }
+
+    public function getObjectTypeResolver(): ObjectTypeResolverInterface
+    {
+        return $this->getUsernameAlreadyExistsErrorPayloadObjectTypeResolver();
+    }
+
+    protected function getTargetObjectClass(): string
+    {
+        return UsernameAlreadyExistsErrorPayload::class;
+    }
+
+    /**
+     * @return array<class-string<UnionTypeResolverInterface>>
+     */
+    public function getUnionTypeResolverClassesToAttachTo(): array
+    {
+        return [
+            AbstractCreateUserMutationErrorPayloadUnionTypeResolver::class,
+        ];
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/CannotDeleteYourselfErrorPayloadObjectTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/CannotDeleteYourselfErrorPayloadObjectTypeDataLoader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType;
+
+use PoPCMSSchema\UserMutations\ObjectModels\CannotDeleteYourselfErrorPayload;
+use PoP\ComponentModel\RelationalTypeDataLoaders\ObjectType\AbstractDictionaryObjectTypeDataLoader;
+
+class CannotDeleteYourselfErrorPayloadObjectTypeDataLoader extends AbstractDictionaryObjectTypeDataLoader
+{
+    public function getObjectClass(): string
+    {
+        return CannotDeleteYourselfErrorPayload::class;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/EmailAlreadyExistsErrorPayloadObjectTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/EmailAlreadyExistsErrorPayloadObjectTypeDataLoader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType;
+
+use PoPCMSSchema\UserMutations\ObjectModels\EmailAlreadyExistsErrorPayload;
+use PoP\ComponentModel\RelationalTypeDataLoaders\ObjectType\AbstractDictionaryObjectTypeDataLoader;
+
+class EmailAlreadyExistsErrorPayloadObjectTypeDataLoader extends AbstractDictionaryObjectTypeDataLoader
+{
+    public function getObjectClass(): string
+    {
+        return EmailAlreadyExistsErrorPayload::class;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/InvalidEmailErrorPayloadObjectTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/InvalidEmailErrorPayloadObjectTypeDataLoader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType;
+
+use PoPCMSSchema\UserMutations\ObjectModels\InvalidEmailErrorPayload;
+use PoP\ComponentModel\RelationalTypeDataLoaders\ObjectType\AbstractDictionaryObjectTypeDataLoader;
+
+class InvalidEmailErrorPayloadObjectTypeDataLoader extends AbstractDictionaryObjectTypeDataLoader
+{
+    public function getObjectClass(): string
+    {
+        return InvalidEmailErrorPayload::class;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType;
+
+use PoPCMSSchema\UserMutations\ObjectModels\LoggedInUserHasNoPermissionToCreateUsersErrorPayload;
+use PoP\ComponentModel\RelationalTypeDataLoaders\ObjectType\AbstractDictionaryObjectTypeDataLoader;
+
+class LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader extends AbstractDictionaryObjectTypeDataLoader
+{
+    public function getObjectClass(): string
+    {
+        return LoggedInUserHasNoPermissionToCreateUsersErrorPayload::class;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType;
+
+use PoPCMSSchema\UserMutations\ObjectModels\LoggedInUserHasNoPermissionToDeleteUserErrorPayload;
+use PoP\ComponentModel\RelationalTypeDataLoaders\ObjectType\AbstractDictionaryObjectTypeDataLoader;
+
+class LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader extends AbstractDictionaryObjectTypeDataLoader
+{
+    public function getObjectClass(): string
+    {
+        return LoggedInUserHasNoPermissionToDeleteUserErrorPayload::class;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType;
+
+use PoPCMSSchema\UserMutations\ObjectModels\LoggedInUserHasNoPermissionToEditUserRolesErrorPayload;
+use PoP\ComponentModel\RelationalTypeDataLoaders\ObjectType\AbstractDictionaryObjectTypeDataLoader;
+
+class LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader extends AbstractDictionaryObjectTypeDataLoader
+{
+    public function getObjectClass(): string
+    {
+        return LoggedInUserHasNoPermissionToEditUserRolesErrorPayload::class;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/ReassignUserDoesNotExistErrorPayloadObjectTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/ReassignUserDoesNotExistErrorPayloadObjectTypeDataLoader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType;
+
+use PoPCMSSchema\UserMutations\ObjectModels\ReassignUserDoesNotExistErrorPayload;
+use PoP\ComponentModel\RelationalTypeDataLoaders\ObjectType\AbstractDictionaryObjectTypeDataLoader;
+
+class ReassignUserDoesNotExistErrorPayloadObjectTypeDataLoader extends AbstractDictionaryObjectTypeDataLoader
+{
+    public function getObjectClass(): string
+    {
+        return ReassignUserDoesNotExistErrorPayload::class;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/UserRoleDoesNotExistErrorPayloadObjectTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/UserRoleDoesNotExistErrorPayloadObjectTypeDataLoader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType;
+
+use PoPCMSSchema\UserMutations\ObjectModels\UserRoleDoesNotExistErrorPayload;
+use PoP\ComponentModel\RelationalTypeDataLoaders\ObjectType\AbstractDictionaryObjectTypeDataLoader;
+
+class UserRoleDoesNotExistErrorPayloadObjectTypeDataLoader extends AbstractDictionaryObjectTypeDataLoader
+{
+    public function getObjectClass(): string
+    {
+        return UserRoleDoesNotExistErrorPayload::class;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/UsernameAlreadyExistsErrorPayloadObjectTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/ObjectType/UsernameAlreadyExistsErrorPayloadObjectTypeDataLoader.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType;
+
+use PoPCMSSchema\UserMutations\ObjectModels\UsernameAlreadyExistsErrorPayload;
+use PoP\ComponentModel\RelationalTypeDataLoaders\ObjectType\AbstractDictionaryObjectTypeDataLoader;
+
+class UsernameAlreadyExistsErrorPayloadObjectTypeDataLoader extends AbstractDictionaryObjectTypeDataLoader
+{
+    public function getObjectClass(): string
+    {
+        return UsernameAlreadyExistsErrorPayload::class;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/UnionType/RootCreateUserMutationErrorPayloadUnionTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/UnionType/RootCreateUserMutationErrorPayloadUnionTypeDataLoader.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\UnionType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootCreateUserMutationErrorPayloadUnionTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\UnionType\AbstractUnionTypeDataLoader;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class RootCreateUserMutationErrorPayloadUnionTypeDataLoader extends AbstractUnionTypeDataLoader
+{
+    private ?RootCreateUserMutationErrorPayloadUnionTypeResolver $rootCreateUserMutationErrorPayloadUnionTypeResolver = null;
+
+    final protected function getRootCreateUserMutationErrorPayloadUnionTypeResolver(): RootCreateUserMutationErrorPayloadUnionTypeResolver
+    {
+        if ($this->rootCreateUserMutationErrorPayloadUnionTypeResolver === null) {
+            /** @var RootCreateUserMutationErrorPayloadUnionTypeResolver */
+            $rootCreateUserMutationErrorPayloadUnionTypeResolver = $this->instanceManager->getInstance(RootCreateUserMutationErrorPayloadUnionTypeResolver::class);
+            $this->rootCreateUserMutationErrorPayloadUnionTypeResolver = $rootCreateUserMutationErrorPayloadUnionTypeResolver;
+        }
+        return $this->rootCreateUserMutationErrorPayloadUnionTypeResolver;
+    }
+
+    protected function getUnionTypeResolver(): UnionTypeResolverInterface
+    {
+        return $this->getRootCreateUserMutationErrorPayloadUnionTypeResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/UnionType/RootDeleteUserMutationErrorPayloadUnionTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/UnionType/RootDeleteUserMutationErrorPayloadUnionTypeDataLoader.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\UnionType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootDeleteUserMutationErrorPayloadUnionTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\UnionType\AbstractUnionTypeDataLoader;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class RootDeleteUserMutationErrorPayloadUnionTypeDataLoader extends AbstractUnionTypeDataLoader
+{
+    private ?RootDeleteUserMutationErrorPayloadUnionTypeResolver $rootDeleteUserMutationErrorPayloadUnionTypeResolver = null;
+
+    final protected function getRootDeleteUserMutationErrorPayloadUnionTypeResolver(): RootDeleteUserMutationErrorPayloadUnionTypeResolver
+    {
+        if ($this->rootDeleteUserMutationErrorPayloadUnionTypeResolver === null) {
+            /** @var RootDeleteUserMutationErrorPayloadUnionTypeResolver */
+            $rootDeleteUserMutationErrorPayloadUnionTypeResolver = $this->instanceManager->getInstance(RootDeleteUserMutationErrorPayloadUnionTypeResolver::class);
+            $this->rootDeleteUserMutationErrorPayloadUnionTypeResolver = $rootDeleteUserMutationErrorPayloadUnionTypeResolver;
+        }
+        return $this->rootDeleteUserMutationErrorPayloadUnionTypeResolver;
+    }
+
+    protected function getUnionTypeResolver(): UnionTypeResolverInterface
+    {
+        return $this->getRootDeleteUserMutationErrorPayloadUnionTypeResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/UnionType/RootUpdateUserMutationErrorPayloadUnionTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/UnionType/RootUpdateUserMutationErrorPayloadUnionTypeDataLoader.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\UnionType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\UnionType\AbstractUnionTypeDataLoader;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class RootUpdateUserMutationErrorPayloadUnionTypeDataLoader extends AbstractUnionTypeDataLoader
+{
+    private ?RootUpdateUserMutationErrorPayloadUnionTypeResolver $rootUpdateUserMutationErrorPayloadUnionTypeResolver = null;
+
+    final protected function getRootUpdateUserMutationErrorPayloadUnionTypeResolver(): RootUpdateUserMutationErrorPayloadUnionTypeResolver
+    {
+        if ($this->rootUpdateUserMutationErrorPayloadUnionTypeResolver === null) {
+            /** @var RootUpdateUserMutationErrorPayloadUnionTypeResolver */
+            $rootUpdateUserMutationErrorPayloadUnionTypeResolver = $this->instanceManager->getInstance(RootUpdateUserMutationErrorPayloadUnionTypeResolver::class);
+            $this->rootUpdateUserMutationErrorPayloadUnionTypeResolver = $rootUpdateUserMutationErrorPayloadUnionTypeResolver;
+        }
+        return $this->rootUpdateUserMutationErrorPayloadUnionTypeResolver;
+    }
+
+    protected function getUnionTypeResolver(): UnionTypeResolverInterface
+    {
+        return $this->getRootUpdateUserMutationErrorPayloadUnionTypeResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/UnionType/UserDeleteMutationErrorPayloadUnionTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/UnionType/UserDeleteMutationErrorPayloadUnionTypeDataLoader.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\UnionType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\UserDeleteMutationErrorPayloadUnionTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\UnionType\AbstractUnionTypeDataLoader;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class UserDeleteMutationErrorPayloadUnionTypeDataLoader extends AbstractUnionTypeDataLoader
+{
+    private ?UserDeleteMutationErrorPayloadUnionTypeResolver $userDeleteMutationErrorPayloadUnionTypeResolver = null;
+
+    final protected function getUserDeleteMutationErrorPayloadUnionTypeResolver(): UserDeleteMutationErrorPayloadUnionTypeResolver
+    {
+        if ($this->userDeleteMutationErrorPayloadUnionTypeResolver === null) {
+            /** @var UserDeleteMutationErrorPayloadUnionTypeResolver */
+            $userDeleteMutationErrorPayloadUnionTypeResolver = $this->instanceManager->getInstance(UserDeleteMutationErrorPayloadUnionTypeResolver::class);
+            $this->userDeleteMutationErrorPayloadUnionTypeResolver = $userDeleteMutationErrorPayloadUnionTypeResolver;
+        }
+        return $this->userDeleteMutationErrorPayloadUnionTypeResolver;
+    }
+
+    protected function getUnionTypeResolver(): UnionTypeResolverInterface
+    {
+        return $this->getUserDeleteMutationErrorPayloadUnionTypeResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/UnionType/UserUpdateMutationErrorPayloadUnionTypeDataLoader.php
+++ b/layers/CMSSchema/packages/user-mutations/src/RelationalTypeDataLoaders/UnionType/UserUpdateMutationErrorPayloadUnionTypeDataLoader.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\UnionType;
+
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\UserUpdateMutationErrorPayloadUnionTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\UnionType\AbstractUnionTypeDataLoader;
+use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
+
+class UserUpdateMutationErrorPayloadUnionTypeDataLoader extends AbstractUnionTypeDataLoader
+{
+    private ?UserUpdateMutationErrorPayloadUnionTypeResolver $userUpdateMutationErrorPayloadUnionTypeResolver = null;
+
+    final protected function getUserUpdateMutationErrorPayloadUnionTypeResolver(): UserUpdateMutationErrorPayloadUnionTypeResolver
+    {
+        if ($this->userUpdateMutationErrorPayloadUnionTypeResolver === null) {
+            /** @var UserUpdateMutationErrorPayloadUnionTypeResolver */
+            $userUpdateMutationErrorPayloadUnionTypeResolver = $this->instanceManager->getInstance(UserUpdateMutationErrorPayloadUnionTypeResolver::class);
+            $this->userUpdateMutationErrorPayloadUnionTypeResolver = $userUpdateMutationErrorPayloadUnionTypeResolver;
+        }
+        return $this->userUpdateMutationErrorPayloadUnionTypeResolver;
+    }
+
+    protected function getUnionTypeResolver(): UnionTypeResolverInterface
+    {
+        return $this->getUserUpdateMutationErrorPayloadUnionTypeResolver();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeAPIs/UserTypeMutationAPIInterface.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeAPIs/UserTypeMutationAPIInterface.php
@@ -4,7 +4,47 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserMutations\TypeAPIs;
 
+use PoPCMSSchema\UserMutations\Exception\UserCRUDMutationException;
+
 interface UserTypeMutationAPIInterface
 {
     public function canLoggedInUserEditUser(string|int $userID): bool;
+    public function canLoggedInUserCreateUsers(): bool;
+    public function canLoggedInUserDeleteUsers(): bool;
+    public function canLoggedInUserDeleteUser(string|int $userID): bool;
+    public function canLoggedInUserPromoteUsers(): bool;
+
+    /**
+     * Whether the site runs on a multisite network, where the user
+     * CRUD semantics differ and are not supported by these mutations.
+     */
+    public function isMultisite(): bool;
+
+    public function roleExists(string $role): bool;
+    public function isValidEmail(string $email): bool;
+
+    /**
+     * @throws UserCRUDMutationException In case of error
+     * @param array<string,mixed> $userData
+     */
+    public function createUser(
+        array $userData,
+    ): string|int;
+
+    /**
+     * @throws UserCRUDMutationException In case of error
+     * @param array<string,mixed> $userData
+     */
+    public function updateUser(
+        array $userData,
+    ): string|int;
+
+    /**
+     * @throws UserCRUDMutationException In case of error
+     * @param string|int|null $reassignAuthorContentToUserID User to reassign the deleted user's content to, or `null` to delete the content
+     */
+    public function deleteUser(
+        string|int $userID,
+        string|int|null $reassignAuthorContentToUserID,
+    ): void;
 }

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/AbstractCreateOrUpdateUserInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/AbstractCreateOrUpdateUserInputObjectTypeResolver.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+use PoPCMSSchema\UserMutations\Constants\MutationInputProperties;
+use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\DateTimeScalarTypeResolver;
+use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\EmailScalarTypeResolver;
+use PoPSchema\SchemaCommons\TypeResolvers\ScalarType\URLScalarTypeResolver;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\InputObjectType\AbstractInputObjectTypeResolver;
+use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ScalarType\BooleanScalarTypeResolver;
+use PoP\ComponentModel\TypeResolvers\ScalarType\IDScalarTypeResolver;
+use PoP\ComponentModel\TypeResolvers\ScalarType\StringScalarTypeResolver;
+
+abstract class AbstractCreateOrUpdateUserInputObjectTypeResolver extends AbstractInputObjectTypeResolver implements CreateUserInputObjectTypeResolverInterface
+{
+    private ?IDScalarTypeResolver $idScalarTypeResolver = null;
+    private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
+    private ?EmailScalarTypeResolver $emailScalarTypeResolver = null;
+    private ?URLScalarTypeResolver $urlScalarTypeResolver = null;
+    private ?DateTimeScalarTypeResolver $dateTimeScalarTypeResolver = null;
+    private ?BooleanScalarTypeResolver $booleanScalarTypeResolver = null;
+
+    final protected function getIDScalarTypeResolver(): IDScalarTypeResolver
+    {
+        if ($this->idScalarTypeResolver === null) {
+            /** @var IDScalarTypeResolver */
+            $idScalarTypeResolver = $this->instanceManager->getInstance(IDScalarTypeResolver::class);
+            $this->idScalarTypeResolver = $idScalarTypeResolver;
+        }
+        return $this->idScalarTypeResolver;
+    }
+    final protected function getStringScalarTypeResolver(): StringScalarTypeResolver
+    {
+        if ($this->stringScalarTypeResolver === null) {
+            /** @var StringScalarTypeResolver */
+            $stringScalarTypeResolver = $this->instanceManager->getInstance(StringScalarTypeResolver::class);
+            $this->stringScalarTypeResolver = $stringScalarTypeResolver;
+        }
+        return $this->stringScalarTypeResolver;
+    }
+    final protected function getEmailScalarTypeResolver(): EmailScalarTypeResolver
+    {
+        if ($this->emailScalarTypeResolver === null) {
+            /** @var EmailScalarTypeResolver */
+            $emailScalarTypeResolver = $this->instanceManager->getInstance(EmailScalarTypeResolver::class);
+            $this->emailScalarTypeResolver = $emailScalarTypeResolver;
+        }
+        return $this->emailScalarTypeResolver;
+    }
+    final protected function getURLScalarTypeResolver(): URLScalarTypeResolver
+    {
+        if ($this->urlScalarTypeResolver === null) {
+            /** @var URLScalarTypeResolver */
+            $urlScalarTypeResolver = $this->instanceManager->getInstance(URLScalarTypeResolver::class);
+            $this->urlScalarTypeResolver = $urlScalarTypeResolver;
+        }
+        return $this->urlScalarTypeResolver;
+    }
+    final protected function getDateTimeScalarTypeResolver(): DateTimeScalarTypeResolver
+    {
+        if ($this->dateTimeScalarTypeResolver === null) {
+            /** @var DateTimeScalarTypeResolver */
+            $dateTimeScalarTypeResolver = $this->instanceManager->getInstance(DateTimeScalarTypeResolver::class);
+            $this->dateTimeScalarTypeResolver = $dateTimeScalarTypeResolver;
+        }
+        return $this->dateTimeScalarTypeResolver;
+    }
+    final protected function getBooleanScalarTypeResolver(): BooleanScalarTypeResolver
+    {
+        if ($this->booleanScalarTypeResolver === null) {
+            /** @var BooleanScalarTypeResolver */
+            $booleanScalarTypeResolver = $this->instanceManager->getInstance(BooleanScalarTypeResolver::class);
+            $this->booleanScalarTypeResolver = $booleanScalarTypeResolver;
+        }
+        return $this->booleanScalarTypeResolver;
+    }
+
+    /**
+     * @return array<string,InputTypeResolverInterface>
+     */
+    public function getInputFieldNameTypeResolvers(): array
+    {
+        return array_merge(
+            $this->addUserInputField() ? [
+                MutationInputProperties::ID => $this->getIDScalarTypeResolver(),
+            ] : [],
+            $this->addUsernameInputField() ? [
+                MutationInputProperties::USERNAME => $this->getStringScalarTypeResolver(),
+            ] : [],
+            [
+                MutationInputProperties::EMAIL => $this->getEmailScalarTypeResolver(),
+                MutationInputProperties::PASSWORD => $this->getStringScalarTypeResolver(),
+                MutationInputProperties::ROLES => $this->getStringScalarTypeResolver(),
+                MutationInputProperties::FIRST_NAME => $this->getStringScalarTypeResolver(),
+                MutationInputProperties::LAST_NAME => $this->getStringScalarTypeResolver(),
+                MutationInputProperties::NICKNAME => $this->getStringScalarTypeResolver(),
+                MutationInputProperties::DISPLAY_NAME => $this->getStringScalarTypeResolver(),
+                MutationInputProperties::SLUG => $this->getStringScalarTypeResolver(),
+                MutationInputProperties::WEBSITE_URL => $this->getURLScalarTypeResolver(),
+                MutationInputProperties::DESCRIPTION => $this->getStringScalarTypeResolver(),
+                MutationInputProperties::LOCALE => $this->getStringScalarTypeResolver(),
+                MutationInputProperties::REGISTERED_DATE => $this->getDateTimeScalarTypeResolver(),
+            ],
+            $this->addUsernameInputField() ? [
+                MutationInputProperties::SEND_EMAIL_NOTIFICATION => $this->getBooleanScalarTypeResolver(),
+            ] : [],
+        );
+    }
+
+    abstract protected function addUserInputField(): bool;
+
+    abstract protected function addUsernameInputField(): bool;
+
+    public function getInputFieldDescription(string $inputFieldName): ?string
+    {
+        return match ($inputFieldName) {
+            MutationInputProperties::ID => $this->__('The ID of the user to update', 'gatographql'),
+            MutationInputProperties::USERNAME => $this->__('The username (login). It cannot be changed once the user is created', 'gatographql'),
+            MutationInputProperties::EMAIL => $this->__('The user\'s email address', 'gatographql'),
+            MutationInputProperties::PASSWORD => $this->__('The user\'s password. When creating a user, if not provided a random password is generated', 'gatographql'),
+            MutationInputProperties::ROLES => $this->__('The roles assigned to the user', 'gatographql'),
+            MutationInputProperties::FIRST_NAME => $this->__('The user\'s first name', 'gatographql'),
+            MutationInputProperties::LAST_NAME => $this->__('The user\'s last name', 'gatographql'),
+            MutationInputProperties::NICKNAME => $this->__('The user\'s nickname', 'gatographql'),
+            MutationInputProperties::DISPLAY_NAME => $this->__('The name to display for the user on the site', 'gatographql'),
+            MutationInputProperties::SLUG => $this->__('The URL-friendly slug (nicename) for the user', 'gatographql'),
+            MutationInputProperties::WEBSITE_URL => $this->__('The user\'s website URL', 'gatographql'),
+            MutationInputProperties::DESCRIPTION => $this->__('The user\'s biographical description', 'gatographql'),
+            MutationInputProperties::LOCALE => $this->__('The user\'s locale', 'gatographql'),
+            MutationInputProperties::REGISTERED_DATE => $this->__('The date the user registered', 'gatographql'),
+            MutationInputProperties::SEND_EMAIL_NOTIFICATION => $this->__('Whether to send the new user an email about their account', 'gatographql'),
+            default => parent::getInputFieldDescription($inputFieldName),
+        };
+    }
+
+    public function getInputFieldTypeModifiers(string $inputFieldName): int
+    {
+        return match ($inputFieldName) {
+            MutationInputProperties::ID,
+            MutationInputProperties::USERNAME
+                => SchemaTypeModifiers::MANDATORY,
+            MutationInputProperties::EMAIL
+                => $this->addUsernameInputField()
+                    ? SchemaTypeModifiers::MANDATORY
+                    : SchemaTypeModifiers::NONE,
+            MutationInputProperties::ROLES
+                => SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
+            default
+                => parent::getInputFieldTypeModifiers($inputFieldName),
+        };
+    }
+
+    public function getInputFieldDefaultValue(string $inputFieldName): mixed
+    {
+        return match ($inputFieldName) {
+            MutationInputProperties::SEND_EMAIL_NOTIFICATION => false,
+            default => parent::getInputFieldDefaultValue($inputFieldName),
+        };
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/AbstractCreateUserInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/AbstractCreateUserInputObjectTypeResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+abstract class AbstractCreateUserInputObjectTypeResolver extends AbstractCreateOrUpdateUserInputObjectTypeResolver implements CreateUserInputObjectTypeResolverInterface
+{
+    protected function addUserInputField(): bool
+    {
+        return false;
+    }
+
+    protected function addUsernameInputField(): bool
+    {
+        return true;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/AbstractDeleteUserInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/AbstractDeleteUserInputObjectTypeResolver.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+use PoPCMSSchema\UserMutations\Constants\MutationInputProperties;
+use PoP\ComponentModel\Schema\SchemaTypeModifiers;
+use PoP\ComponentModel\TypeResolvers\InputObjectType\AbstractInputObjectTypeResolver;
+use PoP\ComponentModel\TypeResolvers\InputTypeResolverInterface;
+use PoP\ComponentModel\TypeResolvers\ScalarType\IDScalarTypeResolver;
+
+abstract class AbstractDeleteUserInputObjectTypeResolver extends AbstractInputObjectTypeResolver implements DeleteUserInputObjectTypeResolverInterface
+{
+    private ?IDScalarTypeResolver $idScalarTypeResolver = null;
+
+    final protected function getIDScalarTypeResolver(): IDScalarTypeResolver
+    {
+        if ($this->idScalarTypeResolver === null) {
+            /** @var IDScalarTypeResolver */
+            $idScalarTypeResolver = $this->instanceManager->getInstance(IDScalarTypeResolver::class);
+            $this->idScalarTypeResolver = $idScalarTypeResolver;
+        }
+        return $this->idScalarTypeResolver;
+    }
+
+    /**
+     * @return array<string,InputTypeResolverInterface>
+     */
+    public function getInputFieldNameTypeResolvers(): array
+    {
+        return array_merge(
+            $this->addIDInputField() ? [
+                MutationInputProperties::ID => $this->getIDScalarTypeResolver(),
+            ] : [],
+            [
+                MutationInputProperties::REASSIGN_AUTHOR_CONTENT_TO => $this->getIDScalarTypeResolver(),
+            ]
+        );
+    }
+
+    abstract protected function addIDInputField(): bool;
+
+    public function getInputFieldDescription(string $inputFieldName): ?string
+    {
+        return match ($inputFieldName) {
+            MutationInputProperties::ID => $this->__('The ID of the user to delete', 'gatographql'),
+            MutationInputProperties::REASSIGN_AUTHOR_CONTENT_TO => $this->__('The ID of the user to reassign the deleted user\'s content to. If not provided, the content is deleted', 'gatographql'),
+            default => parent::getInputFieldDescription($inputFieldName),
+        };
+    }
+
+    public function getInputFieldTypeModifiers(string $inputFieldName): int
+    {
+        return match ($inputFieldName) {
+            MutationInputProperties::ID => SchemaTypeModifiers::MANDATORY,
+            default => parent::getInputFieldTypeModifiers($inputFieldName),
+        };
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/AbstractUpdateUserInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/AbstractUpdateUserInputObjectTypeResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+abstract class AbstractUpdateUserInputObjectTypeResolver extends AbstractCreateOrUpdateUserInputObjectTypeResolver implements UpdateUserInputObjectTypeResolverInterface
+{
+    protected function addUserInputField(): bool
+    {
+        return true;
+    }
+
+    protected function addUsernameInputField(): bool
+    {
+        return false;
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/CreateUserInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/CreateUserInputObjectTypeResolverInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInterface;
+
+interface CreateUserInputObjectTypeResolverInterface extends InputObjectTypeResolverInterface
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/DeleteUserInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/DeleteUserInputObjectTypeResolverInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInterface;
+
+interface DeleteUserInputObjectTypeResolverInterface extends InputObjectTypeResolverInterface
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/RootCreateUserInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/RootCreateUserInputObjectTypeResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+class RootCreateUserInputObjectTypeResolver extends AbstractCreateUserInputObjectTypeResolver
+{
+    public function getTypeName(): string
+    {
+        return 'RootCreateUserInput';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Input to create a user', 'gatographql');
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/RootDeleteUserInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/RootDeleteUserInputObjectTypeResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+class RootDeleteUserInputObjectTypeResolver extends AbstractDeleteUserInputObjectTypeResolver
+{
+    protected function addIDInputField(): bool
+    {
+        return true;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'RootDeleteUserInput';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Input to delete a user', 'gatographql');
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/RootUpdateUserInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/RootUpdateUserInputObjectTypeResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+class RootUpdateUserInputObjectTypeResolver extends AbstractUpdateUserInputObjectTypeResolver
+{
+    public function getTypeName(): string
+    {
+        return 'RootUpdateUserInput';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Input to update a user', 'gatographql');
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/UpdateUserInputObjectTypeResolverInterface.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/UpdateUserInputObjectTypeResolverInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInterface;
+
+interface UpdateUserInputObjectTypeResolverInterface extends InputObjectTypeResolverInterface
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/UserDeleteInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/UserDeleteInputObjectTypeResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+class UserDeleteInputObjectTypeResolver extends AbstractDeleteUserInputObjectTypeResolver
+{
+    protected function addIDInputField(): bool
+    {
+        return false;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'UserDeleteInput';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Input to delete a user (nested mutations)', 'gatographql');
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/UserUpdateInputObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/InputObjectType/UserUpdateInputObjectTypeResolver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType;
+
+class UserUpdateInputObjectTypeResolver extends AbstractUpdateUserInputObjectTypeResolver
+{
+    protected function addUserInputField(): bool
+    {
+        return false;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'UserUpdateInput';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Input to update a user (nested mutations)', 'gatographql');
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/AbstractUserMutationPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/AbstractUserMutationPayloadObjectTypeResolver.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+use PoPSchema\SchemaCommons\TypeResolvers\ObjectType\AbstractObjectMutationPayloadObjectTypeResolver;
+
+abstract class AbstractUserMutationPayloadObjectTypeResolver extends AbstractObjectMutationPayloadObjectTypeResolver
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/CannotDeleteYourselfErrorPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/CannotDeleteYourselfErrorPayloadObjectTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType\CannotDeleteYourselfErrorPayloadObjectTypeDataLoader;
+use PoPSchema\SchemaCommons\TypeResolvers\ObjectType\AbstractErrorPayloadObjectTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class CannotDeleteYourselfErrorPayloadObjectTypeResolver extends AbstractErrorPayloadObjectTypeResolver
+{
+    private ?CannotDeleteYourselfErrorPayloadObjectTypeDataLoader $cannotDeleteYourselfErrorPayloadObjectTypeDataLoader = null;
+
+    final protected function getCannotDeleteYourselfErrorPayloadObjectTypeDataLoader(): CannotDeleteYourselfErrorPayloadObjectTypeDataLoader
+    {
+        if ($this->cannotDeleteYourselfErrorPayloadObjectTypeDataLoader === null) {
+            /** @var CannotDeleteYourselfErrorPayloadObjectTypeDataLoader */
+            $cannotDeleteYourselfErrorPayloadObjectTypeDataLoader = $this->instanceManager->getInstance(CannotDeleteYourselfErrorPayloadObjectTypeDataLoader::class);
+            $this->cannotDeleteYourselfErrorPayloadObjectTypeDataLoader = $cannotDeleteYourselfErrorPayloadObjectTypeDataLoader;
+        }
+        return $this->cannotDeleteYourselfErrorPayloadObjectTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'CannotDeleteYourselfErrorPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Error payload for: "The user cannot delete themselves"', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getCannotDeleteYourselfErrorPayloadObjectTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/EmailAlreadyExistsErrorPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/EmailAlreadyExistsErrorPayloadObjectTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType\EmailAlreadyExistsErrorPayloadObjectTypeDataLoader;
+use PoPSchema\SchemaCommons\TypeResolvers\ObjectType\AbstractErrorPayloadObjectTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class EmailAlreadyExistsErrorPayloadObjectTypeResolver extends AbstractErrorPayloadObjectTypeResolver
+{
+    private ?EmailAlreadyExistsErrorPayloadObjectTypeDataLoader $emailAlreadyExistsErrorPayloadObjectTypeDataLoader = null;
+
+    final protected function getEmailAlreadyExistsErrorPayloadObjectTypeDataLoader(): EmailAlreadyExistsErrorPayloadObjectTypeDataLoader
+    {
+        if ($this->emailAlreadyExistsErrorPayloadObjectTypeDataLoader === null) {
+            /** @var EmailAlreadyExistsErrorPayloadObjectTypeDataLoader */
+            $emailAlreadyExistsErrorPayloadObjectTypeDataLoader = $this->instanceManager->getInstance(EmailAlreadyExistsErrorPayloadObjectTypeDataLoader::class);
+            $this->emailAlreadyExistsErrorPayloadObjectTypeDataLoader = $emailAlreadyExistsErrorPayloadObjectTypeDataLoader;
+        }
+        return $this->emailAlreadyExistsErrorPayloadObjectTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'EmailAlreadyExistsErrorPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Error payload for: "The email already exists"', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getEmailAlreadyExistsErrorPayloadObjectTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/InvalidEmailErrorPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/InvalidEmailErrorPayloadObjectTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType\InvalidEmailErrorPayloadObjectTypeDataLoader;
+use PoPSchema\SchemaCommons\TypeResolvers\ObjectType\AbstractErrorPayloadObjectTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class InvalidEmailErrorPayloadObjectTypeResolver extends AbstractErrorPayloadObjectTypeResolver
+{
+    private ?InvalidEmailErrorPayloadObjectTypeDataLoader $invalidEmailErrorPayloadObjectTypeDataLoader = null;
+
+    final protected function getInvalidEmailErrorPayloadObjectTypeDataLoader(): InvalidEmailErrorPayloadObjectTypeDataLoader
+    {
+        if ($this->invalidEmailErrorPayloadObjectTypeDataLoader === null) {
+            /** @var InvalidEmailErrorPayloadObjectTypeDataLoader */
+            $invalidEmailErrorPayloadObjectTypeDataLoader = $this->instanceManager->getInstance(InvalidEmailErrorPayloadObjectTypeDataLoader::class);
+            $this->invalidEmailErrorPayloadObjectTypeDataLoader = $invalidEmailErrorPayloadObjectTypeDataLoader;
+        }
+        return $this->invalidEmailErrorPayloadObjectTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'InvalidEmailErrorPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Error payload for: "The email is invalid"', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getInvalidEmailErrorPayloadObjectTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType\LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader;
+use PoPSchema\SchemaCommons\TypeResolvers\ObjectType\AbstractErrorPayloadObjectTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeResolver extends AbstractErrorPayloadObjectTypeResolver
+{
+    private ?LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader $loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader = null;
+
+    final protected function getLoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader(): LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader
+    {
+        if ($this->loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader === null) {
+            /** @var LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader */
+            $loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader = $this->instanceManager->getInstance(LoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader::class);
+            $this->loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader = $loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader;
+        }
+        return $this->loggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'LoggedInUserHasNoPermissionToCreateUsersErrorPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Error payload for: "The logged-in user does not have permission to create users"', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getLoggedInUserHasNoPermissionToCreateUsersErrorPayloadObjectTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType\LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader;
+use PoPSchema\SchemaCommons\TypeResolvers\ObjectType\AbstractErrorPayloadObjectTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeResolver extends AbstractErrorPayloadObjectTypeResolver
+{
+    private ?LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader $loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader = null;
+
+    final protected function getLoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader(): LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader
+    {
+        if ($this->loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader === null) {
+            /** @var LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader */
+            $loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader = $this->instanceManager->getInstance(LoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader::class);
+            $this->loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader = $loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader;
+        }
+        return $this->loggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'LoggedInUserHasNoPermissionToDeleteUserErrorPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Error payload for: "The logged-in user does not have permission to delete the user"', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getLoggedInUserHasNoPermissionToDeleteUserErrorPayloadObjectTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType\LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader;
+use PoPSchema\SchemaCommons\TypeResolvers\ObjectType\AbstractErrorPayloadObjectTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeResolver extends AbstractErrorPayloadObjectTypeResolver
+{
+    private ?LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader $loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader = null;
+
+    final protected function getLoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader(): LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader
+    {
+        if ($this->loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader === null) {
+            /** @var LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader */
+            $loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader = $this->instanceManager->getInstance(LoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader::class);
+            $this->loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader = $loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader;
+        }
+        return $this->loggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'LoggedInUserHasNoPermissionToEditUserRolesErrorPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Error payload for: "The logged-in user does not have permission to edit the user roles"', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getLoggedInUserHasNoPermissionToEditUserRolesErrorPayloadObjectTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/ReassignUserDoesNotExistErrorPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/ReassignUserDoesNotExistErrorPayloadObjectTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType\ReassignUserDoesNotExistErrorPayloadObjectTypeDataLoader;
+use PoPSchema\SchemaCommons\TypeResolvers\ObjectType\AbstractErrorPayloadObjectTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class ReassignUserDoesNotExistErrorPayloadObjectTypeResolver extends AbstractErrorPayloadObjectTypeResolver
+{
+    private ?ReassignUserDoesNotExistErrorPayloadObjectTypeDataLoader $reassignUserDoesNotExistErrorPayloadObjectTypeDataLoader = null;
+
+    final protected function getReassignUserDoesNotExistErrorPayloadObjectTypeDataLoader(): ReassignUserDoesNotExistErrorPayloadObjectTypeDataLoader
+    {
+        if ($this->reassignUserDoesNotExistErrorPayloadObjectTypeDataLoader === null) {
+            /** @var ReassignUserDoesNotExistErrorPayloadObjectTypeDataLoader */
+            $reassignUserDoesNotExistErrorPayloadObjectTypeDataLoader = $this->instanceManager->getInstance(ReassignUserDoesNotExistErrorPayloadObjectTypeDataLoader::class);
+            $this->reassignUserDoesNotExistErrorPayloadObjectTypeDataLoader = $reassignUserDoesNotExistErrorPayloadObjectTypeDataLoader;
+        }
+        return $this->reassignUserDoesNotExistErrorPayloadObjectTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'ReassignUserDoesNotExistErrorPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Error payload for: "The user to reassign the content to does not exist"', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getReassignUserDoesNotExistErrorPayloadObjectTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/RootCreateUserMutationPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/RootCreateUserMutationPayloadObjectTypeResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+class RootCreateUserMutationPayloadObjectTypeResolver extends AbstractUserMutationPayloadObjectTypeResolver
+{
+    public function getTypeName(): string
+    {
+        return 'RootCreateUserMutationPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Payload of creating a user', 'gatographql');
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/RootDeleteUserMutationPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/RootDeleteUserMutationPayloadObjectTypeResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+class RootDeleteUserMutationPayloadObjectTypeResolver extends AbstractUserMutationPayloadObjectTypeResolver
+{
+    public function getTypeName(): string
+    {
+        return 'RootDeleteUserMutationPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Payload of deleting a user', 'gatographql');
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/RootUpdateUserMutationPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/RootUpdateUserMutationPayloadObjectTypeResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+class RootUpdateUserMutationPayloadObjectTypeResolver extends AbstractUserMutationPayloadObjectTypeResolver
+{
+    public function getTypeName(): string
+    {
+        return 'RootUpdateUserMutationPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Payload of updating a user', 'gatographql');
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/UserDeleteMutationPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/UserDeleteMutationPayloadObjectTypeResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+class UserDeleteMutationPayloadObjectTypeResolver extends AbstractUserMutationPayloadObjectTypeResolver
+{
+    public function getTypeName(): string
+    {
+        return 'UserDeleteMutationPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Payload of deleting a user (nested mutations)', 'gatographql');
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/UserRoleDoesNotExistErrorPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/UserRoleDoesNotExistErrorPayloadObjectTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType\UserRoleDoesNotExistErrorPayloadObjectTypeDataLoader;
+use PoPSchema\SchemaCommons\TypeResolvers\ObjectType\AbstractErrorPayloadObjectTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class UserRoleDoesNotExistErrorPayloadObjectTypeResolver extends AbstractErrorPayloadObjectTypeResolver
+{
+    private ?UserRoleDoesNotExistErrorPayloadObjectTypeDataLoader $userRoleDoesNotExistErrorPayloadObjectTypeDataLoader = null;
+
+    final protected function getUserRoleDoesNotExistErrorPayloadObjectTypeDataLoader(): UserRoleDoesNotExistErrorPayloadObjectTypeDataLoader
+    {
+        if ($this->userRoleDoesNotExistErrorPayloadObjectTypeDataLoader === null) {
+            /** @var UserRoleDoesNotExistErrorPayloadObjectTypeDataLoader */
+            $userRoleDoesNotExistErrorPayloadObjectTypeDataLoader = $this->instanceManager->getInstance(UserRoleDoesNotExistErrorPayloadObjectTypeDataLoader::class);
+            $this->userRoleDoesNotExistErrorPayloadObjectTypeDataLoader = $userRoleDoesNotExistErrorPayloadObjectTypeDataLoader;
+        }
+        return $this->userRoleDoesNotExistErrorPayloadObjectTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'UserRoleDoesNotExistErrorPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Error payload for: "The user role does not exist"', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getUserRoleDoesNotExistErrorPayloadObjectTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/UserUpdateMutationPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/UserUpdateMutationPayloadObjectTypeResolver.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+class UserUpdateMutationPayloadObjectTypeResolver extends AbstractUserMutationPayloadObjectTypeResolver
+{
+    public function getTypeName(): string
+    {
+        return 'UserUpdateMutationPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Payload of updating a user (nested mutations)', 'gatographql');
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/UsernameAlreadyExistsErrorPayloadObjectTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/ObjectType/UsernameAlreadyExistsErrorPayloadObjectTypeResolver.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\ObjectType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\ObjectType\UsernameAlreadyExistsErrorPayloadObjectTypeDataLoader;
+use PoPSchema\SchemaCommons\TypeResolvers\ObjectType\AbstractErrorPayloadObjectTypeResolver;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class UsernameAlreadyExistsErrorPayloadObjectTypeResolver extends AbstractErrorPayloadObjectTypeResolver
+{
+    private ?UsernameAlreadyExistsErrorPayloadObjectTypeDataLoader $usernameAlreadyExistsErrorPayloadObjectTypeDataLoader = null;
+
+    final protected function getUsernameAlreadyExistsErrorPayloadObjectTypeDataLoader(): UsernameAlreadyExistsErrorPayloadObjectTypeDataLoader
+    {
+        if ($this->usernameAlreadyExistsErrorPayloadObjectTypeDataLoader === null) {
+            /** @var UsernameAlreadyExistsErrorPayloadObjectTypeDataLoader */
+            $usernameAlreadyExistsErrorPayloadObjectTypeDataLoader = $this->instanceManager->getInstance(UsernameAlreadyExistsErrorPayloadObjectTypeDataLoader::class);
+            $this->usernameAlreadyExistsErrorPayloadObjectTypeDataLoader = $usernameAlreadyExistsErrorPayloadObjectTypeDataLoader;
+        }
+        return $this->usernameAlreadyExistsErrorPayloadObjectTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'UsernameAlreadyExistsErrorPayload';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Error payload for: "The username already exists"', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getUsernameAlreadyExistsErrorPayloadObjectTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\UnionType;
+
+use PoPSchema\SchemaCommons\TypeResolvers\UnionType\AbstractErrorPayloadUnionTypeResolver;
+
+abstract class AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver extends AbstractErrorPayloadUnionTypeResolver
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/AbstractCreateUserMutationErrorPayloadUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/AbstractCreateUserMutationErrorPayloadUnionTypeResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\UnionType;
+
+abstract class AbstractCreateUserMutationErrorPayloadUnionTypeResolver extends AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/AbstractDeleteUserMutationErrorPayloadUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/AbstractDeleteUserMutationErrorPayloadUnionTypeResolver.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\UnionType;
+
+use PoPSchema\SchemaCommons\TypeResolvers\UnionType\AbstractErrorPayloadUnionTypeResolver;
+
+abstract class AbstractDeleteUserMutationErrorPayloadUnionTypeResolver extends AbstractErrorPayloadUnionTypeResolver
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/AbstractUpdateUserMutationErrorPayloadUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/AbstractUpdateUserMutationErrorPayloadUnionTypeResolver.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\UnionType;
+
+abstract class AbstractUpdateUserMutationErrorPayloadUnionTypeResolver extends AbstractCreateOrUpdateUserMutationErrorPayloadUnionTypeResolver
+{
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/RootCreateUserMutationErrorPayloadUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/RootCreateUserMutationErrorPayloadUnionTypeResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\UnionType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\UnionType\RootCreateUserMutationErrorPayloadUnionTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class RootCreateUserMutationErrorPayloadUnionTypeResolver extends AbstractCreateUserMutationErrorPayloadUnionTypeResolver
+{
+    private ?RootCreateUserMutationErrorPayloadUnionTypeDataLoader $rootCreateUserMutationErrorPayloadUnionTypeDataLoader = null;
+
+    final protected function getRootCreateUserMutationErrorPayloadUnionTypeDataLoader(): RootCreateUserMutationErrorPayloadUnionTypeDataLoader
+    {
+        if ($this->rootCreateUserMutationErrorPayloadUnionTypeDataLoader === null) {
+            /** @var RootCreateUserMutationErrorPayloadUnionTypeDataLoader */
+            $rootCreateUserMutationErrorPayloadUnionTypeDataLoader = $this->instanceManager->getInstance(RootCreateUserMutationErrorPayloadUnionTypeDataLoader::class);
+            $this->rootCreateUserMutationErrorPayloadUnionTypeDataLoader = $rootCreateUserMutationErrorPayloadUnionTypeDataLoader;
+        }
+        return $this->rootCreateUserMutationErrorPayloadUnionTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'RootCreateUserMutationErrorPayloadUnion';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Union of \'Error Payload\' types when creating a user', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getRootCreateUserMutationErrorPayloadUnionTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/RootDeleteUserMutationErrorPayloadUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/RootDeleteUserMutationErrorPayloadUnionTypeResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\UnionType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\UnionType\RootDeleteUserMutationErrorPayloadUnionTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class RootDeleteUserMutationErrorPayloadUnionTypeResolver extends AbstractDeleteUserMutationErrorPayloadUnionTypeResolver
+{
+    private ?RootDeleteUserMutationErrorPayloadUnionTypeDataLoader $rootDeleteUserMutationErrorPayloadUnionTypeDataLoader = null;
+
+    final protected function getRootDeleteUserMutationErrorPayloadUnionTypeDataLoader(): RootDeleteUserMutationErrorPayloadUnionTypeDataLoader
+    {
+        if ($this->rootDeleteUserMutationErrorPayloadUnionTypeDataLoader === null) {
+            /** @var RootDeleteUserMutationErrorPayloadUnionTypeDataLoader */
+            $rootDeleteUserMutationErrorPayloadUnionTypeDataLoader = $this->instanceManager->getInstance(RootDeleteUserMutationErrorPayloadUnionTypeDataLoader::class);
+            $this->rootDeleteUserMutationErrorPayloadUnionTypeDataLoader = $rootDeleteUserMutationErrorPayloadUnionTypeDataLoader;
+        }
+        return $this->rootDeleteUserMutationErrorPayloadUnionTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'RootDeleteUserMutationErrorPayloadUnion';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Union of \'Error Payload\' types when deleting a user', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getRootDeleteUserMutationErrorPayloadUnionTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/RootUpdateUserMutationErrorPayloadUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/RootUpdateUserMutationErrorPayloadUnionTypeResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\UnionType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\UnionType\RootUpdateUserMutationErrorPayloadUnionTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class RootUpdateUserMutationErrorPayloadUnionTypeResolver extends AbstractUpdateUserMutationErrorPayloadUnionTypeResolver
+{
+    private ?RootUpdateUserMutationErrorPayloadUnionTypeDataLoader $rootUpdateUserMutationErrorPayloadUnionTypeDataLoader = null;
+
+    final protected function getRootUpdateUserMutationErrorPayloadUnionTypeDataLoader(): RootUpdateUserMutationErrorPayloadUnionTypeDataLoader
+    {
+        if ($this->rootUpdateUserMutationErrorPayloadUnionTypeDataLoader === null) {
+            /** @var RootUpdateUserMutationErrorPayloadUnionTypeDataLoader */
+            $rootUpdateUserMutationErrorPayloadUnionTypeDataLoader = $this->instanceManager->getInstance(RootUpdateUserMutationErrorPayloadUnionTypeDataLoader::class);
+            $this->rootUpdateUserMutationErrorPayloadUnionTypeDataLoader = $rootUpdateUserMutationErrorPayloadUnionTypeDataLoader;
+        }
+        return $this->rootUpdateUserMutationErrorPayloadUnionTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'RootUpdateUserMutationErrorPayloadUnion';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Union of \'Error Payload\' types when updating a user', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getRootUpdateUserMutationErrorPayloadUnionTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/UserDeleteMutationErrorPayloadUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/UserDeleteMutationErrorPayloadUnionTypeResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\UnionType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\UnionType\UserDeleteMutationErrorPayloadUnionTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class UserDeleteMutationErrorPayloadUnionTypeResolver extends AbstractDeleteUserMutationErrorPayloadUnionTypeResolver
+{
+    private ?UserDeleteMutationErrorPayloadUnionTypeDataLoader $userDeleteMutationErrorPayloadUnionTypeDataLoader = null;
+
+    final protected function getUserDeleteMutationErrorPayloadUnionTypeDataLoader(): UserDeleteMutationErrorPayloadUnionTypeDataLoader
+    {
+        if ($this->userDeleteMutationErrorPayloadUnionTypeDataLoader === null) {
+            /** @var UserDeleteMutationErrorPayloadUnionTypeDataLoader */
+            $userDeleteMutationErrorPayloadUnionTypeDataLoader = $this->instanceManager->getInstance(UserDeleteMutationErrorPayloadUnionTypeDataLoader::class);
+            $this->userDeleteMutationErrorPayloadUnionTypeDataLoader = $userDeleteMutationErrorPayloadUnionTypeDataLoader;
+        }
+        return $this->userDeleteMutationErrorPayloadUnionTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'UserDeleteMutationErrorPayloadUnion';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Union of \'Error Payload\' types when deleting a user (nested mutations)', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getUserDeleteMutationErrorPayloadUnionTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/UserUpdateMutationErrorPayloadUnionTypeResolver.php
+++ b/layers/CMSSchema/packages/user-mutations/src/TypeResolvers/UnionType/UserUpdateMutationErrorPayloadUnionTypeResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\UserMutations\TypeResolvers\UnionType;
+
+use PoPCMSSchema\UserMutations\RelationalTypeDataLoaders\UnionType\UserUpdateMutationErrorPayloadUnionTypeDataLoader;
+use PoP\ComponentModel\RelationalTypeDataLoaders\RelationalTypeDataLoaderInterface;
+
+class UserUpdateMutationErrorPayloadUnionTypeResolver extends AbstractUpdateUserMutationErrorPayloadUnionTypeResolver
+{
+    private ?UserUpdateMutationErrorPayloadUnionTypeDataLoader $userUpdateMutationErrorPayloadUnionTypeDataLoader = null;
+
+    final protected function getUserUpdateMutationErrorPayloadUnionTypeDataLoader(): UserUpdateMutationErrorPayloadUnionTypeDataLoader
+    {
+        if ($this->userUpdateMutationErrorPayloadUnionTypeDataLoader === null) {
+            /** @var UserUpdateMutationErrorPayloadUnionTypeDataLoader */
+            $userUpdateMutationErrorPayloadUnionTypeDataLoader = $this->instanceManager->getInstance(UserUpdateMutationErrorPayloadUnionTypeDataLoader::class);
+            $this->userUpdateMutationErrorPayloadUnionTypeDataLoader = $userUpdateMutationErrorPayloadUnionTypeDataLoader;
+        }
+        return $this->userUpdateMutationErrorPayloadUnionTypeDataLoader;
+    }
+
+    public function getTypeName(): string
+    {
+        return 'UserUpdateMutationErrorPayloadUnion';
+    }
+
+    public function getTypeDescription(): ?string
+    {
+        return $this->__('Union of \'Error Payload\' types when updating a user (nested mutations)', 'gatographql');
+    }
+
+    public function getRelationalTypeDataLoader(): RelationalTypeDataLoaderInterface
+    {
+        return $this->getUserUpdateMutationErrorPayloadUnionTypeDataLoader();
+    }
+}

--- a/layers/CMSSchema/packages/usermeta-mutations/src/Hooks/AbstractUserMetaMutationResolverHookSet.php
+++ b/layers/CMSSchema/packages/usermeta-mutations/src/Hooks/AbstractUserMetaMutationResolverHookSet.php
@@ -6,6 +6,7 @@ namespace PoPCMSSchema\UserMetaMutations\Hooks;
 
 use PoPCMSSchema\UserMetaMutations\MutationResolvers\MutateUserMetaMutationResolverTrait;
 use PoPCMSSchema\UserMetaMutations\TypeAPIs\UserMetaTypeMutationAPIInterface;
+use PoPCMSSchema\UserMutations\Constants\UserCRUDHookNames;
 use PoPCMSSchema\UserMeta\TypeAPIs\UserMetaTypeAPIInterface;
 use PoPCMSSchema\MetaMutations\Hooks\AbstractMetaMutationResolverHookSet;
 use PoPCMSSchema\MetaMutations\TypeAPIs\EntityMetaTypeMutationAPIInterface;
@@ -47,9 +48,8 @@ abstract class AbstractUserMetaMutationResolverHookSet extends AbstractMetaMutat
         return $this->getUserMetaTypeAPI();
     }
 
-    // @todo Re-enable when adding User Mutations
-    // protected function getErrorPayloadHookName(): string
-    // {
-    //     return UserCRUDHookNames::ERROR_PAYLOAD;
-    // }
+    protected function getErrorPayloadHookName(): string
+    {
+        return UserCRUDHookNames::ERROR_PAYLOAD;
+    }
 }

--- a/layers/CMSSchema/packages/usermeta-mutations/src/Hooks/UserMetaMutationResolverHookSet.php
+++ b/layers/CMSSchema/packages/usermeta-mutations/src/Hooks/UserMetaMutationResolverHookSet.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace PoPCMSSchema\UserMetaMutations\Hooks;
 
 use PoPCMSSchema\UserMetaMutations\Hooks\AbstractUserMetaMutationResolverHookSet;
+use PoPCMSSchema\UserMutations\Constants\UserCRUDHookNames;
 
-// @todo Remove "abstract" when adding User Mutations
-abstract class UserMetaMutationResolverHookSet extends AbstractUserMetaMutationResolverHookSet
+class UserMetaMutationResolverHookSet extends AbstractUserMetaMutationResolverHookSet
 {
-    // @todo Re-enable when adding User Mutations
-    // protected function getValidateCreateHookName(): string
-    // {
-    //     return UserCRUDHookNames::VALIDATE_CREATE;
-    // }
-    // protected function getValidateUpdateHookName(): ?string
-    // {
-    //     return UserCRUDHookNames::VALIDATE_UPDATE;
-    // }
-    // protected function getExecuteCreateOrUpdateHookName(): string
-    // {
-    //     return UserCRUDHookNames::EXECUTE_CREATE_OR_UPDATE;
-    // }
+    protected function getValidateCreateHookName(): string
+    {
+        return UserCRUDHookNames::VALIDATE_CREATE_USER;
+    }
+    protected function getValidateUpdateHookName(): ?string
+    {
+        return UserCRUDHookNames::VALIDATE_UPDATE_USER;
+    }
+    protected function getExecuteCreateOrUpdateHookName(): string
+    {
+        return UserCRUDHookNames::CREATE_OR_UPDATE_USER;
+    }
 }

--- a/layers/CMSSchema/packages/usermeta-mutations/src/ObjectTypeResolverPickers/AccessToMetaKeyIsNotAllowedErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/usermeta-mutations/src/ObjectTypeResolverPickers/AccessToMetaKeyIsNotAllowedErrorPayloadObjectTypeResolverPicker.php
@@ -6,6 +6,9 @@ namespace PoPCMSSchema\UserMetaMutations\ObjectTypeResolverPickers;
 
 use PoPCMSSchema\UserMetaMutations\TypeResolvers\UnionType\AbstractUserMetaMutationErrorPayloadUnionTypeResolver;
 use PoPCMSSchema\MetaMutations\ObjectTypeResolverPickers\AbstractAccessToMetaKeyIsNotAllowedErrorPayloadObjectTypeResolverPicker;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootCreateUserMutationErrorPayloadUnionTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\UserUpdateMutationErrorPayloadUnionTypeResolver;
 use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
 
 class AccessToMetaKeyIsNotAllowedErrorPayloadObjectTypeResolverPicker extends AbstractAccessToMetaKeyIsNotAllowedErrorPayloadObjectTypeResolverPicker
@@ -17,10 +20,9 @@ class AccessToMetaKeyIsNotAllowedErrorPayloadObjectTypeResolverPicker extends Ab
     {
         return [
             AbstractUserMetaMutationErrorPayloadUnionTypeResolver::class,
-            // @todo Re-enable when adding User Mutations
-            // RootCreateUserMutationErrorPayloadUnionTypeResolver::class,
-            // RootUpdateUserMutationErrorPayloadUnionTypeResolver::class,
-            // UserUpdateMutationErrorPayloadUnionTypeResolver::class,
+            RootCreateUserMutationErrorPayloadUnionTypeResolver::class,
+            RootUpdateUserMutationErrorPayloadUnionTypeResolver::class,
+            UserUpdateMutationErrorPayloadUnionTypeResolver::class,
         ];
     }
 }

--- a/layers/CMSSchema/packages/usermeta-mutations/src/ObjectTypeResolverPickers/EntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/usermeta-mutations/src/ObjectTypeResolverPickers/EntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker.php
@@ -7,6 +7,9 @@ namespace PoPCMSSchema\UserMetaMutations\ObjectTypeResolverPickers;
 use PoPCMSSchema\UserMetaMutations\TypeResolvers\UnionType\AbstractUserAddMetaMutationErrorPayloadUnionTypeResolver;
 use PoPCMSSchema\UserMetaMutations\TypeResolvers\UnionType\AbstractRootAddUserMetaMutationErrorPayloadUnionTypeResolver;
 use PoPCMSSchema\MetaMutations\ObjectTypeResolverPickers\AbstractEntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootCreateUserMutationErrorPayloadUnionTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootUpdateUserMutationErrorPayloadUnionTypeResolver;
+use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\UserUpdateMutationErrorPayloadUnionTypeResolver;
 use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
 
 class EntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker extends AbstractEntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker
@@ -19,10 +22,9 @@ class EntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker extend
         return [
             AbstractRootAddUserMetaMutationErrorPayloadUnionTypeResolver::class,
             AbstractUserAddMetaMutationErrorPayloadUnionTypeResolver::class,
-            // @todo Re-enable when adding User Mutations
-            // RootCreateUserMutationErrorPayloadUnionTypeResolver::class,
-            // RootUpdateUserMutationErrorPayloadUnionTypeResolver::class,
-            // UserUpdateMutationErrorPayloadUnionTypeResolver::class,
+            RootCreateUserMutationErrorPayloadUnionTypeResolver::class,
+            RootUpdateUserMutationErrorPayloadUnionTypeResolver::class,
+            UserUpdateMutationErrorPayloadUnionTypeResolver::class,
         ];
     }
 }

--- a/layers/CMSSchema/packages/usermeta-mutations/src/ObjectTypeResolverPickers/EntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/usermeta-mutations/src/ObjectTypeResolverPickers/EntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker.php
@@ -7,9 +7,6 @@ namespace PoPCMSSchema\UserMetaMutations\ObjectTypeResolverPickers;
 use PoPCMSSchema\UserMetaMutations\TypeResolvers\UnionType\AbstractUserAddMetaMutationErrorPayloadUnionTypeResolver;
 use PoPCMSSchema\UserMetaMutations\TypeResolvers\UnionType\AbstractRootAddUserMetaMutationErrorPayloadUnionTypeResolver;
 use PoPCMSSchema\MetaMutations\ObjectTypeResolverPickers\AbstractEntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker;
-use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootCreateUserMutationErrorPayloadUnionTypeResolver;
-use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\RootUpdateUserMutationErrorPayloadUnionTypeResolver;
-use PoPCMSSchema\UserMutations\TypeResolvers\UnionType\UserUpdateMutationErrorPayloadUnionTypeResolver;
 use PoP\ComponentModel\TypeResolvers\UnionType\UnionTypeResolverInterface;
 
 class EntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker extends AbstractEntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker
@@ -22,9 +19,6 @@ class EntityMetaAlreadyHasSingleEntryErrorPayloadObjectTypeResolverPicker extend
         return [
             AbstractRootAddUserMetaMutationErrorPayloadUnionTypeResolver::class,
             AbstractUserAddMetaMutationErrorPayloadUnionTypeResolver::class,
-            RootCreateUserMutationErrorPayloadUnionTypeResolver::class,
-            RootUpdateUserMutationErrorPayloadUnionTypeResolver::class,
-            UserUpdateMutationErrorPayloadUnionTypeResolver::class,
         ];
     }
 }

--- a/layers/CMSSchema/packages/usermeta-mutations/src/ObjectTypeResolverPickers/EntityMetaEntryAlreadyHasValueErrorPayloadObjectTypeResolverPicker.php
+++ b/layers/CMSSchema/packages/usermeta-mutations/src/ObjectTypeResolverPickers/EntityMetaEntryAlreadyHasValueErrorPayloadObjectTypeResolverPicker.php
@@ -19,10 +19,6 @@ class EntityMetaEntryAlreadyHasValueErrorPayloadObjectTypeResolverPicker extends
         return [
             AbstractRootUpdateUserMetaMutationErrorPayloadUnionTypeResolver::class,
             AbstractUserUpdateMetaMutationErrorPayloadUnionTypeResolver::class,
-            // @todo Re-enable when adding User Mutations
-            // RootCreateUserMutationErrorPayloadUnionTypeResolver::class,
-            // RootUpdateUserMutationErrorPayloadUnionTypeResolver::class,
-            // UserUpdateMutationErrorPayloadUnionTypeResolver::class,
         ];
     }
 }

--- a/layers/CMSSchema/packages/usermeta-mutations/src/SchemaHooks/AbstractUserMutationResolverHookSet.php
+++ b/layers/CMSSchema/packages/usermeta-mutations/src/SchemaHooks/AbstractUserMutationResolverHookSet.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace PoPCMSSchema\UserMetaMutations\SchemaHooks;
 
 use PoPCMSSchema\Users\TypeResolvers\ObjectType\UserObjectTypeResolverInterface;
+use PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType\CreateUserInputObjectTypeResolverInterface;
+use PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType\UpdateUserInputObjectTypeResolverInterface;
 use PoPCMSSchema\MetaMutations\Constants\MutationInputProperties;
 use PoPSchema\ExtendedSchemaCommons\TypeResolvers\ScalarType\NullableListValueJSONObjectScalarTypeResolver;
 use PoP\ComponentModel\TypeResolvers\InputObjectType\HookNames;
@@ -59,15 +61,11 @@ abstract class AbstractUserMutationResolverHookSet extends AbstractHookSet
         return $inputFieldNameTypeResolvers;
     }
 
-    // @todo Re-enable when adding User Mutations
     protected function isInputObjectTypeResolver(
         InputObjectTypeResolverInterface $inputObjectTypeResolver,
     ): bool {
-        // @todo Remove temp code when adding User Mutations
-        return false;
-        // @todo Re-enable when adding User Mutations
-        // return $inputObjectTypeResolver instanceof CreateUserInputObjectTypeResolverInterface
-        //     || $inputObjectTypeResolver instanceof UpdateUserInputObjectTypeResolverInterface;
+        return $inputObjectTypeResolver instanceof CreateUserInputObjectTypeResolverInterface
+            || $inputObjectTypeResolver instanceof UpdateUserInputObjectTypeResolverInterface;
     }
 
     public function maybeAddInputFieldDescription(

--- a/layers/CMSSchema/packages/usermeta-mutations/src/SchemaHooks/UserMutationResolverHookSetTrait.php
+++ b/layers/CMSSchema/packages/usermeta-mutations/src/SchemaHooks/UserMutationResolverHookSetTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserMetaMutations\SchemaHooks;
 
+use PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType\CreateUserInputObjectTypeResolverInterface;
+use PoPCMSSchema\UserMutations\TypeResolvers\InputObjectType\UpdateUserInputObjectTypeResolverInterface;
 use PoP\ComponentModel\TypeResolvers\InputObjectType\InputObjectTypeResolverInterface;
 
 trait UserMutationResolverHookSetTrait
@@ -11,10 +13,7 @@ trait UserMutationResolverHookSetTrait
     protected function isInputObjectTypeResolver(
         InputObjectTypeResolverInterface $inputObjectTypeResolver,
     ): bool {
-        // @todo Remove temp code when adding User Mutations
-        return false;
-        // @todo Re-enable when adding User Mutations
-        // return $inputObjectTypeResolver instanceof CreateUserInputObjectTypeResolverInterface
-        //     || $inputObjectTypeResolver instanceof UpdateUserInputObjectTypeResolverInterface;
+        return $inputObjectTypeResolver instanceof CreateUserInputObjectTypeResolverInterface
+            || $inputObjectTypeResolver instanceof UpdateUserInputObjectTypeResolverInterface;
     }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -8,6 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Added
 
+- Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type (#3362)
 - Mutations to delete posts, pages and custom posts: `deletePost`, `deletePage` and `deleteCustomPost` (and their bulk versions), and the nested `delete` field on the `Post`, `Page` and `GenericCustomPost` types (#3358)
 - Mutations to delete media items: `deleteMediaItem` and `deleteMediaItems`, and the nested `delete` field on the `Media` type (#3358)
 - Mutations to delete menus: `deleteMenu` and `deleteMenus`, and the nested `delete` field on the `Menu` type (#3358)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -8,7 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Added
 
-- Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type (#3362)
+- Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type; `createUser` and `updateUser` (and their nested and bulk versions) also accept a `meta` input to set the user's custom meta (#3362)
 - Mutations to delete posts, pages and custom posts: `deletePost`, `deletePage` and `deleteCustomPost` (and their bulk versions), and the nested `delete` field on the `Post`, `Page` and `GenericCustomPost` types (#3358)
 - Mutations to delete media items: `deleteMediaItem` and `deleteMediaItems`, and the nested `delete` field on the `Media` type (#3358)
 - Mutations to delete menus: `deleteMenu` and `deleteMenus`, and the nested `delete` field on the `Menu` type (#3358)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -8,7 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Added
 
-- Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type; `createUser` and `updateUser` (and their nested and bulk versions) also accept a `meta` input to set the user's custom meta (#3362)
+- Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type; `createUser` and `updateUser` (and their nested and bulk versions) also accept a `meta` input to set the user's custom meta; the "payload types for mutations" schema configuration also applies to them (#3362)
 - Mutations to delete posts, pages and custom posts: `deletePost`, `deletePage` and `deleteCustomPost` (and their bulk versions), and the nested `delete` field on the `Post`, `Page` and `GenericCustomPost` types (#3358)
 - Mutations to delete media items: `deleteMediaItem` and `deleteMediaItems`, and the nested `delete` field on the `Media` type (#3358)
 - Mutations to delete menus: `deleteMenu` and `deleteMenus`, and the nested `delete` field on the `Menu` type (#3358)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/schema-user-mutations/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/schema-user-mutations/en.md
@@ -1,0 +1,22 @@
+# User Mutations
+
+Create, update and delete users
+
+## Description
+
+This module adds mutations to manage users to the GraphQL schema.
+
+On the `Root` type:
+
+- `createUser`, `updateUser` and `deleteUser`
+- their bulk versions `createUsers`, `updateUsers` and `deleteUsers`
+
+On the `User` type (for nested mutations):
+
+- the `update` and `delete` fields
+
+When creating a user, `username` and `email` are mandatory; the password is generated automatically when not provided. `username` cannot be changed afterwards, so it is not available when updating. Roles are assigned via the `roles` input (accepting more than one role).
+
+The mutations enforce the corresponding WordPress capabilities: `create_users` to create, `edit_users` (or editing one's own profile) to update, `delete_users` to delete, and `promote_users` to assign roles. Every failure is returned as a typed error payload (missing permission, user does not exist, username/email already exists, role does not exist, and so on).
+
+These mutations operate on single-site installations.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/schema-user-mutations/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/schema-user-mutations/en.md
@@ -20,3 +20,141 @@ When creating a user, `username` and `email` are mandatory; the password is gene
 The mutations enforce the corresponding WordPress capabilities: `create_users` to create, `edit_users` (or editing one's own profile) to update, `delete_users` to delete, and `promote_users` to assign roles. Every failure is returned as a typed error payload (missing permission, user does not exist, username/email already exists, role does not exist, and so on).
 
 These mutations operate on single-site installations.
+
+## Examples
+
+### Creating a user
+
+```graphql
+mutation {
+  createUser(input: {
+    username: "newuser"
+    email: "newuser@example.com"
+    roles: ["editor", "author"]
+    firstName: "New"
+    lastName: "User"
+    displayName: "New User"
+    websiteURL: "https://example.com"
+    description: "About the user"
+    meta: {
+      phone: ["555-1234"]
+    }
+  }) {
+    status
+    user {
+      id
+      name
+      roles
+    }
+    errors {
+      __typename
+      ...on ErrorPayload {
+        message
+      }
+    }
+  }
+}
+```
+
+### Updating a user
+
+`username` cannot be changed, so it is not accepted here.
+
+```graphql
+mutation {
+  updateUser(input: {
+    id: 5
+    email: "updated@example.com"
+    roles: ["administrator"]
+    description: "Updated bio"
+    meta: {
+      phone: ["555-9999"]
+    }
+  }) {
+    status
+    user {
+      id
+      email
+      roles
+    }
+    errors {
+      __typename
+      ...on ErrorPayload {
+        message
+      }
+    }
+  }
+}
+```
+
+### Deleting a user, reassigning their content
+
+Pass `reassignAuthorContentTo` to transfer the deleted user's posts to another user (otherwise the content is trashed).
+
+```graphql
+mutation {
+  deleteUser(input: {
+    id: 5
+    reassignAuthorContentTo: 1
+  }) {
+    status
+    errors {
+      __typename
+      ...on ErrorPayload {
+        message
+      }
+    }
+  }
+}
+```
+
+### Creating several users at once
+
+The bulk mutations (`createUsers`, `updateUsers`, `deleteUsers`) receive a list of inputs and return a list of payloads:
+
+```graphql
+mutation {
+  createUsers(inputs: [
+    { username: "user1", email: "user1@example.com", roles: ["subscriber"] },
+    { username: "user2", email: "user2@example.com", roles: ["subscriber"] }
+  ]) {
+    status
+    user {
+      id
+      name
+    }
+    errors {
+      __typename
+      ...on ErrorPayload {
+        message
+      }
+    }
+  }
+}
+```
+
+### Nested mutations on the `User` type
+
+When the "Nested mutations" module is enabled, users can be updated or deleted from within the `User` type:
+
+```graphql
+mutation {
+  user(by: { id: 5 }) {
+    update(input: {
+      displayName: "Updated via nested mutation"
+    }) {
+      status
+      user {
+        id
+        displayName
+      }
+      errors {
+        __typename
+        ...on ErrorPayload {
+          message
+        }
+      }
+    }
+  }
+}
+```

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
@@ -2,7 +2,34 @@
 
 ## Added
 
-The schema can now delete entities, and moderate comments.
+The schema can now manage users, delete entities, and moderate comments.
+
+### Managing users
+
+New mutations to create, update and delete users ([#3362](https://github.com/GatoGraphQL/GatoGraphQL/pull/3362)):
+
+- On the `Root` type: `createUser`, `updateUser` and `deleteUser`, and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`.
+- On the `User` type (for nested mutations): the `update` and `delete` fields.
+
+Every failure mode is returned as a typed error payload (missing capability, user does not exist, username/email already exists, role does not exist, reassign-user does not exist, and cannot-delete-yourself). Capabilities follow WordPress core: `create_users` to create, `edit_users`/`edit_user` to update, `delete_users`/`delete_user` to delete, and `promote_users` to assign roles. These mutations run on single-site installs.
+
+```graphql
+mutation {
+  createUser(input: { username: "newuser", email: "newuser@example.com", roles: ["editor"] }) {
+    status
+    user {
+      id
+      name
+    }
+    errors {
+      __typename
+      ...on ErrorPayload {
+        message
+      }
+    }
+  }
+}
+```
 
 ### Deleting entities
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
@@ -10,6 +10,7 @@ New mutations to create, update and delete users ([#3362](https://github.com/Gat
 
 - On the `Root` type: `createUser`, `updateUser` and `deleteUser`, and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`.
 - On the `User` type (for nested mutations): the `update` and `delete` fields.
+- `createUser` and `updateUser` (and their nested and bulk versions) accept a `meta` input to set the user's custom meta.
 
 Every failure mode is returned as a typed error payload (missing capability, user does not exist, username/email already exists, role does not exist, reassign-user does not exist, and cannot-delete-yourself). Capabilities follow WordPress core: `create_users` to create, `edit_users`/`edit_user` to update, `delete_users`/`delete_user` to delete, and `promote_users` to assign roles. These mutations run on single-site installs.
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
@@ -11,6 +11,7 @@ New mutations to create, update and delete users ([#3362](https://github.com/Gat
 - On the `Root` type: `createUser`, `updateUser` and `deleteUser`, and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`.
 - On the `User` type (for nested mutations): the `update` and `delete` fields.
 - `createUser` and `updateUser` (and their nested and bulk versions) accept a `meta` input to set the user's custom meta.
+- The "payload types for mutations" schema configuration (global setting and per-endpoint schema config) applies to these mutations.
 
 Every failure mode is returned as a typed error payload (missing capability, user does not exist, username/email already exists, role does not exist, reassign-user does not exist, and cannot-delete-yourself). Capabilities follow WordPress core: `create_users` to create, `edit_users`/`edit_user` to update, `delete_users`/`delete_user` to delete, and `promote_users` to assign roles. These mutations run on single-site installs.
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -248,6 +248,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 == Changelog ==
 
 = 19.1.0 =
+* Added - Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type (#3362)
 * Added - Mutations to delete posts, pages and custom posts: `deletePost`, `deletePage` and `deleteCustomPost` (and their bulk versions), and the nested `delete` field on the `Post`, `Page` and `GenericCustomPost` types (#3358)
 * Added - Mutations to delete media items: `deleteMediaItem` and `deleteMediaItems`, and the nested `delete` field on the `Media` type (#3358)
 * Added - Mutations to delete menus: `deleteMenu` and `deleteMenus`, and the nested `delete` field on the `Menu` type (#3358)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -248,7 +248,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 == Changelog ==
 
 = 19.1.0 =
-* Added - Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type (#3362)
+* Added - Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type; `createUser` and `updateUser` (and their nested and bulk versions) also accept a `meta` input to set the user's custom meta (#3362)
 * Added - Mutations to delete posts, pages and custom posts: `deletePost`, `deletePage` and `deleteCustomPost` (and their bulk versions), and the nested `delete` field on the `Post`, `Page` and `GenericCustomPost` types (#3358)
 * Added - Mutations to delete media items: `deleteMediaItem` and `deleteMediaItems`, and the nested `delete` field on the `Media` type (#3358)
 * Added - Mutations to delete menus: `deleteMenu` and `deleteMenus`, and the nested `delete` field on the `Menu` type (#3358)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -248,7 +248,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 == Changelog ==
 
 = 19.1.0 =
-* Added - Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type; `createUser` and `updateUser` (and their nested and bulk versions) also accept a `meta` input to set the user's custom meta (#3362)
+* Added - Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type; `createUser` and `updateUser` (and their nested and bulk versions) also accept a `meta` input to set the user's custom meta; the "payload types for mutations" schema configuration also applies to them (#3362)
 * Added - Mutations to delete posts, pages and custom posts: `deletePost`, `deletePage` and `deleteCustomPost` (and their bulk versions), and the nested `delete` field on the `Post`, `Page` and `GenericCustomPost` types (#3358)
 * Added - Mutations to delete media items: `deleteMediaItem` and `deleteMediaItems`, and the nested `delete` field on the `Media` type (#3358)
 * Added - Mutations to delete menus: `deleteMenu` and `deleteMenus`, and the nested `delete` field on the `Menu` type (#3358)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/ModuleResolvers/MutationSchemaTypeModuleResolver.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/ModuleResolvers/MutationSchemaTypeModuleResolver.php
@@ -18,6 +18,7 @@ class MutationSchemaTypeModuleResolver extends AbstractModuleResolver
     }
 
     public final const SCHEMA_USER_STATE_MUTATIONS = Plugin::NAMESPACE . '\schema-user-state-mutations';
+    public final const SCHEMA_USER_MUTATIONS = Plugin::NAMESPACE . '\schema-user-mutations';
     public final const SCHEMA_META_MUTATIONS = Plugin::NAMESPACE . '\schema-meta-mutations';
     public final const SCHEMA_USER_META_MUTATIONS = Plugin::NAMESPACE . '\schema-user-meta-mutations';
     public final const SCHEMA_CUSTOMPOST_MUTATIONS = Plugin::NAMESPACE . '\schema-custompost-mutations';
@@ -72,6 +73,7 @@ class MutationSchemaTypeModuleResolver extends AbstractModuleResolver
     {
         return [
             self::SCHEMA_USER_STATE_MUTATIONS,
+            self::SCHEMA_USER_MUTATIONS,
             self::SCHEMA_META_MUTATIONS,
             self::SCHEMA_USER_META_MUTATIONS,
             self::SCHEMA_CUSTOMPOST_MUTATIONS,
@@ -126,13 +128,19 @@ class MutationSchemaTypeModuleResolver extends AbstractModuleResolver
                         self::SCHEMA_USER_STATE_MUTATIONS,
                     ],
                 ];
+            case self::SCHEMA_USER_MUTATIONS:
+                return [
+                    [
+                        SchemaTypeModuleResolver::SCHEMA_USERS,
+                    ],
+                    [
+                        self::SCHEMA_USER_STATE_MUTATIONS,
+                    ],
+                ];
             case self::SCHEMA_USER_META_MUTATIONS:
                 return [
                     [
-                        // @todo Re-enable when adding User Mutations
-                        // self::SCHEMA_USER_MUTATIONS,
-                        // @todo Remove temp code when adding User Mutations
-                        SchemaTypeModuleResolver::SCHEMA_USERS,
+                        self::SCHEMA_USER_MUTATIONS,
                     ],
                     [
                         self::SCHEMA_META_MUTATIONS,
@@ -378,6 +386,7 @@ class MutationSchemaTypeModuleResolver extends AbstractModuleResolver
     {
         return match ($module) {
             self::SCHEMA_USER_STATE_MUTATIONS => \__('User State Mutations', 'gatographql'),
+            self::SCHEMA_USER_MUTATIONS => \__('User Mutations', 'gatographql'),
             self::SCHEMA_META_MUTATIONS => \__('Meta Mutations', 'gatographql'),
             self::SCHEMA_USER_META_MUTATIONS => \__('User Meta Mutations', 'gatographql'),
             self::SCHEMA_CUSTOMPOST_MUTATIONS => \__('Custom Post Mutations', 'gatographql'),
@@ -414,6 +423,7 @@ class MutationSchemaTypeModuleResolver extends AbstractModuleResolver
     {
         return match ($module) {
             self::SCHEMA_USER_STATE_MUTATIONS => \__('Have the user log-in, and be able to perform mutations', 'gatographql'),
+            self::SCHEMA_USER_MUTATIONS => \__('Create, update and delete users', 'gatographql'),
             self::SCHEMA_META_MUTATIONS => \__('Mutate meta', 'gatographql'),
             self::SCHEMA_USER_META_MUTATIONS => \__('Mutate user meta', 'gatographql'),
             self::SCHEMA_CUSTOMPOST_MUTATIONS => \__('Base functionality to mutate custom posts', 'gatographql'),

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginInitializationConfiguration.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginInitializationConfiguration.php
@@ -741,6 +741,20 @@ class PluginInitializationConfiguration extends AbstractMainPluginInitialization
                 'callback' => fn ($value) => $value === MutationPayloadTypeOptions::USE_AND_QUERY_PAYLOAD_TYPES_FOR_MUTATIONS,
             ],
             [
+                'class' => \PoPCMSSchema\UserMutations\Module::class,
+                'envVariable' => \PoPCMSSchema\UserMutations\Environment::USE_PAYLOADABLE_USER_MUTATIONS,
+                'module' => SchemaConfigurationFunctionalityModuleResolver::MUTATIONS,
+                'option' => SchemaConfigurationFunctionalityModuleResolver::OPTION_USE_PAYLOADABLE_MUTATIONS_DEFAULT_VALUE,
+                'callback' => fn ($value) => $value !== MutationPayloadTypeOptions::DO_NOT_USE_PAYLOAD_TYPES_FOR_MUTATIONS,
+            ],
+            [
+                'class' => \PoPCMSSchema\UserMutations\Module::class,
+                'envVariable' => \PoPCMSSchema\UserMutations\Environment::ADD_FIELDS_TO_QUERY_PAYLOADABLE_USER_MUTATIONS,
+                'module' => SchemaConfigurationFunctionalityModuleResolver::MUTATIONS,
+                'option' => SchemaConfigurationFunctionalityModuleResolver::OPTION_USE_PAYLOADABLE_MUTATIONS_DEFAULT_VALUE,
+                'callback' => fn ($value) => $value === MutationPayloadTypeOptions::USE_AND_QUERY_PAYLOAD_TYPES_FOR_MUTATIONS,
+            ],
+            [
                 'class' => \PoPCMSSchema\UserMetaMutations\Module::class,
                 'envVariable' => \PoPCMSSchema\UserMetaMutations\Environment::USE_PAYLOADABLE_USER_META_MUTATIONS,
                 'module' => SchemaConfigurationFunctionalityModuleResolver::MUTATIONS,
@@ -1064,6 +1078,18 @@ class PluginInitializationConfiguration extends AbstractMainPluginInitialization
                     \PoPCMSSchema\MediaMutations\Module::class => [
                         \PoPCMSSchema\MediaMutations\Environment::USE_PAYLOADABLE_MEDIA_MUTATIONS => false,
                     ],
+                    \PoPCMSSchema\UserMutations\Module::class => [
+                        \PoPCMSSchema\UserMutations\Environment::USE_PAYLOADABLE_USER_MUTATIONS => false,
+                    ],
+                    \PoPCMSSchema\UserMetaMutations\Module::class => [
+                        \PoPCMSSchema\UserMetaMutations\Environment::USE_PAYLOADABLE_USER_META_MUTATIONS => false,
+                    ],
+                    \PoPCMSSchema\CustomPostMetaMutations\Module::class => [
+                        \PoPCMSSchema\CustomPostMetaMutations\Environment::USE_PAYLOADABLE_CUSTOMPOST_META_MUTATIONS => false,
+                    ],
+                    \PoPCMSSchema\CommentMetaMutations\Module::class => [
+                        \PoPCMSSchema\CommentMetaMutations\Environment::USE_PAYLOADABLE_COMMENT_META_MUTATIONS => false,
+                    ],
                 ]
             );
         }
@@ -1179,6 +1205,26 @@ class PluginInitializationConfiguration extends AbstractMainPluginInitialization
                     \PoPCMSSchema\UserStateMutations\Module::class => [
                         \PoPCMSSchema\UserStateMutations\Environment::USE_PAYLOADABLE_USERSTATE_MUTATIONS => true,
                         \PoPCMSSchema\UserStateMutations\Environment::ADD_FIELDS_TO_QUERY_PAYLOADABLE_USERSTATE_MUTATIONS => false,
+                    ],
+                    \PoPCMSSchema\MediaMutations\Module::class => [
+                        \PoPCMSSchema\MediaMutations\Environment::USE_PAYLOADABLE_MEDIA_MUTATIONS => true,
+                        \PoPCMSSchema\MediaMutations\Environment::ADD_FIELDS_TO_QUERY_PAYLOADABLE_MEDIA_MUTATIONS => false,
+                    ],
+                    \PoPCMSSchema\UserMutations\Module::class => [
+                        \PoPCMSSchema\UserMutations\Environment::USE_PAYLOADABLE_USER_MUTATIONS => true,
+                        \PoPCMSSchema\UserMutations\Environment::ADD_FIELDS_TO_QUERY_PAYLOADABLE_USER_MUTATIONS => false,
+                    ],
+                    \PoPCMSSchema\UserMetaMutations\Module::class => [
+                        \PoPCMSSchema\UserMetaMutations\Environment::USE_PAYLOADABLE_USER_META_MUTATIONS => true,
+                        \PoPCMSSchema\UserMetaMutations\Environment::ADD_FIELDS_TO_QUERY_PAYLOADABLE_USER_META_MUTATIONS => false,
+                    ],
+                    \PoPCMSSchema\CustomPostMetaMutations\Module::class => [
+                        \PoPCMSSchema\CustomPostMetaMutations\Environment::USE_PAYLOADABLE_CUSTOMPOST_META_MUTATIONS => true,
+                        \PoPCMSSchema\CustomPostMetaMutations\Environment::ADD_FIELDS_TO_QUERY_PAYLOADABLE_CUSTOMPOST_META_MUTATIONS => false,
+                    ],
+                    \PoPCMSSchema\CommentMetaMutations\Module::class => [
+                        \PoPCMSSchema\CommentMetaMutations\Environment::USE_PAYLOADABLE_COMMENT_META_MUTATIONS => true,
+                        \PoPCMSSchema\CommentMetaMutations\Environment::ADD_FIELDS_TO_QUERY_PAYLOADABLE_COMMENT_META_MUTATIONS => false,
                     ],
                 ]
             );
@@ -1326,9 +1372,11 @@ class PluginInitializationConfiguration extends AbstractMainPluginInitialization
                 \PoPCMSSchema\UserMetaMutations\Module::class,
                 \PoPCMSSchema\UserMetaMutationsWP\Module::class,
             ],
-            MutationSchemaTypeModuleResolver::SCHEMA_CUSTOMPOST_USER_MUTATIONS => [
+            MutationSchemaTypeModuleResolver::SCHEMA_USER_MUTATIONS => [
                 \PoPCMSSchema\UserMutations\Module::class,
                 \PoPCMSSchema\UserMutationsWP\Module::class,
+            ],
+            MutationSchemaTypeModuleResolver::SCHEMA_CUSTOMPOST_USER_MUTATIONS => [
                 \PoPCMSSchema\CustomPostUserMutations\Module::class,
                 \PoPCMSSchema\CustomPostUserMutationsWP\Module::class,
             ],

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/SchemaConfigurationExecuters/SchemaUserMutationsBlockSchemaConfigurationExecuter.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/SchemaConfigurationExecuters/SchemaUserMutationsBlockSchemaConfigurationExecuter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GatoGraphQL\GatoGraphQL\Services\SchemaConfigurationExecuters;
+
+class SchemaUserMutationsBlockSchemaConfigurationExecuter extends AbstractSchemaMutationsBlockSchemaConfigurationExecuter
+{
+    public function getHookModuleClass(): string
+    {
+        return \PoPCMSSchema\UserMutations\Module::class;
+    }
+
+    public function getHookUsePayloadableEnvironmentClass(): string
+    {
+        return \PoPCMSSchema\UserMutations\Environment::USE_PAYLOADABLE_USER_MUTATIONS;
+    }
+
+    public function getHookAddFieldsToQueryPayloadableEnvironmentClass(): string
+    {
+        return \PoPCMSSchema\UserMutations\Environment::ADD_FIELDS_TO_QUERY_PAYLOADABLE_USER_MUTATIONS;
+    }
+}


### PR DESCRIPTION
Adds full user CRUD to the schema, extending the previously edit-helper-only `user-mutations` / `user-mutations-wp` packages (modeled on `media-mutations`).

## New mutations

- **Root**: `createUser`, `updateUser`, `deleteUser`, and their bulk versions `createUsers`, `updateUsers`, `deleteUsers`.
- **Nested** (on the `User` type): `update` and `delete`.
- Both payloadable and classic schemes, toggled by `usePayloadableUserMutations()` (default payloadable).

## Behavior

- **Inputs**: `username` (immutable — omitted from update inputs), `email`, `password` (auto-generated when omitted on create), `roles: [String!]` (multi-role), plus `firstName`/`lastName`/`nickname`/`displayName`/`slug`/`websiteURL`/`description`/`locale`/`registeredDate`/`sendEmailNotification`. Delete accepts `reassignAuthorContentTo`.
- **Capabilities** follow WordPress core, enforced in the TypeAPI: `create_users` to create; `edit_users` / `edit_user` to update (a user may always edit their own profile); `delete_users` / `delete_user` to delete; `promote_users` to assign roles.
- **Typed error payloads** for every failure mode: not-logged-in, no-permission-to-create/edit/delete/edit-roles, user-does-not-exist, username-already-exists, email-already-exists, invalid-email, role-does-not-exist, reassign-user-does-not-exist, and cannot-delete-yourself.
- **Single-site only**: on a multisite network the mutations return a clear error rather than acting with the wrong (network-wide) user semantics.

## Notes

- Writes go through the standard WordPress user APIs (`wp_insert_user` / `wp_update_user` / `wp_delete_user`), with multi-role applied via `WP_User::set_role` + `add_role`.
- Follow-up (not in this PR): registering the `SCHEMA_USER_MUTATIONS` admin module to make these fields individually toggleable (see the existing `@todo` in `MutationSchemaTypeModuleResolver`).
