### PR TITLE
[Settings] Add `optionNames` and `options` fields to query the site's options in bulk

### DIFF
--- a/layers/CMSSchema/packages/settings-wp/src/TypeAPIs/SettingsTypeAPI.php
+++ b/layers/CMSSchema/packages/settings-wp/src/TypeAPIs/SettingsTypeAPI.php
@@ -16,4 +16,14 @@ class SettingsTypeAPI extends AbstractSettingsTypeAPI
     {
         return \get_option($name, null);
     }
+
+    /**
+     * @return string[]
+     */
+    public function getOptionNames(): array
+    {
+        global $wpdb;
+        /** @var string[] */
+        return $wpdb->get_col("SELECT option_name FROM {$wpdb->options}");
+    }
 }

--- a/layers/CMSSchema/packages/settings/src/FeedbackItemProviders/FeedbackItemProvider.php
+++ b/layers/CMSSchema/packages/settings/src/FeedbackItemProviders/FeedbackItemProvider.php
@@ -10,6 +10,7 @@ use PoP\ComponentModel\Feedback\FeedbackCategories;
 class FeedbackItemProvider extends AbstractFeedbackItemProvider
 {
     public final const E1 = 'e1';
+    public final const E2 = 'e2';
 
     /**
      * @return string[]
@@ -18,6 +19,7 @@ class FeedbackItemProvider extends AbstractFeedbackItemProvider
     {
         return [
             self::E1,
+            self::E2,
         ];
     }
 
@@ -25,6 +27,7 @@ class FeedbackItemProvider extends AbstractFeedbackItemProvider
     {
         return match ($code) {
             self::E1 => $this->__('There is no option with name \'%s\'', 'gatographql'),
+            self::E2 => $this->__('There are no options with names \'%s\'', 'gatographql'),
             default => parent::getMessagePlaceholder($code),
         };
     }
@@ -32,7 +35,9 @@ class FeedbackItemProvider extends AbstractFeedbackItemProvider
     public function getCategory(string $code): string
     {
         return match ($code) {
-            self::E1 => FeedbackCategories::ERROR,
+            self::E1,
+            self::E2
+                => FeedbackCategories::ERROR,
             default => parent::getCategory($code),
         };
     }

--- a/layers/CMSSchema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
+++ b/layers/CMSSchema/packages/settings/src/FieldResolvers/ObjectType/RootObjectTypeFieldResolver.php
@@ -19,12 +19,15 @@ use PoP\ComponentModel\TypeResolvers\ScalarType\AnyBuiltInScalarScalarTypeResolv
 use PoP\ComponentModel\TypeResolvers\ScalarType\StringScalarTypeResolver;
 use PoP\Engine\TypeResolvers\ObjectType\RootObjectTypeResolver;
 use PoP\Engine\TypeResolvers\ScalarType\JSONObjectScalarTypeResolver;
+use PoPSchema\SchemaCommons\TypeResolvers\InputObjectType\IncludeExcludeFilterInputObjectTypeResolver;
+use stdClass;
 
 class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
 {
     private ?AnyBuiltInScalarScalarTypeResolver $anyBuiltInScalarScalarTypeResolver = null;
     private ?JSONObjectScalarTypeResolver $jsonObjectScalarTypeResolver = null;
     private ?StringScalarTypeResolver $stringScalarTypeResolver = null;
+    private ?IncludeExcludeFilterInputObjectTypeResolver $includeExcludeFilterInputObjectTypeResolver = null;
     private ?SettingsTypeAPIInterface $settingsTypeAPI = null;
 
     final protected function getAnyBuiltInScalarScalarTypeResolver(): AnyBuiltInScalarScalarTypeResolver
@@ -53,6 +56,15 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             $this->stringScalarTypeResolver = $stringScalarTypeResolver;
         }
         return $this->stringScalarTypeResolver;
+    }
+    final protected function getIncludeExcludeFilterInputObjectTypeResolver(): IncludeExcludeFilterInputObjectTypeResolver
+    {
+        if ($this->includeExcludeFilterInputObjectTypeResolver === null) {
+            /** @var IncludeExcludeFilterInputObjectTypeResolver */
+            $includeExcludeFilterInputObjectTypeResolver = $this->instanceManager->getInstance(IncludeExcludeFilterInputObjectTypeResolver::class);
+            $this->includeExcludeFilterInputObjectTypeResolver = $includeExcludeFilterInputObjectTypeResolver;
+        }
+        return $this->includeExcludeFilterInputObjectTypeResolver;
     }
     final protected function getSettingsTypeAPI(): SettingsTypeAPIInterface
     {
@@ -84,6 +96,8 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'optionValues',
             'optionObjectValue',
             'optionObjectValues',
+            'optionNames',
+            'options',
         ];
     }
 
@@ -94,6 +108,8 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'optionValues' => $this->__('Array-value option saved in the DB, of any built-in scalar type, or `null` if entry does not exist', 'gatographql'),
             'optionObjectValue' => $this->__('Object-value option saved in the DB, or `null` if entry does not exist', 'gatographql'),
             'optionObjectValues' => $this->__('Array of object-value options saved in the DB, or `null` if entry does not exist', 'gatographql'),
+            'optionNames' => $this->__('List of the allowed option names saved in the DB.', 'gatographql'),
+            'options' => $this->__('JSON object, with the option name as key and the option value as value, for the provided option names.', 'gatographql'),
             default => parent::getFieldDescription($objectTypeResolver, $fieldName),
         };
     }
@@ -105,6 +121,8 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'optionValues' => $this->getAnyBuiltInScalarScalarTypeResolver(),
             'optionObjectValue' => $this->getJSONObjectScalarTypeResolver(),
             'optionObjectValues' => $this->getJSONObjectScalarTypeResolver(),
+            'optionNames' => $this->getStringScalarTypeResolver(),
+            'options' => $this->getJSONObjectScalarTypeResolver(),
             default => parent::getFieldTypeResolver($objectTypeResolver, $fieldName),
         };
     }
@@ -115,6 +133,10 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
             'optionValues',
             'optionObjectValues'
                 => SchemaTypeModifiers::IS_ARRAY,
+            'optionNames'
+                => SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY | SchemaTypeModifiers::NON_NULLABLE,
+            'options'
+                => SchemaTypeModifiers::NON_NULLABLE,
             default
                 => parent::getFieldTypeModifiers($objectTypeResolver, $fieldName),
         };
@@ -133,6 +155,14 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                 => [
                     'name' => $this->getStringScalarTypeResolver(),
                 ],
+            'optionNames'
+                => [
+                    'filterBy' => $this->getIncludeExcludeFilterInputObjectTypeResolver(),
+                ],
+            'options'
+                => [
+                    'names' => $this->getStringScalarTypeResolver(),
+                ],
             default
                 => parent::getFieldArgNameTypeResolvers($objectTypeResolver, $fieldName),
         };
@@ -142,6 +172,8 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     {
         return match ($fieldArgName) {
             'name' => $this->__('The option name', 'gatographql'),
+            'names' => $this->__('The option names', 'gatographql'),
+            'filterBy' => $this->__('Filter the option names to be retrieved', 'gatographql'),
             default => parent::getFieldArgDescription($objectTypeResolver, $fieldName, $fieldArgName),
         };
     }
@@ -150,6 +182,7 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
     {
         return match ($fieldArgName) {
             'name' => SchemaTypeModifiers::MANDATORY,
+            'names' => SchemaTypeModifiers::MANDATORY | SchemaTypeModifiers::IS_ARRAY | SchemaTypeModifiers::IS_NON_NULLABLE_ITEMS_IN_ARRAY,
             default => parent::getFieldArgTypeModifiers($objectTypeResolver, $fieldName, $fieldArgName),
         };
     }
@@ -184,6 +217,47 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                     );
                 }
                 break;
+            case 'options':
+                $nonAllowedNames = [];
+                /** @var string[] */
+                $names = $fieldDataAccessor->getValue('names');
+                foreach ($names as $name) {
+                    if ($this->getSettingsTypeAPI()->validateIsOptionAllowed($name)) {
+                        continue;
+                    }
+                    $nonAllowedNames[] = $name;
+                }
+                if ($nonAllowedNames !== []) {
+                    $field = $fieldDataAccessor->getField();
+                    if (count($nonAllowedNames) === 1) {
+                        $objectTypeFieldResolutionFeedbackStore->addError(
+                            new ObjectTypeFieldResolutionFeedback(
+                                new FeedbackItemResolution(
+                                    FeedbackItemProvider::class,
+                                    FeedbackItemProvider::E1,
+                                    [
+                                        $nonAllowedNames[0],
+                                    ]
+                                ),
+                                $field->getArgument('names') ?? $field,
+                            )
+                        );
+                        break;
+                    }
+                    $objectTypeFieldResolutionFeedbackStore->addError(
+                        new ObjectTypeFieldResolutionFeedback(
+                            new FeedbackItemResolution(
+                                FeedbackItemProvider::class,
+                                FeedbackItemProvider::E2,
+                                [
+                                    implode($this->__('\', \'', 'gatographql'), $nonAllowedNames),
+                                ]
+                            ),
+                            $field->getArgument('names') ?? $field,
+                        )
+                    );
+                }
+                break;
         }
     }
 
@@ -213,8 +287,68 @@ class RootObjectTypeFieldResolver extends AbstractObjectTypeFieldResolver
                     return array_values(array_map(fn (mixed $valueItem) => is_array($valueItem) ? (object) $valueItem : $valueItem, $value));
                 }
                 return $value;
+            case 'optionNames':
+                $optionNames = [];
+                $settingsTypeAPI = $this->getSettingsTypeAPI();
+                foreach ($settingsTypeAPI->getOptionNames() as $optionName) {
+                    if (!$settingsTypeAPI->validateIsOptionAllowed($optionName)) {
+                        continue;
+                    }
+                    $optionNames[] = $optionName;
+                }
+                /** @var stdClass|null */
+                $filterBy = $fieldDataAccessor->getValue('filterBy');
+                return $this->filterOptionNames($optionNames, $filterBy);
+            case 'options':
+                $options = [];
+                /** @var string[] */
+                $names = $fieldDataAccessor->getValue('names');
+                foreach ($names as $name) {
+                    $options[$name] = $this->getSettingsTypeAPI()->getOption($name);
+                }
+                return (object) $options;
         }
 
         return parent::resolveValue($objectTypeResolver, $object, $fieldDataAccessor, $objectTypeFieldResolutionFeedbackStore);
+    }
+
+    /**
+     * @param string[] $optionNames
+     * @return string[]
+     */
+    protected function filterOptionNames(array $optionNames, ?stdClass $filterBy): array
+    {
+        if ($filterBy === null) {
+            return $optionNames;
+        }
+        if (isset($filterBy->include)) {
+            /** @var string[] */
+            $include = $filterBy->include;
+            $optionNames = array_values(array_filter(
+                $optionNames,
+                fn (string $optionName) => $this->optionNameContainsAnyString($optionName, $include)
+            ));
+        } elseif (isset($filterBy->exclude)) {
+            /** @var string[] */
+            $exclude = $filterBy->exclude;
+            $optionNames = array_values(array_filter(
+                $optionNames,
+                fn (string $optionName) => !$this->optionNameContainsAnyString($optionName, $exclude)
+            ));
+        }
+        return $optionNames;
+    }
+
+    /**
+     * @param string[] $strings
+     */
+    protected function optionNameContainsAnyString(string $optionName, array $strings): bool
+    {
+        foreach ($strings as $string) {
+            if (str_contains($optionName, $string)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/layers/CMSSchema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
+++ b/layers/CMSSchema/packages/settings/src/TypeAPIs/AbstractSettingsTypeAPI.php
@@ -87,4 +87,11 @@ abstract class AbstractSettingsTypeAPI extends AbstractBasicService implements S
      * Otherwise, return the value.
      */
     abstract protected function doGetOption(string $name): mixed;
+
+    /**
+     * List of all the option names stored in the DB.
+     *
+     * @return string[]
+     */
+    abstract public function getOptionNames(): array;
 }

--- a/layers/CMSSchema/packages/settings/src/TypeAPIs/SettingsTypeAPIInterface.php
+++ b/layers/CMSSchema/packages/settings/src/TypeAPIs/SettingsTypeAPIInterface.php
@@ -13,6 +13,12 @@ interface SettingsTypeAPIInterface
      * @throws OptionNotAllowedException When the option does not exist, or is not in the allowlist
      */
     public function getOption(string $name, array $options = []): mixed;
+    /**
+     * List of all the option names stored in the DB.
+     *
+     * @return string[]
+     */
+    public function getOptionNames(): array;
     public function validateIsOptionAllowed(string $key): bool;
     /**
      * @return string[]

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractOptionsModifyPluginSettingsFixtureEndpointWebserverRequestTestCase.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/AbstractOptionsModifyPluginSettingsFixtureEndpointWebserverRequestTestCase.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGatoGraphQL\GatoGraphQL\Integration;
+
+use GatoGraphQL\GatoGraphQL\Constants\ModuleSettingOptions;
+use GatoGraphQL\GatoGraphQL\ModuleSettings\Properties;
+use GuzzleHttp\RequestOptions;
+use PHPUnitForGatoGraphQL\GatoGraphQL\Constants\RESTAPIEndpoints;
+use PHPUnitForGatoGraphQL\GatoGraphQLTesting\RESTAPI\Constants\Params;
+use PHPUnitForGatoGraphQL\GatoGraphQLTesting\RESTAPI\Response\ResponseKeys;
+use PoPSchema\SchemaCommons\Constants\Behaviors;
+
+/**
+ * The `optionNames`/`options` fields require both the "entries" and the
+ * "behavior" settings to be configured to produce a deterministic response
+ * (otherwise, under the default "deny" behavior with no entries, `optionNames`
+ * returns every option stored in the DB). Hence this test case modifies both
+ * settings at once, instead of only one as `AbstractModifyPluginSettingsFixtureEndpointWebserverRequestTestCase`.
+ */
+abstract class AbstractOptionsModifyPluginSettingsFixtureEndpointWebserverRequestTestCase extends AbstractModifyPluginSettingsFixtureEndpointWebserverRequestTestCase
+{
+    protected function getSettingsKey(): string
+    {
+        return ModuleSettingOptions::ENTRIES;
+    }
+
+    protected function getModuleID(string $dataName): string
+    {
+        return 'gatographql_gatographql_schema-settings';
+    }
+
+    /**
+     * @return string[]
+     */
+    abstract protected function getAllowedOptionEntries(): array;
+
+    protected function getOptionAccessBehavior(): string
+    {
+        return Behaviors::ALLOW;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getPluginSettingsNewValue(): mixed
+    {
+        return [
+            ModuleSettingOptions::ENTRIES => $this->getAllowedOptionEntries(),
+            ModuleSettingOptions::BEHAVIOR => $this->getOptionAccessBehavior(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    protected function getPluginSettingsOriginalValue(): mixed
+    {
+        $pluginSettings = $this->executeRESTEndpointToGetPluginSettings(
+            $this->getDataName(),
+        );
+        $values = [];
+        foreach ([ModuleSettingOptions::ENTRIES, ModuleSettingOptions::BEHAVIOR] as $input) {
+            $pluginInputSettings = array_values(array_filter(
+                $pluginSettings,
+                fn (array $pluginSetting) => $pluginSetting[Properties::INPUT] === $input,
+            ));
+            $this->assertEquals(count($pluginInputSettings), 1);
+            $values[$input] = $pluginInputSettings[0][ResponseKeys::VALUE];
+        }
+        return $values;
+    }
+
+    protected function executeRESTEndpointToUpdatePluginSettings(
+        string $dataName,
+        mixed $value,
+    ): void {
+        $client = static::getClient();
+        $endpointURLPlaceholder = static::getWebserverHomeURL() . '/' . RESTAPIEndpoints::MODULE_SETTINGS;
+        $endpointURL = sprintf(
+            $endpointURLPlaceholder,
+            $this->getModuleID($dataName),
+        );
+        $options = $this->getRESTEndpointRequestOptions();
+        $options[RequestOptions::QUERY][Params::JSON_ENCODED_OPTION_VALUES] = json_encode($value);
+        $response = $client->post(
+            $endpointURL,
+            $options,
+        );
+        $this->assertRESTPostCallIsSuccessful($response, $dataName, $endpointURL, $options);
+    }
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/OptionNamesFilterByModifyPluginSettingsFixtureEndpointWebserverRequestTest.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/OptionNamesFilterByModifyPluginSettingsFixtureEndpointWebserverRequestTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGatoGraphQL\GatoGraphQL\Integration;
+
+class OptionNamesFilterByModifyPluginSettingsFixtureEndpointWebserverRequestTest extends AbstractOptionsModifyPluginSettingsFixtureEndpointWebserverRequestTestCase
+{
+    protected static function getEndpoint(): string
+    {
+        return 'graphql';
+    }
+
+    protected static function getFixtureFolder(): string
+    {
+        return __DIR__ . '/fixture-option-names-filter-by';
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getAllowedOptionEntries(): array
+    {
+        return [
+            'blogname',
+            'blogdescription',
+            'siteurl',
+            'home',
+            'template',
+            'stylesheet',
+            'date_format',
+            'posts_per_page',
+        ];
+    }
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/OptionsModifyPluginSettingsFixtureEndpointWebserverRequestTest.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/OptionsModifyPluginSettingsFixtureEndpointWebserverRequestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPUnitForGatoGraphQL\GatoGraphQL\Integration;
+
+class OptionsModifyPluginSettingsFixtureEndpointWebserverRequestTest extends AbstractOptionsModifyPluginSettingsFixtureEndpointWebserverRequestTestCase
+{
+    protected static function getEndpoint(): string
+    {
+        return 'graphql';
+    }
+
+    protected static function getFixtureFolder(): string
+    {
+        return __DIR__ . '/fixture-options';
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getAllowedOptionEntries(): array
+    {
+        $dataName = $this->getDataName();
+        if (str_ends_with($dataName, ':1')) {
+            return ['siteurl', 'home'];
+        }
+        return ['blogname', 'blogdescription', 'siteurl', 'home'];
+    }
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-admin-client/introspection-extensions.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-admin-client/introspection-extensions.json
@@ -184,6 +184,26 @@
                     "enumValues": null
                 },
                 {
+                    "name": "CannotDeleteYourselfErrorPayload",
+                    "extensions": {
+                        "elementName": "CannotDeleteYourselfErrorPayload",
+                        "namespacedName": "CannotDeleteYourselfErrorPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "message",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
                     "name": "CategoryTermDoesNotExistErrorPayload",
                     "extensions": {
                         "elementName": "CategoryTermDoesNotExistErrorPayload",
@@ -734,6 +754,26 @@
                     "extensions": {
                         "elementName": "CustomPostHasAlreadyBeenTrashedErrorPayload",
                         "namespacedName": "CustomPostHasAlreadyBeenTrashedErrorPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "message",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
+                    "name": "EmailAlreadyExistsErrorPayload",
+                    "extensions": {
+                        "elementName": "EmailAlreadyExistsErrorPayload",
+                        "namespacedName": "EmailAlreadyExistsErrorPayload",
                         "possibleValues": null
                     },
                     "fields": [
@@ -2034,6 +2074,26 @@
                     "enumValues": null
                 },
                 {
+                    "name": "InvalidEmailErrorPayload",
+                    "extensions": {
+                        "elementName": "InvalidEmailErrorPayload",
+                        "namespacedName": "InvalidEmailErrorPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "message",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
                     "name": "InvalidUserEmailErrorPayload",
                     "extensions": {
                         "elementName": "InvalidUserEmailErrorPayload",
@@ -2214,6 +2274,26 @@
                     "enumValues": null
                 },
                 {
+                    "name": "LoggedInUserHasNoPermissionToCreateUsersErrorPayload",
+                    "extensions": {
+                        "elementName": "LoggedInUserHasNoPermissionToCreateUsersErrorPayload",
+                        "namespacedName": "LoggedInUserHasNoPermissionToCreateUsersErrorPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "message",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
                     "name": "LoggedInUserHasNoPermissionToDeleteCommentErrorPayload",
                     "extensions": {
                         "elementName": "LoggedInUserHasNoPermissionToDeleteCommentErrorPayload",
@@ -2278,6 +2358,26 @@
                     "extensions": {
                         "elementName": "LoggedInUserHasNoPermissionToDeleteMenuErrorPayload",
                         "namespacedName": "LoggedInUserHasNoPermissionToDeleteMenuErrorPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "message",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToDeleteUserErrorPayload",
+                    "extensions": {
+                        "elementName": "LoggedInUserHasNoPermissionToDeleteUserErrorPayload",
+                        "namespacedName": "LoggedInUserHasNoPermissionToDeleteUserErrorPayload",
                         "possibleValues": null
                     },
                     "fields": [
@@ -2378,6 +2478,26 @@
                     "extensions": {
                         "elementName": "LoggedInUserHasNoPermissionToEditUserErrorPayload",
                         "namespacedName": "LoggedInUserHasNoPermissionToEditUserErrorPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "message",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToEditUserRolesErrorPayload",
+                    "extensions": {
+                        "elementName": "LoggedInUserHasNoPermissionToEditUserRolesErrorPayload",
+                        "namespacedName": "LoggedInUserHasNoPermissionToEditUserRolesErrorPayload",
                         "possibleValues": null
                     },
                     "fields": [
@@ -3702,6 +3822,42 @@
                             ]
                         },
                         {
+                            "name": "createUser",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "createUsers",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "deleteCategories",
                             "extensions": {
                                 "isMutation": true,
@@ -4278,6 +4434,21 @@
                             ]
                         },
                         {
+                            "name": "deleteUser",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "deleteUserMeta",
                             "extensions": {
                                 "isMutation": true,
@@ -4294,6 +4465,27 @@
                         },
                         {
                             "name": "deleteUserMetas",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "deleteUsers",
                             "extensions": {
                                 "isMutation": true,
                                 "isSensitiveDataElement": false
@@ -5417,6 +5609,21 @@
                             ]
                         },
                         {
+                            "name": "updateUser",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "updateUserMeta",
                             "extensions": {
                                 "isMutation": true,
@@ -5433,6 +5640,27 @@
                         },
                         {
                             "name": "updateUserMetas",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "updateUsers",
                             "extensions": {
                                 "isMutation": true,
                                 "isSensitiveDataElement": false
@@ -7882,6 +8110,21 @@
                             ]
                         },
                         {
+                            "name": "optionNames",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "filterBy",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "optionObjectValue",
                             "extensions": {
                                 "isMutation": false,
@@ -7935,6 +8178,21 @@
                             "args": [
                                 {
                                     "name": "name",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "options",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "names",
                                     "extensions": {
                                         "isSensitiveDataElement": false
                                     }
@@ -8548,6 +8806,26 @@
                                     }
                                 }
                             ]
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
+                    "name": "ReassignUserDoesNotExistErrorPayload",
+                    "extensions": {
+                        "elementName": "ReassignUserDoesNotExistErrorPayload",
+                        "namespacedName": "ReassignUserDoesNotExistErrorPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "message",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
                         }
                     ],
                     "inputFields": null,
@@ -9368,6 +9646,42 @@
                             ]
                         },
                         {
+                            "name": "createUser",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "createUsers",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "customPost",
                             "extensions": {
                                 "isMutation": false,
@@ -10013,6 +10327,21 @@
                             ]
                         },
                         {
+                            "name": "deleteUser",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "deleteUserMeta",
                             "extensions": {
                                 "isMutation": true,
@@ -10029,6 +10358,27 @@
                         },
                         {
                             "name": "deleteUserMetas",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "deleteUsers",
                             "extensions": {
                                 "isMutation": true,
                                 "isSensitiveDataElement": false
@@ -10557,6 +10907,21 @@
                             ]
                         },
                         {
+                            "name": "optionNames",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "filterBy",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "optionObjectValue",
                             "extensions": {
                                 "isMutation": false,
@@ -10610,6 +10975,21 @@
                             "args": [
                                 {
                                     "name": "name",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "options",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "names",
                                     "extensions": {
                                         "isSensitiveDataElement": false
                                     }
@@ -12203,6 +12583,21 @@
                             ]
                         },
                         {
+                            "name": "updateUser",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
                             "name": "updateUserMeta",
                             "extensions": {
                                 "isMutation": true,
@@ -12219,6 +12614,27 @@
                         },
                         {
                             "name": "updateUserMetas",
+                            "extensions": {
+                                "isMutation": true,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "extensions": {
+                                        "isSensitiveDataElement": false
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "updateUsers",
                             "extensions": {
                                 "isMutation": true,
                                 "isSensitiveDataElement": false
@@ -13093,6 +13509,50 @@
                     "enumValues": null
                 },
                 {
+                    "name": "RootCreateUserMutationPayload",
+                    "extensions": {
+                        "elementName": "RootCreateUserMutationPayload",
+                        "namespacedName": "RootCreateUserMutationPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "errors",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "status",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "user",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "userID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
                     "name": "RootDeleteCommentMetaMutationPayload",
                     "extensions": {
                         "elementName": "RootDeleteCommentMetaMutationPayload",
@@ -13670,6 +14130,34 @@
                         },
                         {
                             "name": "userID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
+                    "name": "RootDeleteUserMutationPayload",
+                    "extensions": {
+                        "elementName": "RootDeleteUserMutationPayload",
+                        "namespacedName": "RootDeleteUserMutationPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "errors",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "status",
                             "extensions": {
                                 "isMutation": false,
                                 "isSensitiveDataElement": false
@@ -15133,6 +15621,50 @@
                     "enumValues": null
                 },
                 {
+                    "name": "RootUpdateUserMutationPayload",
+                    "extensions": {
+                        "elementName": "RootUpdateUserMutationPayload",
+                        "namespacedName": "RootUpdateUserMutationPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "errors",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "status",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "user",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        },
+                        {
+                            "name": "userID",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
                     "name": "TagTermDoesNotExistErrorPayload",
                     "extensions": {
                         "elementName": "TagTermDoesNotExistErrorPayload",
@@ -15800,6 +16332,46 @@
                         },
                         {
                             "name": "self",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
+                    "name": "UserRoleDoesNotExistErrorPayload",
+                    "extensions": {
+                        "elementName": "UserRoleDoesNotExistErrorPayload",
+                        "namespacedName": "UserRoleDoesNotExistErrorPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "message",
+                            "extensions": {
+                                "isMutation": false,
+                                "isSensitiveDataElement": false
+                            },
+                            "args": []
+                        }
+                    ],
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
+                    "name": "UsernameAlreadyExistsErrorPayload",
+                    "extensions": {
+                        "elementName": "UsernameAlreadyExistsErrorPayload",
+                        "namespacedName": "UsernameAlreadyExistsErrorPayload",
+                        "possibleValues": null
+                    },
+                    "fields": [
+                        {
+                            "name": "message",
                             "extensions": {
                                 "isMutation": false,
                                 "isSensitiveDataElement": false
@@ -20250,6 +20822,108 @@
                     "enumValues": null
                 },
                 {
+                    "name": "RootCreateUserInput",
+                    "extensions": {
+                        "elementName": "RootCreateUserInput",
+                        "namespacedName": "RootCreateUserInput",
+                        "possibleValues": null
+                    },
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "description",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "displayName",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "email",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "firstName",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "lastName",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "locale",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "meta",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "nickname",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "password",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "registeredDate",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "roles",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "sendEmailNotification",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "slug",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "username",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "websiteURL",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        }
+                    ],
+                    "enumValues": null
+                },
+                {
                     "name": "RootCustomPostsFilterInput",
                     "extensions": {
                         "elementName": "RootCustomPostsFilterInput",
@@ -20686,6 +21360,30 @@
                         },
                         {
                             "name": "value",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        }
+                    ],
+                    "enumValues": null
+                },
+                {
+                    "name": "RootDeleteUserInput",
+                    "extensions": {
+                        "elementName": "RootDeleteUserInput",
+                        "namespacedName": "RootDeleteUserInput",
+                        "possibleValues": null
+                    },
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "id",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "reassignAuthorContentTo",
                             "extensions": {
                                 "isSensitiveDataElement": false
                             }
@@ -22746,6 +23444,102 @@
                     "enumValues": null
                 },
                 {
+                    "name": "RootUpdateUserInput",
+                    "extensions": {
+                        "elementName": "RootUpdateUserInput",
+                        "namespacedName": "RootUpdateUserInput",
+                        "possibleValues": null
+                    },
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "description",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "displayName",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "email",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "firstName",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "id",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "lastName",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "locale",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "meta",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "nickname",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "password",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "registeredDate",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "roles",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "slug",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        },
+                        {
+                            "name": "websiteURL",
+                            "extensions": {
+                                "isSensitiveDataElement": false
+                            }
+                        }
+                    ],
+                    "enumValues": null
+                },
+                {
                     "name": "RootUpdateUserMetaInput",
                     "extensions": {
                         "elementName": "RootUpdateUserMetaInput",
@@ -24784,6 +25578,17 @@
                     "enumValues": null
                 },
                 {
+                    "name": "RootCreateUserMutationErrorPayloadUnion",
+                    "extensions": {
+                        "elementName": "RootCreateUserMutationErrorPayloadUnion",
+                        "namespacedName": "RootCreateUserMutationErrorPayloadUnion",
+                        "possibleValues": null
+                    },
+                    "fields": null,
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
                     "name": "RootDeleteCommentMetaMutationErrorPayloadUnion",
                     "extensions": {
                         "elementName": "RootDeleteCommentMetaMutationErrorPayloadUnion",
@@ -24964,6 +25769,17 @@
                     "extensions": {
                         "elementName": "RootDeleteUserMetaMutationErrorPayloadUnion",
                         "namespacedName": "RootDeleteUserMetaMutationErrorPayloadUnion",
+                        "possibleValues": null
+                    },
+                    "fields": null,
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
+                    "name": "RootDeleteUserMutationErrorPayloadUnion",
+                    "extensions": {
+                        "elementName": "RootDeleteUserMutationErrorPayloadUnion",
+                        "namespacedName": "RootDeleteUserMutationErrorPayloadUnion",
                         "possibleValues": null
                     },
                     "fields": null,
@@ -25327,6 +26143,17 @@
                     "extensions": {
                         "elementName": "RootUpdateUserMetaMutationErrorPayloadUnion",
                         "namespacedName": "RootUpdateUserMetaMutationErrorPayloadUnion",
+                        "possibleValues": null
+                    },
+                    "fields": null,
+                    "inputFields": null,
+                    "enumValues": null
+                },
+                {
+                    "name": "RootUpdateUserMutationErrorPayloadUnion",
+                    "extensions": {
+                        "elementName": "RootUpdateUserMutationErrorPayloadUnion",
+                        "namespacedName": "RootUpdateUserMutationErrorPayloadUnion",
                         "possibleValues": null
                     },
                     "fields": null,

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-admin-client/introspection-query.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-admin-client/introspection-query.json
@@ -358,6 +358,42 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "CannotDeleteYourselfErrorPayload",
+                    "description": "Error payload for: \"The user cannot delete themselves\"",
+                    "fields": [
+                        {
+                            "name": "message",
+                            "description": "Error message",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "String!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "CategoryTermDoesNotExistErrorPayload",
                     "description": "Error payload for: \"The requested category does not exist\"",
                     "fields": [
@@ -1446,6 +1482,42 @@
                     "kind": "OBJECT",
                     "name": "CustomPostHasAlreadyBeenTrashedErrorPayload",
                     "description": "Error payload for: \"The custom post has already been sent to the trash\"",
+                    "fields": [
+                        {
+                            "name": "message",
+                            "description": "Error message",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "String!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "EmailAlreadyExistsErrorPayload",
+                    "description": "Error payload for: \"The email already exists\"",
                     "fields": [
                         {
                             "name": "message",
@@ -4301,6 +4373,42 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "InvalidEmailErrorPayload",
+                    "description": "Error payload for: \"The email is invalid\"",
+                    "fields": [
+                        {
+                            "name": "message",
+                            "description": "Error message",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "String!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "InvalidUserEmailErrorPayload",
                     "description": "Error payload for: \"No user is registered with the provided email\"",
                     "fields": [
@@ -4625,6 +4733,42 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "LoggedInUserHasNoPermissionToCreateUsersErrorPayload",
+                    "description": "Error payload for: \"The logged-in user does not have permission to create users\"",
+                    "fields": [
+                        {
+                            "name": "message",
+                            "description": "Error message",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "String!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "LoggedInUserHasNoPermissionToDeleteCommentErrorPayload",
                     "description": "Error payload for: \"The user has no permission to delete the comment\"",
                     "fields": [
@@ -4735,6 +4879,42 @@
                     "kind": "OBJECT",
                     "name": "LoggedInUserHasNoPermissionToDeleteMenuErrorPayload",
                     "description": "Error payload for: \"The user has no permission to delete the menu\"",
+                    "fields": [
+                        {
+                            "name": "message",
+                            "description": "Error message",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "String!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "LoggedInUserHasNoPermissionToDeleteUserErrorPayload",
+                    "description": "Error payload for: \"The logged-in user does not have permission to delete the user\"",
                     "fields": [
                         {
                             "name": "message",
@@ -4915,6 +5095,42 @@
                     "kind": "OBJECT",
                     "name": "LoggedInUserHasNoPermissionToEditUserErrorPayload",
                     "description": "Error payload for: \"The logged-in user has no permission to edit the user\"",
+                    "fields": [
+                        {
+                            "name": "message",
+                            "description": "Error message",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "String!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "LoggedInUserHasNoPermissionToEditUserRolesErrorPayload",
+                    "description": "Error payload for: \"The logged-in user does not have permission to edit the user roles\"",
                     "fields": [
                         {
                             "name": "message",
@@ -8183,6 +8399,112 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "createUser",
+                            "description": "Create a user",
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": "Input to create a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootCreateUserInput!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "RootCreateUserInput",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "RootCreateUserMutationPayload!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "RootCreateUserMutationPayload",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "createUsers",
+                            "description": "Create users",
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "description": "Input to create a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "[RootCreateUserInput!]!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "LIST",
+                                            "name": "[RootCreateUserInput!]",
+                                            "isOneOf": false,
+                                            "ofType": {
+                                                "kind": "NON_NULL",
+                                                "name": "RootCreateUserInput!",
+                                                "isOneOf": false,
+                                                "ofType": {
+                                                    "kind": "INPUT_OBJECT",
+                                                    "name": "RootCreateUserInput",
+                                                    "isOneOf": false,
+                                                    "ofType": null
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "description": "The Boolean scalar type represents `true` or `false`.",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "Boolean!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "Boolean",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "[RootCreateUserMutationPayload!]!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": "[RootCreateUserMutationPayload!]",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootCreateUserMutationPayload!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "RootCreateUserMutationPayload",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "deleteCategories",
                             "description": "Delete categories",
                             "args": [
@@ -9879,6 +10201,41 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "deleteUser",
+                            "description": "Delete a user",
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": "Input to delete a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootDeleteUserInput!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "RootDeleteUserInput",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "RootDeleteUserMutationPayload!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "RootDeleteUserMutationPayload",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "deleteUserMeta",
                             "description": "Delete meta from user",
                             "args": [
@@ -9975,6 +10332,77 @@
                                         "ofType": {
                                             "kind": "OBJECT",
                                             "name": "RootDeleteUserMetaMutationPayload",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deleteUsers",
+                            "description": "Delete users",
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "description": "Input to delete a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "[RootDeleteUserInput!]!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "LIST",
+                                            "name": "[RootDeleteUserInput!]",
+                                            "isOneOf": false,
+                                            "ofType": {
+                                                "kind": "NON_NULL",
+                                                "name": "RootDeleteUserInput!",
+                                                "isOneOf": false,
+                                                "ofType": {
+                                                    "kind": "INPUT_OBJECT",
+                                                    "name": "RootDeleteUserInput",
+                                                    "isOneOf": false,
+                                                    "ofType": null
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "description": "The Boolean scalar type represents `true` or `false`.",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "Boolean!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "Boolean",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "[RootDeleteUserMutationPayload!]!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": "[RootDeleteUserMutationPayload!]",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootDeleteUserMutationPayload!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "RootDeleteUserMutationPayload",
                                             "isOneOf": false,
                                             "ofType": null
                                         }
@@ -13218,6 +13646,41 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "updateUser",
+                            "description": "Update a user",
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": "Input to update a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootUpdateUserInput!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "RootUpdateUserInput",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "RootUpdateUserMutationPayload!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "RootUpdateUserMutationPayload",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "updateUserMeta",
                             "description": "Update meta from user",
                             "args": [
@@ -13314,6 +13777,77 @@
                                         "ofType": {
                                             "kind": "OBJECT",
                                             "name": "RootUpdateUserMetaMutationPayload",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "updateUsers",
+                            "description": "Update users",
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "description": "Input to update a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "[RootUpdateUserInput!]!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "LIST",
+                                            "name": "[RootUpdateUserInput!]",
+                                            "isOneOf": false,
+                                            "ofType": {
+                                                "kind": "NON_NULL",
+                                                "name": "RootUpdateUserInput!",
+                                                "isOneOf": false,
+                                                "ofType": {
+                                                    "kind": "INPUT_OBJECT",
+                                                    "name": "RootUpdateUserInput",
+                                                    "isOneOf": false,
+                                                    "ofType": null
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "description": "The Boolean scalar type represents `true` or `false`.",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "Boolean!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "Boolean",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "[RootUpdateUserMutationPayload!]!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": "[RootUpdateUserMutationPayload!]",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootUpdateUserMutationPayload!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "RootUpdateUserMutationPayload",
                                             "isOneOf": false,
                                             "ofType": null
                                         }
@@ -18860,6 +19394,46 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "optionNames",
+                            "description": "List of the allowed option names saved in the DB.",
+                            "args": [
+                                {
+                                    "name": "filterBy",
+                                    "description": "Filter the option names to be retrieved",
+                                    "type": {
+                                        "kind": "INPUT_OBJECT",
+                                        "name": "IncludeExcludeFilterInput",
+                                        "isOneOf": true,
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "[String!]!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": "[String!]",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": "String!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "optionObjectValue",
                             "description": "Object-value option saved in the DB, or `null` if entry does not exist",
                             "args": [
@@ -18982,6 +19556,51 @@
                                 "ofType": {
                                     "kind": "SCALAR",
                                     "name": "AnyBuiltInScalar",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "options",
+                            "description": "JSON object, with the option name as key and the option value as value, for the provided option names.",
+                            "args": [
+                                {
+                                    "name": "names",
+                                    "description": "The option names",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "[String!]!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "LIST",
+                                            "name": "[String!]",
+                                            "isOneOf": false,
+                                            "ofType": {
+                                                "kind": "NON_NULL",
+                                                "name": "String!",
+                                                "isOneOf": false,
+                                                "ofType": {
+                                                    "kind": "SCALAR",
+                                                    "name": "String",
+                                                    "isOneOf": false,
+                                                    "ofType": null
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "JSONObject!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "JSONObject",
                                     "isOneOf": false,
                                     "ofType": null
                                 }
@@ -20348,6 +20967,42 @@
                         {
                             "kind": "INTERFACE",
                             "name": "IdentifiableObject",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "ReassignUserDoesNotExistErrorPayload",
+                    "description": "Error payload for: \"The user to reassign the content to does not exist\"",
+                    "fields": [
+                        {
+                            "name": "message",
+                            "description": "Error message",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "String!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ErrorPayload",
                             "isOneOf": false,
                             "ofType": null
                         }
@@ -22607,6 +23262,112 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "createUser",
+                            "description": "Create a user",
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": "Input to create a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootCreateUserInput!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "RootCreateUserInput",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "RootCreateUserMutationPayload!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "RootCreateUserMutationPayload",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "createUsers",
+                            "description": "Create users",
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "description": "Input to create a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "[RootCreateUserInput!]!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "LIST",
+                                            "name": "[RootCreateUserInput!]",
+                                            "isOneOf": false,
+                                            "ofType": {
+                                                "kind": "NON_NULL",
+                                                "name": "RootCreateUserInput!",
+                                                "isOneOf": false,
+                                                "ofType": {
+                                                    "kind": "INPUT_OBJECT",
+                                                    "name": "RootCreateUserInput",
+                                                    "isOneOf": false,
+                                                    "ofType": null
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "description": "The Boolean scalar type represents `true` or `false`.",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "Boolean!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "Boolean",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "[RootCreateUserMutationPayload!]!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": "[RootCreateUserMutationPayload!]",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootCreateUserMutationPayload!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "RootCreateUserMutationPayload",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "customPost",
                             "description": "Query a custom post by different properties",
                             "args": [
@@ -24477,6 +25238,41 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "deleteUser",
+                            "description": "Delete a user",
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": "Input to delete a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootDeleteUserInput!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "RootDeleteUserInput",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "RootDeleteUserMutationPayload!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "RootDeleteUserMutationPayload",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "deleteUserMeta",
                             "description": "Delete meta from user",
                             "args": [
@@ -24573,6 +25369,77 @@
                                         "ofType": {
                                             "kind": "OBJECT",
                                             "name": "RootDeleteUserMetaMutationPayload",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "deleteUsers",
+                            "description": "Delete users",
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "description": "Input to delete a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "[RootDeleteUserInput!]!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "LIST",
+                                            "name": "[RootDeleteUserInput!]",
+                                            "isOneOf": false,
+                                            "ofType": {
+                                                "kind": "NON_NULL",
+                                                "name": "RootDeleteUserInput!",
+                                                "isOneOf": false,
+                                                "ofType": {
+                                                    "kind": "INPUT_OBJECT",
+                                                    "name": "RootDeleteUserInput",
+                                                    "isOneOf": false,
+                                                    "ofType": null
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "description": "The Boolean scalar type represents `true` or `false`.",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "Boolean!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "Boolean",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "[RootDeleteUserMutationPayload!]!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": "[RootDeleteUserMutationPayload!]",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootDeleteUserMutationPayload!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "RootDeleteUserMutationPayload",
                                             "isOneOf": false,
                                             "ofType": null
                                         }
@@ -25746,6 +26613,46 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "optionNames",
+                            "description": "List of the allowed option names saved in the DB.",
+                            "args": [
+                                {
+                                    "name": "filterBy",
+                                    "description": "Filter the option names to be retrieved",
+                                    "type": {
+                                        "kind": "INPUT_OBJECT",
+                                        "name": "IncludeExcludeFilterInput",
+                                        "isOneOf": true,
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "[String!]!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": "[String!]",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": "String!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "optionObjectValue",
                             "description": "Object-value option saved in the DB, or `null` if entry does not exist",
                             "args": [
@@ -25868,6 +26775,51 @@
                                 "ofType": {
                                     "kind": "SCALAR",
                                     "name": "AnyBuiltInScalar",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "options",
+                            "description": "JSON object, with the option name as key and the option value as value, for the provided option names.",
+                            "args": [
+                                {
+                                    "name": "names",
+                                    "description": "The option names",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "[String!]!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "LIST",
+                                            "name": "[String!]",
+                                            "isOneOf": false,
+                                            "ofType": {
+                                                "kind": "NON_NULL",
+                                                "name": "String!",
+                                                "isOneOf": false,
+                                                "ofType": {
+                                                    "kind": "SCALAR",
+                                                    "name": "String",
+                                                    "isOneOf": false,
+                                                    "ofType": null
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "JSONObject!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "JSONObject",
                                     "isOneOf": false,
                                     "ofType": null
                                 }
@@ -30192,6 +31144,41 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "updateUser",
+                            "description": "Update a user",
+                            "args": [
+                                {
+                                    "name": "input",
+                                    "description": "Input to update a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootUpdateUserInput!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "INPUT_OBJECT",
+                                            "name": "RootUpdateUserInput",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "RootUpdateUserMutationPayload!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "RootUpdateUserMutationPayload",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "updateUserMeta",
                             "description": "Update meta from user",
                             "args": [
@@ -30288,6 +31275,77 @@
                                         "ofType": {
                                             "kind": "OBJECT",
                                             "name": "RootUpdateUserMetaMutationPayload",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "updateUsers",
+                            "description": "Update users",
+                            "args": [
+                                {
+                                    "name": "inputs",
+                                    "description": "Input to update a user",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "[RootUpdateUserInput!]!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "LIST",
+                                            "name": "[RootUpdateUserInput!]",
+                                            "isOneOf": false,
+                                            "ofType": {
+                                                "kind": "NON_NULL",
+                                                "name": "RootUpdateUserInput!",
+                                                "isOneOf": false,
+                                                "ofType": {
+                                                    "kind": "INPUT_OBJECT",
+                                                    "name": "RootUpdateUserInput",
+                                                    "isOneOf": false,
+                                                    "ofType": null
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
+                                    "name": "stopExecutingMutationItemsOnFirstError",
+                                    "description": "The Boolean scalar type represents `true` or `false`.",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": "Boolean!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "Boolean",
+                                            "isOneOf": false,
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": "false"
+                                }
+                            ],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "[RootUpdateUserMutationPayload!]!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": "[RootUpdateUserMutationPayload!]",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": "RootUpdateUserMutationPayload!",
+                                        "isOneOf": false,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "RootUpdateUserMutationPayload",
                                             "isOneOf": false,
                                             "ofType": null
                                         }
@@ -31855,6 +32913,84 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "RootCreateUserMutationPayload",
+                    "description": "Payload of creating a user",
+                    "fields": [
+                        {
+                            "name": "errors",
+                            "description": "List of error data, if the operation failed",
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": "[RootCreateUserMutationErrorPayloadUnion!]",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": "RootCreateUserMutationErrorPayloadUnion!",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "UNION",
+                                        "name": "RootCreateUserMutationErrorPayloadUnion",
+                                        "isOneOf": false,
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "status",
+                            "description": "Status of the operation",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "OperationStatusEnum!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "ENUM",
+                                    "name": "OperationStatusEnum",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "user",
+                            "description": "Object affected by the mutation, if the operation was successful",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "User",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "userID",
+                            "description": "ID of the entity, if the operation was successful",
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "ID",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "RootDeleteCommentMetaMutationPayload",
                     "description": "Payload of executing a delete meta mutation on a comment",
                     "fields": [
@@ -32909,6 +34045,58 @@
                                 "name": "ID",
                                 "isOneOf": false,
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "RootDeleteUserMutationPayload",
+                    "description": "Payload of deleting a user",
+                    "fields": [
+                        {
+                            "name": "errors",
+                            "description": "List of error data, if the operation failed",
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": "[RootDeleteUserMutationErrorPayloadUnion!]",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": "RootDeleteUserMutationErrorPayloadUnion!",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "UNION",
+                                        "name": "RootDeleteUserMutationErrorPayloadUnion",
+                                        "isOneOf": false,
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "status",
+                            "description": "Status of the operation",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "OperationStatusEnum!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "ENUM",
+                                    "name": "OperationStatusEnum",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -35495,6 +36683,84 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "RootUpdateUserMutationPayload",
+                    "description": "Payload of updating a user",
+                    "fields": [
+                        {
+                            "name": "errors",
+                            "description": "List of error data, if the operation failed",
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": "[RootUpdateUserMutationErrorPayloadUnion!]",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": "RootUpdateUserMutationErrorPayloadUnion!",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "UNION",
+                                        "name": "RootUpdateUserMutationErrorPayloadUnion",
+                                        "isOneOf": false,
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "status",
+                            "description": "Status of the operation",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "OperationStatusEnum!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "ENUM",
+                                    "name": "OperationStatusEnum",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "user",
+                            "description": "Object affected by the mutation, if the operation was successful",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "User",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "userID",
+                            "description": "ID of the entity, if the operation was successful",
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "ID",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "TagTermDoesNotExistErrorPayload",
                     "description": "Error payload for: \"The requested tag does not exist\"",
                     "fields": [
@@ -36957,6 +38223,78 @@
                         {
                             "kind": "INTERFACE",
                             "name": "IdentifiableObject",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "UserRoleDoesNotExistErrorPayload",
+                    "description": "Error payload for: \"The user role does not exist\"",
+                    "fields": [
+                        {
+                            "name": "message",
+                            "description": "Error message",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "String!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "UsernameAlreadyExistsErrorPayload",
+                    "description": "Error payload for: \"The username already exists\"",
+                    "fields": [
+                        {
+                            "name": "message",
+                            "description": "Error message",
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "String!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ErrorPayload",
                             "isOneOf": false,
                             "ofType": null
                         }
@@ -39488,6 +40826,12 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "CannotDeleteYourselfErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "CategoryTermDoesNotExistErrorPayload",
                             "isOneOf": false,
                             "ofType": null
@@ -39572,6 +40916,12 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "EmailAlreadyExistsErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "EntityMetaAlreadyHasSingleEntryErrorPayload",
                             "isOneOf": false,
                             "ofType": null
@@ -39603,6 +40953,12 @@
                         {
                             "kind": "OBJECT",
                             "name": "GenericErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "InvalidEmailErrorPayload",
                             "isOneOf": false,
                             "ofType": null
                         },
@@ -39662,6 +41018,12 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "LoggedInUserHasNoPermissionToCreateUsersErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "LoggedInUserHasNoPermissionToDeleteCommentErrorPayload",
                             "isOneOf": false,
                             "ofType": null
@@ -39681,6 +41043,12 @@
                         {
                             "kind": "OBJECT",
                             "name": "LoggedInUserHasNoPermissionToDeleteMenuErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "LoggedInUserHasNoPermissionToDeleteUserErrorPayload",
                             "isOneOf": false,
                             "ofType": null
                         },
@@ -39711,6 +41079,12 @@
                         {
                             "kind": "OBJECT",
                             "name": "LoggedInUserHasNoPermissionToEditUserErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "LoggedInUserHasNoPermissionToEditUserRolesErrorPayload",
                             "isOneOf": false,
                             "ofType": null
                         },
@@ -39753,6 +41127,12 @@
                         {
                             "kind": "OBJECT",
                             "name": "PasswordIsIncorrectErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "ReassignUserDoesNotExistErrorPayload",
                             "isOneOf": false,
                             "ofType": null
                         },
@@ -39801,6 +41181,18 @@
                         {
                             "kind": "OBJECT",
                             "name": "UserIsNotLoggedInErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "UserRoleDoesNotExistErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "UsernameAlreadyExistsErrorPayload",
                             "isOneOf": false,
                             "ofType": null
                         }
@@ -45689,6 +47081,202 @@
                 },
                 {
                     "kind": "INPUT_OBJECT",
+                    "name": "RootCreateUserInput",
+                    "description": "Input to create a user",
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "description",
+                            "description": "The user's biographical description",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "displayName",
+                            "description": "The name to display for the user on the site",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "email",
+                            "description": "The user's email address",
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "Email!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Email",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "firstName",
+                            "description": "The user's first name",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "lastName",
+                            "description": "The user's last name",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "locale",
+                            "description": "The user's locale",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "meta",
+                            "description": "The meta to set",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "NullableListValueJSONObject",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "nickname",
+                            "description": "The user's nickname",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "password",
+                            "description": "The user's password. When creating a user, if not provided a random password is generated",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "registeredDate",
+                            "description": "The date the user registered",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "DateTime",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "roles",
+                            "description": "The roles assigned to the user",
+                            "type": {
+                                "kind": "LIST",
+                                "name": "[String!]",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": "String!",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "isOneOf": false,
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "sendEmailNotification",
+                            "description": "Whether to send the new user an email about their account",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": "false"
+                        },
+                        {
+                            "name": "slug",
+                            "description": "The URL-friendly slug (nicename) for the user",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "username",
+                            "description": "The username (login). It cannot be changed once the user is created",
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "String!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "websiteURL",
+                            "description": "The user's website URL",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "URL",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
                     "name": "RootCustomPostsFilterInput",
                     "description": "Input to filter custom posts",
                     "fields": null,
@@ -46511,6 +48099,44 @@
                             "type": {
                                 "kind": "SCALAR",
                                 "name": "AnyScalar",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
+                    "name": "RootDeleteUserInput",
+                    "description": "Input to delete a user",
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "id",
+                            "description": "The ID of the user to delete",
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "ID!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "reassignAuthorContentTo",
+                            "description": "The ID of the user to reassign the deleted user's content to. If not provided, the content is deleted",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "ID",
                                 "isOneOf": false,
                                 "ofType": null
                             },
@@ -50844,6 +52470,186 @@
                 },
                 {
                     "kind": "INPUT_OBJECT",
+                    "name": "RootUpdateUserInput",
+                    "description": "Input to update a user",
+                    "fields": null,
+                    "inputFields": [
+                        {
+                            "name": "description",
+                            "description": "The user's biographical description",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "displayName",
+                            "description": "The name to display for the user on the site",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "email",
+                            "description": "The user's email address",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Email",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "firstName",
+                            "description": "The user's first name",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "id",
+                            "description": "The ID of the user to update",
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": "ID!",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "ID",
+                                    "isOneOf": false,
+                                    "ofType": null
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "lastName",
+                            "description": "The user's last name",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "locale",
+                            "description": "The user's locale",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "meta",
+                            "description": "The meta to set",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "NullableListValueJSONObject",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "nickname",
+                            "description": "The user's nickname",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "password",
+                            "description": "The user's password. When creating a user, if not provided a random password is generated",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "registeredDate",
+                            "description": "The date the user registered",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "DateTime",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "roles",
+                            "description": "The roles assigned to the user",
+                            "type": {
+                                "kind": "LIST",
+                                "name": "[String!]",
+                                "isOneOf": false,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": "String!",
+                                    "isOneOf": false,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "isOneOf": false,
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "slug",
+                            "description": "The URL-friendly slug (nicename) for the user",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        },
+                        {
+                            "name": "websiteURL",
+                            "description": "The user's website URL",
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "URL",
+                                "isOneOf": false,
+                                "ofType": null
+                            },
+                            "defaultValue": null
+                        }
+                    ],
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "INPUT_OBJECT",
                     "name": "RootUpdateUserMetaInput",
                     "description": "Input to update a user's meta",
                     "fields": null,
@@ -54409,6 +56215,71 @@
                 },
                 {
                     "kind": "UNION",
+                    "name": "RootCreateUserMutationErrorPayloadUnion",
+                    "description": "Union of 'Error Payload' types when creating a user",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": [
+                        {
+                            "kind": "OBJECT",
+                            "name": "AccessToMetaKeyIsNotAllowedErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "EmailAlreadyExistsErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "GenericErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "InvalidEmailErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "LoggedInUserHasNoPermissionToCreateUsersErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "LoggedInUserHasNoPermissionToEditUserRolesErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "UserIsNotLoggedInErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "UserRoleDoesNotExistErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "UsernameAlreadyExistsErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ]
+                },
+                {
+                    "kind": "UNION",
                     "name": "RootDeleteCommentMetaMutationErrorPayloadUnion",
                     "description": "Union of 'Error Payload' types when deleting meta on a comment",
                     "fields": null,
@@ -55171,6 +57042,53 @@
                         {
                             "kind": "OBJECT",
                             "name": "LoggedInUserHasNoPermissionToEditUserErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "UserDoesNotExistErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "UserIsNotLoggedInErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ]
+                },
+                {
+                    "kind": "UNION",
+                    "name": "RootDeleteUserMutationErrorPayloadUnion",
+                    "description": "Union of 'Error Payload' types when deleting a user",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": [
+                        {
+                            "kind": "OBJECT",
+                            "name": "CannotDeleteYourselfErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "GenericErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "LoggedInUserHasNoPermissionToDeleteUserErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "ReassignUserDoesNotExistErrorPayload",
                             "isOneOf": false,
                             "ofType": null
                         },
@@ -56950,6 +58868,71 @@
                         {
                             "kind": "OBJECT",
                             "name": "UserIsNotLoggedInErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        }
+                    ]
+                },
+                {
+                    "kind": "UNION",
+                    "name": "RootUpdateUserMutationErrorPayloadUnion",
+                    "description": "Union of 'Error Payload' types when updating a user",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": [
+                        {
+                            "kind": "OBJECT",
+                            "name": "AccessToMetaKeyIsNotAllowedErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "EmailAlreadyExistsErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "GenericErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "InvalidEmailErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "LoggedInUserHasNoPermissionToEditUserErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "LoggedInUserHasNoPermissionToEditUserRolesErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "UserDoesNotExistErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "UserIsNotLoggedInErrorPayload",
+                            "isOneOf": false,
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "UserRoleDoesNotExistErrorPayload",
                             "isOneOf": false,
                             "ofType": null
                         }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-admin-editor-block-queries/get-type-fields.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-admin-editor-block-queries/get-type-fields.json
@@ -1,6735 +1,6978 @@
 {
-  "data": {
-    "__schema": {
-      "types": [
-        {
-          "name": "AccessToMetaKeyIsNotAllowedErrorPayload",
-          "namespacedName": "AccessToMetaKeyIsNotAllowedErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"Access to the meta key is not allowed\""
-        },
-        {
-          "name": "BlockType",
-          "namespacedName": "BlockType",
-          "fields": [
-            {
-              "name": "attributeNames"
-            },
-            {
-              "name": "attributes"
-            },
-            {
-              "name": "hasRenderCallback"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "supports"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "A block type registered in the WordPress block registry"
-        },
-        {
-          "name": "BlockTypeAttribute",
-          "namespacedName": "BlockTypeAttribute",
-          "fields": [
-            {
-              "name": "autoGenerateControl"
-            },
-            {
-              "name": "blockTypeName"
-            },
-            {
-              "name": "default"
-            },
-            {
-              "name": "enum"
-            },
-            {
-              "name": "fieldType"
-            },
-            {
-              "name": "label"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "role"
-            },
-            {
-              "name": "schema"
-            },
-            {
-              "name": "source"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "A registered attribute of a block type, as defined in its block.json schema"
-        },
-        {
-          "name": "CategoryTermDoesNotExistErrorPayload",
-          "namespacedName": "CategoryTermDoesNotExistErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The requested category does not exist\""
-        },
-        {
-          "name": "Comment",
-          "namespacedName": "Comment",
-          "fields": [
-            {
-              "name": "approved"
-            },
-            {
-              "name": "author"
-            },
-            {
-              "name": "authorEmail"
-            },
-            {
-              "name": "authorIP"
-            },
-            {
-              "name": "authorName"
-            },
-            {
-              "name": "authorURL"
-            },
-            {
-              "name": "content"
-            },
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "date"
-            },
-            {
-              "name": "dateStr"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "karma"
-            },
-            {
-              "name": "meta"
-            },
-            {
-              "name": "metaKeys"
-            },
-            {
-              "name": "metaValue"
-            },
-            {
-              "name": "metaValues"
-            },
-            {
-              "name": "parent"
-            },
-            {
-              "name": "rawContent"
-            },
-            {
-              "name": "responseCount"
-            },
-            {
-              "name": "responses"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "type"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Comments added to custom posts"
-        },
-        {
-          "name": "CommentAuthorEmailIsMissingErrorPayload",
-          "namespacedName": "CommentAuthorEmailIsMissingErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The comment's author email is missing\""
-        },
-        {
-          "name": "CommentAuthorNameIsMissingErrorPayload",
-          "namespacedName": "CommentAuthorNameIsMissingErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The comment's author name is missing\""
-        },
-        {
-          "name": "CommentDoesNotExistErrorPayload",
-          "namespacedName": "CommentDoesNotExistErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The comment does not exist\""
-        },
-        {
-          "name": "CommentDoesNotSupportTrashErrorPayload",
-          "namespacedName": "CommentDoesNotSupportTrashErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The comment does not support being sent to the trash\""
-        },
-        {
-          "name": "CommentHasAlreadyBeenTrashedErrorPayload",
-          "namespacedName": "CommentHasAlreadyBeenTrashedErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The comment has already been sent to the trash\""
-        },
-        {
-          "name": "CommentParentCommentDoesNotExistErrorPayload",
-          "namespacedName": "CommentParentCommentDoesNotExistErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The comment's parent does not exist\""
-        },
-        {
-          "name": "CommentsAreNotOpenForCustomPostErrorPayload",
-          "namespacedName": "CommentsAreNotOpenForCustomPostErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"Comments are not open for the custom post\""
-        },
-        {
-          "name": "CommentsAreNotSupportedByCustomPostTypeErrorPayload",
-          "namespacedName": "CommentsAreNotSupportedByCustomPostTypeErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"Comments are not supported by the custom post type\""
-        },
-        {
-          "name": "CustomPostAncestorRecursionErrorPayload",
-          "namespacedName": "CustomPostAncestorRecursionErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The custom post is an ancestor of itself\""
-        },
-        {
-          "name": "CustomPostDoesNotExistErrorPayload",
-          "namespacedName": "CustomPostDoesNotExistErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The requested custom post does not exist\""
-        },
-        {
-          "name": "CustomPostDoesNotHaveExpectedTypeErrorPayload",
-          "namespacedName": "CustomPostDoesNotHaveExpectedTypeErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The requested custom post does not have the expected type\""
-        },
-        {
-          "name": "CustomPostDoesNotSupportTrashErrorPayload",
-          "namespacedName": "CustomPostDoesNotSupportTrashErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The custom post does not support being sent to the trash\""
-        },
-        {
-          "name": "CustomPostHasAlreadyBeenTrashedErrorPayload",
-          "namespacedName": "CustomPostHasAlreadyBeenTrashedErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The custom post has already been sent to the trash\""
-        },
-        {
-          "name": "EntityMetaAlreadyHasSingleEntryErrorPayload",
-          "namespacedName": "EntityMetaAlreadyHasSingleEntryErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The taxonomy term already has the single meta entry\""
-        },
-        {
-          "name": "EntityMetaEntryAlreadyHasValueErrorPayload",
-          "namespacedName": "EntityMetaEntryAlreadyHasValueErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The taxonomy term already has the meta entry with the provided update value\""
-        },
-        {
-          "name": "EntityMetaKeyDoesNotExistErrorPayload",
-          "namespacedName": "EntityMetaKeyDoesNotExistErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The taxonomy term doesn't have a meta entry with that key\""
-        },
-        {
-          "name": "EntityMetaKeyWithValueDoesNotExistErrorPayload",
-          "namespacedName": "EntityMetaKeyWithValueDoesNotExistErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The taxonomy term doesn't have a meta entry with that key\""
-        },
-        {
-          "name": "FeaturedImageIsNotSupportedByCustomPostTypeErrorPayload",
-          "namespacedName": "FeaturedImageIsNotSupportedByCustomPostTypeErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"Setting the featured image is not supported by the custom post type\""
-        },
-        {
-          "name": "GeneralBlock",
-          "namespacedName": "GeneralBlock",
-          "fields": [
-            {
-              "name": "attributes"
-            },
-            {
-              "name": "contentSource"
-            },
-            {
-              "name": "innerBlocks"
-            },
-            {
-              "name": "name"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of a Block that works for all blocks, retrieving the block attributes as a non-strictly-typed JSON object"
-        },
-        {
-          "name": "GenericCategory",
-          "namespacedName": "GenericCategory",
-          "fields": [
-            {
-              "name": "ancestors"
-            },
-            {
-              "name": "count"
-            },
-            {
-              "name": "customPostCount"
-            },
-            {
-              "name": "customPosts"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "meta"
-            },
-            {
-              "name": "metaKeys"
-            },
-            {
-              "name": "metaValue"
-            },
-            {
-              "name": "metaValues"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "parent"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "slug"
-            },
-            {
-              "name": "slugPath"
-            },
-            {
-              "name": "taxonomy"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "A category that does not have its own type in the schema"
-        },
-        {
-          "name": "GenericCustomPost",
-          "namespacedName": "GenericCustomPost",
-          "fields": [
-            {
-              "name": "ancestors"
-            },
-            {
-              "name": "areCommentsOpen"
-            },
-            {
-              "name": "author"
-            },
-            {
-              "name": "blockDataItems"
-            },
-            {
-              "name": "blockFlattenedDataItems"
-            },
-            {
-              "name": "blocks"
-            },
-            {
-              "name": "categories"
-            },
-            {
-              "name": "categoryCount"
-            },
-            {
-              "name": "categoryNames"
-            },
-            {
-              "name": "childCount"
-            },
-            {
-              "name": "children"
-            },
-            {
-              "name": "commentCount"
-            },
-            {
-              "name": "comments"
-            },
-            {
-              "name": "content"
-            },
-            {
-              "name": "customPostType"
-            },
-            {
-              "name": "date"
-            },
-            {
-              "name": "dateStr"
-            },
-            {
-              "name": "excerpt"
-            },
-            {
-              "name": "featuredImage"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "hasComments"
-            },
-            {
-              "name": "hasFeaturedImage"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "isStatus"
-            },
-            {
-              "name": "menuOrder"
-            },
-            {
-              "name": "meta"
-            },
-            {
-              "name": "metaKeys"
-            },
-            {
-              "name": "metaValue"
-            },
-            {
-              "name": "metaValues"
-            },
-            {
-              "name": "modifiedDate"
-            },
-            {
-              "name": "modifiedDateStr"
-            },
-            {
-              "name": "parent"
-            },
-            {
-              "name": "rawContent"
-            },
-            {
-              "name": "rawExcerpt"
-            },
-            {
-              "name": "rawStatus"
-            },
-            {
-              "name": "rawTitle"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "slug"
-            },
-            {
-              "name": "slugPath"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tagCount"
-            },
-            {
-              "name": "tagNames"
-            },
-            {
-              "name": "tags"
-            },
-            {
-              "name": "title"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            },
-            {
-              "name": "wpAdminEditURL"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "A custom post that does not have its own type in the schema"
-        },
-        {
-          "name": "GenericErrorPayload",
-          "namespacedName": "GenericErrorPayload",
-          "fields": [
-            {
-              "name": "code"
-            },
-            {
-              "name": "data"
-            },
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Generic error payload"
-        },
-        {
-          "name": "GenericTag",
-          "namespacedName": "GenericTag",
-          "fields": [
-            {
-              "name": "count"
-            },
-            {
-              "name": "customPostCount"
-            },
-            {
-              "name": "customPosts"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "meta"
-            },
-            {
-              "name": "metaKeys"
-            },
-            {
-              "name": "metaValue"
-            },
-            {
-              "name": "metaValues"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "slug"
-            },
-            {
-              "name": "taxonomy"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "A tag that does not have its own type in the schema"
-        },
-        {
-          "name": "InvalidUserEmailErrorPayload",
-          "namespacedName": "InvalidUserEmailErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"No user is registered with the provided email\""
-        },
-        {
-          "name": "InvalidUsernameErrorPayload",
-          "namespacedName": "InvalidUsernameErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"No user is registered with the provided username\""
-        },
-        {
-          "name": "LoggedInUserHasNoAssigningTermsToTaxonomyCapabilityErrorPayload",
-          "namespacedName": "LoggedInUserHasNoAssigningTermsToTaxonomyCapabilityErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to assign terms to a taxonomy\""
-        },
-        {
-          "name": "LoggedInUserHasNoDeletingTaxonomyTermCapabilityErrorPayload",
-          "namespacedName": "LoggedInUserHasNoDeletingTaxonomyTermCapabilityErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to delete a taxonomy term\""
-        },
-        {
-          "name": "LoggedInUserHasNoEditingCustomPostCapabilityErrorPayload",
-          "namespacedName": "LoggedInUserHasNoEditingCustomPostCapabilityErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to edit custom posts\""
-        },
-        {
-          "name": "LoggedInUserHasNoEditingMediaCapabilityErrorPayload",
-          "namespacedName": "LoggedInUserHasNoEditingMediaCapabilityErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user cannot edit media items\""
-        },
-        {
-          "name": "LoggedInUserHasNoEditingMenuCapabilityErrorPayload",
-          "namespacedName": "LoggedInUserHasNoEditingMenuCapabilityErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user cannot edit menus\""
-        },
-        {
-          "name": "LoggedInUserHasNoEditingPageCapabilityErrorPayload",
-          "namespacedName": "LoggedInUserHasNoEditingPageCapabilityErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to edit pages\""
-        },
-        {
-          "name": "LoggedInUserHasNoEditingTaxonomyTermsCapabilityErrorPayload",
-          "namespacedName": "LoggedInUserHasNoEditingTaxonomyTermsCapabilityErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to edit taxonomy terms\""
-        },
-        {
-          "name": "LoggedInUserHasNoPermissionToDeleteCommentErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPermissionToDeleteCommentErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user has no permission to delete the comment\""
-        },
-        {
-          "name": "LoggedInUserHasNoPermissionToDeleteCustomPostErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPermissionToDeleteCustomPostErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to delete the requested custom post\""
-        },
-        {
-          "name": "LoggedInUserHasNoPermissionToDeleteMediaItemErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPermissionToDeleteMediaItemErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user has no permission to delete the media item\""
-        },
-        {
-          "name": "LoggedInUserHasNoPermissionToDeleteMenuErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPermissionToDeleteMenuErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user has no permission to delete the menu\""
-        },
-        {
-          "name": "LoggedInUserHasNoPermissionToEditCommentErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPermissionToEditCommentErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to edit the comment\""
-        },
-        {
-          "name": "LoggedInUserHasNoPermissionToEditCustomPostErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPermissionToEditCustomPostErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to edit the requested custom post\""
-        },
-        {
-          "name": "LoggedInUserHasNoPermissionToEditMediaItemErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPermissionToEditMediaItemErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user has no permission to edit the media item\""
-        },
-        {
-          "name": "LoggedInUserHasNoPermissionToEditMenuErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPermissionToEditMenuErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user has no permission to edit the menu\""
-        },
-        {
-          "name": "LoggedInUserHasNoPermissionToEditUserErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPermissionToEditUserErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to edit the user\""
-        },
-        {
-          "name": "LoggedInUserHasNoPublishingCustomPostCapabilityErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPublishingCustomPostCapabilityErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to publish custom posts\""
-        },
-        {
-          "name": "LoggedInUserHasNoPublishingPageCapabilityErrorPayload",
-          "namespacedName": "LoggedInUserHasNoPublishingPageCapabilityErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The logged-in user has no permission to publish pages\""
-        },
-        {
-          "name": "Media",
-          "namespacedName": "Media",
-          "fields": [
-            {
-              "name": "altText"
-            },
-            {
-              "name": "author"
-            },
-            {
-              "name": "caption"
-            },
-            {
-              "name": "date"
-            },
-            {
-              "name": "dateStr"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "height"
-            },
-            {
-              "name": "heights"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "mimeType"
-            },
-            {
-              "name": "modifiedDate"
-            },
-            {
-              "name": "modifiedDateStr"
-            },
-            {
-              "name": "parentCustomPost"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "sizes"
-            },
-            {
-              "name": "slug"
-            },
-            {
-              "name": "src"
-            },
-            {
-              "name": "srcPath"
-            },
-            {
-              "name": "srcSet"
-            },
-            {
-              "name": "srcs"
-            },
-            {
-              "name": "title"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            },
-            {
-              "name": "width"
-            },
-            {
-              "name": "widths"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Media elements (such as images, videos, etc), attached to a post or independent"
-        },
-        {
-          "name": "MediaItemDoesNotExistErrorPayload",
-          "namespacedName": "MediaItemDoesNotExistErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The requested media item does not exist\""
-        },
-        {
-          "name": "MediaItemDoesNotSupportTrashErrorPayload",
-          "namespacedName": "MediaItemDoesNotSupportTrashErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The media item does not support being sent to the trash\""
-        },
-        {
-          "name": "MediaItemHasAlreadyBeenTrashedErrorPayload",
-          "namespacedName": "MediaItemHasAlreadyBeenTrashedErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The media item has already been sent to the trash\""
-        },
-        {
-          "name": "Menu",
-          "namespacedName": "Menu",
-          "fields": [
-            {
-              "name": "count"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "itemDataEntries"
-            },
-            {
-              "name": "items"
-            },
-            {
-              "name": "locations"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "slug"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of a navigation menu"
-        },
-        {
-          "name": "MenuDoesNotExistErrorPayload",
-          "namespacedName": "MenuDoesNotExistErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The requested menu does not exist\""
-        },
-        {
-          "name": "MenuItem",
-          "namespacedName": "MenuItem",
-          "fields": [
-            {
-              "name": "children"
-            },
-            {
-              "name": "cssClasses"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "itemType"
-            },
-            {
-              "name": "label"
-            },
-            {
-              "name": "linkRelationship"
-            },
-            {
-              "name": "localURLPath"
-            },
-            {
-              "name": "objectID"
-            },
-            {
-              "name": "objectType"
-            },
-            {
-              "name": "parentID"
-            },
-            {
-              "name": "rawLabel"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "target"
-            },
-            {
-              "name": "titleAttribute"
-            },
-            {
-              "name": "url"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Items (links, pages, etc) added to a menu"
-        },
-        {
-          "name": "MutationRoot",
-          "namespacedName": "MutationRoot",
-          "fields": [
-            {
-              "name": "addCategoryMeta"
-            },
-            {
-              "name": "addCategoryMetas"
-            },
-            {
-              "name": "addCommentMeta"
-            },
-            {
-              "name": "addCommentMetas"
-            },
-            {
-              "name": "addCommentToCustomPost"
-            },
-            {
-              "name": "addCommentToCustomPosts"
-            },
-            {
-              "name": "addCustomPostMeta"
-            },
-            {
-              "name": "addCustomPostMetas"
-            },
-            {
-              "name": "addPostCategoryMeta"
-            },
-            {
-              "name": "addPostCategoryMetas"
-            },
-            {
-              "name": "addPostTagMeta"
-            },
-            {
-              "name": "addPostTagMetas"
-            },
-            {
-              "name": "addTagMeta"
-            },
-            {
-              "name": "addTagMetas"
-            },
-            {
-              "name": "addUserMeta"
-            },
-            {
-              "name": "addUserMetas"
-            },
-            {
-              "name": "createCategories"
-            },
-            {
-              "name": "createCategory"
-            },
-            {
-              "name": "createCustomPost"
-            },
-            {
-              "name": "createCustomPosts"
-            },
-            {
-              "name": "createMediaItem"
-            },
-            {
-              "name": "createMediaItems"
-            },
-            {
-              "name": "createMenu"
-            },
-            {
-              "name": "createMenus"
-            },
-            {
-              "name": "createPage"
-            },
-            {
-              "name": "createPages"
-            },
-            {
-              "name": "createPost"
-            },
-            {
-              "name": "createPostCategories"
-            },
-            {
-              "name": "createPostCategory"
-            },
-            {
-              "name": "createPostTag"
-            },
-            {
-              "name": "createPostTags"
-            },
-            {
-              "name": "createPosts"
-            },
-            {
-              "name": "createTag"
-            },
-            {
-              "name": "createTags"
-            },
-            {
-              "name": "deleteCategories"
-            },
-            {
-              "name": "deleteCategory"
-            },
-            {
-              "name": "deleteCategoryMeta"
-            },
-            {
-              "name": "deleteCategoryMetas"
-            },
-            {
-              "name": "deleteComment"
-            },
-            {
-              "name": "deleteCommentMeta"
-            },
-            {
-              "name": "deleteCommentMetas"
-            },
-            {
-              "name": "deleteComments"
-            },
-            {
-              "name": "deleteCustomPost"
-            },
-            {
-              "name": "deleteCustomPostMeta"
-            },
-            {
-              "name": "deleteCustomPostMetas"
-            },
-            {
-              "name": "deleteCustomPosts"
-            },
-            {
-              "name": "deleteMediaItem"
-            },
-            {
-              "name": "deleteMediaItems"
-            },
-            {
-              "name": "deleteMenu"
-            },
-            {
-              "name": "deleteMenus"
-            },
-            {
-              "name": "deletePage"
-            },
-            {
-              "name": "deletePages"
-            },
-            {
-              "name": "deletePost"
-            },
-            {
-              "name": "deletePostCategories"
-            },
-            {
-              "name": "deletePostCategory"
-            },
-            {
-              "name": "deletePostCategoryMeta"
-            },
-            {
-              "name": "deletePostCategoryMetas"
-            },
-            {
-              "name": "deletePostTag"
-            },
-            {
-              "name": "deletePostTagMeta"
-            },
-            {
-              "name": "deletePostTagMetas"
-            },
-            {
-              "name": "deletePostTags"
-            },
-            {
-              "name": "deletePosts"
-            },
-            {
-              "name": "deleteTag"
-            },
-            {
-              "name": "deleteTagMeta"
-            },
-            {
-              "name": "deleteTagMetas"
-            },
-            {
-              "name": "deleteTags"
-            },
-            {
-              "name": "deleteUserMeta"
-            },
-            {
-              "name": "deleteUserMetas"
-            },
-            {
-              "name": "loginUser"
-            },
-            {
-              "name": "logoutUser"
-            },
-            {
-              "name": "removeFeaturedImageFromCustomPost"
-            },
-            {
-              "name": "removeFeaturedImageFromCustomPosts"
-            },
-            {
-              "name": "replyComment"
-            },
-            {
-              "name": "replyComments"
-            },
-            {
-              "name": "setCategoriesOnCustomPost"
-            },
-            {
-              "name": "setCategoriesOnCustomPosts"
-            },
-            {
-              "name": "setCategoriesOnPost"
-            },
-            {
-              "name": "setCategoriesOnPosts"
-            },
-            {
-              "name": "setCategoryMeta"
-            },
-            {
-              "name": "setCategoryMetas"
-            },
-            {
-              "name": "setCommentMeta"
-            },
-            {
-              "name": "setCommentMetas"
-            },
-            {
-              "name": "setCustomPostMeta"
-            },
-            {
-              "name": "setCustomPostMetas"
-            },
-            {
-              "name": "setFeaturedImageOnCustomPost"
-            },
-            {
-              "name": "setFeaturedImageOnCustomPosts"
-            },
-            {
-              "name": "setPostCategoryMeta"
-            },
-            {
-              "name": "setPostCategoryMetas"
-            },
-            {
-              "name": "setPostTagMeta"
-            },
-            {
-              "name": "setPostTagMetas"
-            },
-            {
-              "name": "setTagMeta"
-            },
-            {
-              "name": "setTagMetas"
-            },
-            {
-              "name": "setTagsOnCustomPost"
-            },
-            {
-              "name": "setTagsOnCustomPosts"
-            },
-            {
-              "name": "setTagsOnPost"
-            },
-            {
-              "name": "setTagsOnPosts"
-            },
-            {
-              "name": "setUserMeta"
-            },
-            {
-              "name": "setUserMetas"
-            },
-            {
-              "name": "updateCategories"
-            },
-            {
-              "name": "updateCategory"
-            },
-            {
-              "name": "updateCategoryMeta"
-            },
-            {
-              "name": "updateCategoryMetas"
-            },
-            {
-              "name": "updateComment"
-            },
-            {
-              "name": "updateCommentMeta"
-            },
-            {
-              "name": "updateCommentMetas"
-            },
-            {
-              "name": "updateComments"
-            },
-            {
-              "name": "updateCustomPost"
-            },
-            {
-              "name": "updateCustomPostMeta"
-            },
-            {
-              "name": "updateCustomPostMetas"
-            },
-            {
-              "name": "updateCustomPosts"
-            },
-            {
-              "name": "updateMediaItem"
-            },
-            {
-              "name": "updateMediaItems"
-            },
-            {
-              "name": "updateMenu"
-            },
-            {
-              "name": "updateMenus"
-            },
-            {
-              "name": "updatePage"
-            },
-            {
-              "name": "updatePages"
-            },
-            {
-              "name": "updatePost"
-            },
-            {
-              "name": "updatePostCategories"
-            },
-            {
-              "name": "updatePostCategory"
-            },
-            {
-              "name": "updatePostCategoryMeta"
-            },
-            {
-              "name": "updatePostCategoryMetas"
-            },
-            {
-              "name": "updatePostTag"
-            },
-            {
-              "name": "updatePostTagMeta"
-            },
-            {
-              "name": "updatePostTagMetas"
-            },
-            {
-              "name": "updatePostTags"
-            },
-            {
-              "name": "updatePosts"
-            },
-            {
-              "name": "updateTag"
-            },
-            {
-              "name": "updateTagMeta"
-            },
-            {
-              "name": "updateTagMetas"
-            },
-            {
-              "name": "updateTags"
-            },
-            {
-              "name": "updateUserMeta"
-            },
-            {
-              "name": "updateUserMetas"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Mutation type, starting from which mutations are executed"
-        },
-        {
-          "name": "Page",
-          "namespacedName": "Page",
-          "fields": [
-            {
-              "name": "ancestors"
-            },
-            {
-              "name": "areCommentsOpen"
-            },
-            {
-              "name": "author"
-            },
-            {
-              "name": "blockDataItems"
-            },
-            {
-              "name": "blockFlattenedDataItems"
-            },
-            {
-              "name": "blocks"
-            },
-            {
-              "name": "childCount"
-            },
-            {
-              "name": "children"
-            },
-            {
-              "name": "commentCount"
-            },
-            {
-              "name": "comments"
-            },
-            {
-              "name": "content"
-            },
-            {
-              "name": "customPostType"
-            },
-            {
-              "name": "date"
-            },
-            {
-              "name": "dateStr"
-            },
-            {
-              "name": "excerpt"
-            },
-            {
-              "name": "featuredImage"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "hasComments"
-            },
-            {
-              "name": "hasFeaturedImage"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "isStatus"
-            },
-            {
-              "name": "menuOrder"
-            },
-            {
-              "name": "meta"
-            },
-            {
-              "name": "metaKeys"
-            },
-            {
-              "name": "metaValue"
-            },
-            {
-              "name": "metaValues"
-            },
-            {
-              "name": "modifiedDate"
-            },
-            {
-              "name": "modifiedDateStr"
-            },
-            {
-              "name": "parent"
-            },
-            {
-              "name": "rawContent"
-            },
-            {
-              "name": "rawExcerpt"
-            },
-            {
-              "name": "rawStatus"
-            },
-            {
-              "name": "rawTitle"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "slug"
-            },
-            {
-              "name": "slugPath"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "title"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            },
-            {
-              "name": "wpAdminEditURL"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of a page"
-        },
-        {
-          "name": "PasswordIsIncorrectErrorPayload",
-          "namespacedName": "PasswordIsIncorrectErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The password is incorrect\""
-        },
-        {
-          "name": "Post",
-          "namespacedName": "Post",
-          "fields": [
-            {
-              "name": "areCommentsOpen"
-            },
-            {
-              "name": "author"
-            },
-            {
-              "name": "blockDataItems"
-            },
-            {
-              "name": "blockFlattenedDataItems"
-            },
-            {
-              "name": "blocks"
-            },
-            {
-              "name": "categories"
-            },
-            {
-              "name": "categoryCount"
-            },
-            {
-              "name": "categoryNames"
-            },
-            {
-              "name": "commentCount"
-            },
-            {
-              "name": "comments"
-            },
-            {
-              "name": "content"
-            },
-            {
-              "name": "customPostType"
-            },
-            {
-              "name": "date"
-            },
-            {
-              "name": "dateStr"
-            },
-            {
-              "name": "excerpt"
-            },
-            {
-              "name": "featuredImage"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "hasComments"
-            },
-            {
-              "name": "hasFeaturedImage"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "isStatus"
-            },
-            {
-              "name": "isSticky"
-            },
-            {
-              "name": "menuOrder"
-            },
-            {
-              "name": "meta"
-            },
-            {
-              "name": "metaKeys"
-            },
-            {
-              "name": "metaValue"
-            },
-            {
-              "name": "metaValues"
-            },
-            {
-              "name": "modifiedDate"
-            },
-            {
-              "name": "modifiedDateStr"
-            },
-            {
-              "name": "postFormat"
-            },
-            {
-              "name": "rawContent"
-            },
-            {
-              "name": "rawExcerpt"
-            },
-            {
-              "name": "rawStatus"
-            },
-            {
-              "name": "rawTitle"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "slug"
-            },
-            {
-              "name": "slugPath"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tagCount"
-            },
-            {
-              "name": "tagNames"
-            },
-            {
-              "name": "tags"
-            },
-            {
-              "name": "title"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            },
-            {
-              "name": "wpAdminEditURL"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of a post"
-        },
-        {
-          "name": "PostCategory",
-          "namespacedName": "PostCategory",
-          "fields": [
-            {
-              "name": "ancestors"
-            },
-            {
-              "name": "childCount"
-            },
-            {
-              "name": "childNames"
-            },
-            {
-              "name": "children"
-            },
-            {
-              "name": "count"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "meta"
-            },
-            {
-              "name": "metaKeys"
-            },
-            {
-              "name": "metaValue"
-            },
-            {
-              "name": "metaValues"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "parent"
-            },
-            {
-              "name": "postCount"
-            },
-            {
-              "name": "posts"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "slug"
-            },
-            {
-              "name": "slugPath"
-            },
-            {
-              "name": "taxonomy"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of a category, added to a post (taxonomy: \"category\")"
-        },
-        {
-          "name": "PostTag",
-          "namespacedName": "PostTag",
-          "fields": [
-            {
-              "name": "count"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "meta"
-            },
-            {
-              "name": "metaKeys"
-            },
-            {
-              "name": "metaValue"
-            },
-            {
-              "name": "metaValues"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "postCount"
-            },
-            {
-              "name": "posts"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "slug"
-            },
-            {
-              "name": "taxonomy"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of a tag, added to a post (taxonomy: \"post_tag\")"
-        },
-        {
-          "name": "QueryRoot",
-          "namespacedName": "QueryRoot",
-          "fields": [
-            {
-              "name": "blockTypes"
-            },
-            {
-              "name": "capabilities"
-            },
-            {
-              "name": "categories"
-            },
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryCount"
-            },
-            {
-              "name": "categoryNames"
-            },
-            {
-              "name": "comment"
-            },
-            {
-              "name": "commentCount"
-            },
-            {
-              "name": "comments"
-            },
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostCount"
-            },
-            {
-              "name": "customPosts"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "imageSizeNames"
-            },
-            {
-              "name": "isGutenbergEditorEnabled"
-            },
-            {
-              "name": "isUserLoggedIn"
-            },
-            {
-              "name": "loggedInUserID"
-            },
-            {
-              "name": "me"
-            },
-            {
-              "name": "mediaItem"
-            },
-            {
-              "name": "mediaItemCount"
-            },
-            {
-              "name": "mediaItems"
-            },
-            {
-              "name": "menu"
-            },
-            {
-              "name": "menuCount"
-            },
-            {
-              "name": "menus"
-            },
-            {
-              "name": "myComment"
-            },
-            {
-              "name": "myCommentCount"
-            },
-            {
-              "name": "myComments"
-            },
-            {
-              "name": "myCustomPost"
-            },
-            {
-              "name": "myCustomPostCount"
-            },
-            {
-              "name": "myCustomPosts"
-            },
-            {
-              "name": "myMediaItem"
-            },
-            {
-              "name": "myMediaItemCount"
-            },
-            {
-              "name": "myMediaItems"
-            },
-            {
-              "name": "myPage"
-            },
-            {
-              "name": "myPageCount"
-            },
-            {
-              "name": "myPages"
-            },
-            {
-              "name": "myPost"
-            },
-            {
-              "name": "myPostCount"
-            },
-            {
-              "name": "myPosts"
-            },
-            {
-              "name": "optionObjectValue"
-            },
-            {
-              "name": "optionObjectValues"
-            },
-            {
-              "name": "optionValue"
-            },
-            {
-              "name": "optionValues"
-            },
-            {
-              "name": "page"
-            },
-            {
-              "name": "pageBuilders"
-            },
-            {
-              "name": "pageCount"
-            },
-            {
-              "name": "pages"
-            },
-            {
-              "name": "post"
-            },
-            {
-              "name": "postCategories"
-            },
-            {
-              "name": "postCategory"
-            },
-            {
-              "name": "postCategoryCount"
-            },
-            {
-              "name": "postCategoryNames"
-            },
-            {
-              "name": "postCount"
-            },
-            {
-              "name": "postTag"
-            },
-            {
-              "name": "postTagCount"
-            },
-            {
-              "name": "postTagNames"
-            },
-            {
-              "name": "postTags"
-            },
-            {
-              "name": "posts"
-            },
-            {
-              "name": "roleNames"
-            },
-            {
-              "name": "roles"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "siteLanguage"
-            },
-            {
-              "name": "siteLocale"
-            },
-            {
-              "name": "siteURL"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagCount"
-            },
-            {
-              "name": "tagNames"
-            },
-            {
-              "name": "tags"
-            },
-            {
-              "name": "useGutenbergEditorWithCustomPostType"
-            },
-            {
-              "name": "useWhichPageBuilderWithCustomPostType"
-            },
-            {
-              "name": "user"
-            },
-            {
-              "name": "userCount"
-            },
-            {
-              "name": "users"
-            },
-            {
-              "name": "_urlToCustomPostID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Query type, starting from which the query is executed"
-        },
-        {
-          "name": "Root",
-          "namespacedName": "Root",
-          "fields": [
-            {
-              "name": "addCategoryMeta"
-            },
-            {
-              "name": "addCategoryMetas"
-            },
-            {
-              "name": "addCommentMeta"
-            },
-            {
-              "name": "addCommentMetas"
-            },
-            {
-              "name": "addCommentToCustomPost"
-            },
-            {
-              "name": "addCommentToCustomPosts"
-            },
-            {
-              "name": "addCustomPostMeta"
-            },
-            {
-              "name": "addCustomPostMetas"
-            },
-            {
-              "name": "addPostCategoryMeta"
-            },
-            {
-              "name": "addPostCategoryMetas"
-            },
-            {
-              "name": "addPostTagMeta"
-            },
-            {
-              "name": "addPostTagMetas"
-            },
-            {
-              "name": "addTagMeta"
-            },
-            {
-              "name": "addTagMetas"
-            },
-            {
-              "name": "addUserMeta"
-            },
-            {
-              "name": "addUserMetas"
-            },
-            {
-              "name": "blockTypes"
-            },
-            {
-              "name": "capabilities"
-            },
-            {
-              "name": "categories"
-            },
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryCount"
-            },
-            {
-              "name": "categoryNames"
-            },
-            {
-              "name": "comment"
-            },
-            {
-              "name": "commentCount"
-            },
-            {
-              "name": "comments"
-            },
-            {
-              "name": "createCategories"
-            },
-            {
-              "name": "createCategory"
-            },
-            {
-              "name": "createCustomPost"
-            },
-            {
-              "name": "createCustomPosts"
-            },
-            {
-              "name": "createMediaItem"
-            },
-            {
-              "name": "createMediaItems"
-            },
-            {
-              "name": "createMenu"
-            },
-            {
-              "name": "createMenus"
-            },
-            {
-              "name": "createPage"
-            },
-            {
-              "name": "createPages"
-            },
-            {
-              "name": "createPost"
-            },
-            {
-              "name": "createPostCategories"
-            },
-            {
-              "name": "createPostCategory"
-            },
-            {
-              "name": "createPostTag"
-            },
-            {
-              "name": "createPostTags"
-            },
-            {
-              "name": "createPosts"
-            },
-            {
-              "name": "createTag"
-            },
-            {
-              "name": "createTags"
-            },
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostCount"
-            },
-            {
-              "name": "customPosts"
-            },
-            {
-              "name": "deleteCategories"
-            },
-            {
-              "name": "deleteCategory"
-            },
-            {
-              "name": "deleteCategoryMeta"
-            },
-            {
-              "name": "deleteCategoryMetas"
-            },
-            {
-              "name": "deleteComment"
-            },
-            {
-              "name": "deleteCommentMeta"
-            },
-            {
-              "name": "deleteCommentMetas"
-            },
-            {
-              "name": "deleteComments"
-            },
-            {
-              "name": "deleteCustomPost"
-            },
-            {
-              "name": "deleteCustomPostMeta"
-            },
-            {
-              "name": "deleteCustomPostMetas"
-            },
-            {
-              "name": "deleteCustomPosts"
-            },
-            {
-              "name": "deleteMediaItem"
-            },
-            {
-              "name": "deleteMediaItems"
-            },
-            {
-              "name": "deleteMenu"
-            },
-            {
-              "name": "deleteMenus"
-            },
-            {
-              "name": "deletePage"
-            },
-            {
-              "name": "deletePages"
-            },
-            {
-              "name": "deletePost"
-            },
-            {
-              "name": "deletePostCategories"
-            },
-            {
-              "name": "deletePostCategory"
-            },
-            {
-              "name": "deletePostCategoryMeta"
-            },
-            {
-              "name": "deletePostCategoryMetas"
-            },
-            {
-              "name": "deletePostTag"
-            },
-            {
-              "name": "deletePostTagMeta"
-            },
-            {
-              "name": "deletePostTagMetas"
-            },
-            {
-              "name": "deletePostTags"
-            },
-            {
-              "name": "deletePosts"
-            },
-            {
-              "name": "deleteTag"
-            },
-            {
-              "name": "deleteTagMeta"
-            },
-            {
-              "name": "deleteTagMetas"
-            },
-            {
-              "name": "deleteTags"
-            },
-            {
-              "name": "deleteUserMeta"
-            },
-            {
-              "name": "deleteUserMetas"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "imageSizeNames"
-            },
-            {
-              "name": "isGutenbergEditorEnabled"
-            },
-            {
-              "name": "isUserLoggedIn"
-            },
-            {
-              "name": "loggedInUserID"
-            },
-            {
-              "name": "loginUser"
-            },
-            {
-              "name": "logoutUser"
-            },
-            {
-              "name": "me"
-            },
-            {
-              "name": "mediaItem"
-            },
-            {
-              "name": "mediaItemCount"
-            },
-            {
-              "name": "mediaItems"
-            },
-            {
-              "name": "menu"
-            },
-            {
-              "name": "menuCount"
-            },
-            {
-              "name": "menus"
-            },
-            {
-              "name": "myComment"
-            },
-            {
-              "name": "myCommentCount"
-            },
-            {
-              "name": "myComments"
-            },
-            {
-              "name": "myCustomPost"
-            },
-            {
-              "name": "myCustomPostCount"
-            },
-            {
-              "name": "myCustomPosts"
-            },
-            {
-              "name": "myMediaItem"
-            },
-            {
-              "name": "myMediaItemCount"
-            },
-            {
-              "name": "myMediaItems"
-            },
-            {
-              "name": "myPage"
-            },
-            {
-              "name": "myPageCount"
-            },
-            {
-              "name": "myPages"
-            },
-            {
-              "name": "myPost"
-            },
-            {
-              "name": "myPostCount"
-            },
-            {
-              "name": "myPosts"
-            },
-            {
-              "name": "optionObjectValue"
-            },
-            {
-              "name": "optionObjectValues"
-            },
-            {
-              "name": "optionValue"
-            },
-            {
-              "name": "optionValues"
-            },
-            {
-              "name": "page"
-            },
-            {
-              "name": "pageBuilders"
-            },
-            {
-              "name": "pageCount"
-            },
-            {
-              "name": "pages"
-            },
-            {
-              "name": "post"
-            },
-            {
-              "name": "postCategories"
-            },
-            {
-              "name": "postCategory"
-            },
-            {
-              "name": "postCategoryCount"
-            },
-            {
-              "name": "postCategoryNames"
-            },
-            {
-              "name": "postCount"
-            },
-            {
-              "name": "postTag"
-            },
-            {
-              "name": "postTagCount"
-            },
-            {
-              "name": "postTagNames"
-            },
-            {
-              "name": "postTags"
-            },
-            {
-              "name": "posts"
-            },
-            {
-              "name": "removeFeaturedImageFromCustomPost"
-            },
-            {
-              "name": "removeFeaturedImageFromCustomPosts"
-            },
-            {
-              "name": "replyComment"
-            },
-            {
-              "name": "replyComments"
-            },
-            {
-              "name": "roleNames"
-            },
-            {
-              "name": "roles"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "setCategoriesOnCustomPost"
-            },
-            {
-              "name": "setCategoriesOnCustomPosts"
-            },
-            {
-              "name": "setCategoriesOnPost"
-            },
-            {
-              "name": "setCategoriesOnPosts"
-            },
-            {
-              "name": "setCategoryMeta"
-            },
-            {
-              "name": "setCategoryMetas"
-            },
-            {
-              "name": "setCommentMeta"
-            },
-            {
-              "name": "setCommentMetas"
-            },
-            {
-              "name": "setCustomPostMeta"
-            },
-            {
-              "name": "setCustomPostMetas"
-            },
-            {
-              "name": "setFeaturedImageOnCustomPost"
-            },
-            {
-              "name": "setFeaturedImageOnCustomPosts"
-            },
-            {
-              "name": "setPostCategoryMeta"
-            },
-            {
-              "name": "setPostCategoryMetas"
-            },
-            {
-              "name": "setPostTagMeta"
-            },
-            {
-              "name": "setPostTagMetas"
-            },
-            {
-              "name": "setTagMeta"
-            },
-            {
-              "name": "setTagMetas"
-            },
-            {
-              "name": "setTagsOnCustomPost"
-            },
-            {
-              "name": "setTagsOnCustomPosts"
-            },
-            {
-              "name": "setTagsOnPost"
-            },
-            {
-              "name": "setTagsOnPosts"
-            },
-            {
-              "name": "setUserMeta"
-            },
-            {
-              "name": "setUserMetas"
-            },
-            {
-              "name": "siteLanguage"
-            },
-            {
-              "name": "siteLocale"
-            },
-            {
-              "name": "siteURL"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagCount"
-            },
-            {
-              "name": "tagNames"
-            },
-            {
-              "name": "tags"
-            },
-            {
-              "name": "updateCategories"
-            },
-            {
-              "name": "updateCategory"
-            },
-            {
-              "name": "updateCategoryMeta"
-            },
-            {
-              "name": "updateCategoryMetas"
-            },
-            {
-              "name": "updateComment"
-            },
-            {
-              "name": "updateCommentMeta"
-            },
-            {
-              "name": "updateCommentMetas"
-            },
-            {
-              "name": "updateComments"
-            },
-            {
-              "name": "updateCustomPost"
-            },
-            {
-              "name": "updateCustomPostMeta"
-            },
-            {
-              "name": "updateCustomPostMetas"
-            },
-            {
-              "name": "updateCustomPosts"
-            },
-            {
-              "name": "updateMediaItem"
-            },
-            {
-              "name": "updateMediaItems"
-            },
-            {
-              "name": "updateMenu"
-            },
-            {
-              "name": "updateMenus"
-            },
-            {
-              "name": "updatePage"
-            },
-            {
-              "name": "updatePages"
-            },
-            {
-              "name": "updatePost"
-            },
-            {
-              "name": "updatePostCategories"
-            },
-            {
-              "name": "updatePostCategory"
-            },
-            {
-              "name": "updatePostCategoryMeta"
-            },
-            {
-              "name": "updatePostCategoryMetas"
-            },
-            {
-              "name": "updatePostTag"
-            },
-            {
-              "name": "updatePostTagMeta"
-            },
-            {
-              "name": "updatePostTagMetas"
-            },
-            {
-              "name": "updatePostTags"
-            },
-            {
-              "name": "updatePosts"
-            },
-            {
-              "name": "updateTag"
-            },
-            {
-              "name": "updateTagMeta"
-            },
-            {
-              "name": "updateTagMetas"
-            },
-            {
-              "name": "updateTags"
-            },
-            {
-              "name": "updateUserMeta"
-            },
-            {
-              "name": "updateUserMetas"
-            },
-            {
-              "name": "useGutenbergEditorWithCustomPostType"
-            },
-            {
-              "name": "useWhichPageBuilderWithCustomPostType"
-            },
-            {
-              "name": "user"
-            },
-            {
-              "name": "userCount"
-            },
-            {
-              "name": "users"
-            },
-            {
-              "name": "_urlToCustomPostID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Root type, starting from which the query is executed"
-        },
-        {
-          "name": "RootAddCommentMetaMutationPayload",
-          "namespacedName": "RootAddCommentMetaMutationPayload",
-          "fields": [
-            {
-              "name": "comment"
-            },
-            {
-              "name": "commentID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of adding meta to a comment"
-        },
-        {
-          "name": "RootAddCommentToCustomPostMutationPayload",
-          "namespacedName": "RootAddCommentToCustomPostMutationPayload",
-          "fields": [
-            {
-              "name": "comment"
-            },
-            {
-              "name": "commentID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of adding a comment to a custom post"
-        },
-        {
-          "name": "RootAddGenericCategoryTermMetaMutationPayload",
-          "namespacedName": "RootAddGenericCategoryTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of adding meta to a category term"
-        },
-        {
-          "name": "RootAddGenericCustomPostMetaMutationPayload",
-          "namespacedName": "RootAddGenericCustomPostMetaMutationPayload",
-          "fields": [
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of adding meta to a custom post"
-        },
-        {
-          "name": "RootAddGenericTagTermMetaMutationPayload",
-          "namespacedName": "RootAddGenericTagTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of adding meta to a tag term"
-        },
-        {
-          "name": "RootAddPostCategoryTermMetaMutationPayload",
-          "namespacedName": "RootAddPostCategoryTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of adding meta to a posts's category term"
-        },
-        {
-          "name": "RootAddPostTagTermMetaMutationPayload",
-          "namespacedName": "RootAddPostTagTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of adding meta to a posts's tag term"
-        },
-        {
-          "name": "RootAddUserMetaMutationPayload",
-          "namespacedName": "RootAddUserMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "user"
-            },
-            {
-              "name": "userID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of adding meta to a user"
-        },
-        {
-          "name": "RootCreateCustomPostMutationPayload",
-          "namespacedName": "RootCreateCustomPostMutationPayload",
-          "fields": [
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of creating a custom post"
-        },
-        {
-          "name": "RootCreateGenericCategoryTermMutationPayload",
-          "namespacedName": "RootCreateGenericCategoryTermMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of creating a category term"
-        },
-        {
-          "name": "RootCreateGenericTagTermMutationPayload",
-          "namespacedName": "RootCreateGenericTagTermMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of creating a tag term"
-        },
-        {
-          "name": "RootCreateMediaItemMutationPayload",
-          "namespacedName": "RootCreateMediaItemMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "mediaItem"
-            },
-            {
-              "name": "mediaItemID"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of uploading an attachment"
-        },
-        {
-          "name": "RootCreateMenuMutationPayload",
-          "namespacedName": "RootCreateMenuMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "menu"
-            },
-            {
-              "name": "menuID"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of creating a menu"
-        },
-        {
-          "name": "RootCreatePageMutationPayload",
-          "namespacedName": "RootCreatePageMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "page"
-            },
-            {
-              "name": "pageID"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of creating a page"
-        },
-        {
-          "name": "RootCreatePostCategoryTermMutationPayload",
-          "namespacedName": "RootCreatePostCategoryTermMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of creating a post category term"
-        },
-        {
-          "name": "RootCreatePostMutationPayload",
-          "namespacedName": "RootCreatePostMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "post"
-            },
-            {
-              "name": "postID"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of creating a post"
-        },
-        {
-          "name": "RootCreatePostTagTermMutationPayload",
-          "namespacedName": "RootCreatePostTagTermMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of creating a post tag term"
-        },
-        {
-          "name": "RootDeleteCommentMetaMutationPayload",
-          "namespacedName": "RootDeleteCommentMetaMutationPayload",
-          "fields": [
-            {
-              "name": "comment"
-            },
-            {
-              "name": "commentID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete meta mutation on a comment"
-        },
-        {
-          "name": "RootDeleteCommentMutationPayload",
-          "namespacedName": "RootDeleteCommentMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of deleting a comment"
-        },
-        {
-          "name": "RootDeleteCustomPostMutationPayload",
-          "namespacedName": "RootDeleteCustomPostMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete mutation on a custom post"
-        },
-        {
-          "name": "RootDeleteGenericCategoryTermMetaMutationPayload",
-          "namespacedName": "RootDeleteGenericCategoryTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete meta mutation on a category term"
-        },
-        {
-          "name": "RootDeleteGenericCategoryTermMutationPayload",
-          "namespacedName": "RootDeleteGenericCategoryTermMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete mutation on a category term"
-        },
-        {
-          "name": "RootDeleteGenericCustomPostMetaMutationPayload",
-          "namespacedName": "RootDeleteGenericCustomPostMetaMutationPayload",
-          "fields": [
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete meta mutation on a custom post"
-        },
-        {
-          "name": "RootDeleteGenericTagTermMetaMutationPayload",
-          "namespacedName": "RootDeleteGenericTagTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete meta mutation on a tag term"
-        },
-        {
-          "name": "RootDeleteGenericTagTermMutationPayload",
-          "namespacedName": "RootDeleteGenericTagTermMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete mutation on a tag term"
-        },
-        {
-          "name": "RootDeleteMediaItemMutationPayload",
-          "namespacedName": "RootDeleteMediaItemMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of deleting an attachment"
-        },
-        {
-          "name": "RootDeleteMenuMutationPayload",
-          "namespacedName": "RootDeleteMenuMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of deleting a menu"
-        },
-        {
-          "name": "RootDeletePageMutationPayload",
-          "namespacedName": "RootDeletePageMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete mutation on a page"
-        },
-        {
-          "name": "RootDeletePostCategoryTermMetaMutationPayload",
-          "namespacedName": "RootDeletePostCategoryTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete meta mutation on a post's category term"
-        },
-        {
-          "name": "RootDeletePostCategoryTermMutationPayload",
-          "namespacedName": "RootDeletePostCategoryTermMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete mutation on a post category term"
-        },
-        {
-          "name": "RootDeletePostMutationPayload",
-          "namespacedName": "RootDeletePostMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete mutation on a post"
-        },
-        {
-          "name": "RootDeletePostTagTermMetaMutationPayload",
-          "namespacedName": "RootDeletePostTagTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete meta mutation on a post's tag term"
-        },
-        {
-          "name": "RootDeletePostTagTermMutationPayload",
-          "namespacedName": "RootDeletePostTagTermMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete mutation on a post tag term"
-        },
-        {
-          "name": "RootDeleteUserMetaMutationPayload",
-          "namespacedName": "RootDeleteUserMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "user"
-            },
-            {
-              "name": "userID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a delete meta mutation on a user"
-        },
-        {
-          "name": "RootLoginUserMutationPayload",
-          "namespacedName": "RootLoginUserMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "user"
-            },
-            {
-              "name": "userID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of logging the user in"
-        },
-        {
-          "name": "RootLogoutUserMutationPayload",
-          "namespacedName": "RootLogoutUserMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "user"
-            },
-            {
-              "name": "userID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of logging the user out"
-        },
-        {
-          "name": "RootRemoveFeaturedImageFromCustomPostMutationPayload",
-          "namespacedName": "RootRemoveFeaturedImageFromCustomPostMutationPayload",
-          "fields": [
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of removing the featured image from a custom post"
-        },
-        {
-          "name": "RootReplyCommentMutationPayload",
-          "namespacedName": "RootReplyCommentMutationPayload",
-          "fields": [
-            {
-              "name": "comment"
-            },
-            {
-              "name": "commentID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of replying to a comment"
-        },
-        {
-          "name": "RootSetCategoriesOnCustomPostMutationPayload",
-          "namespacedName": "RootSetCategoriesOnCustomPostMutationPayload",
-          "fields": [
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of setting categories on a custom post"
-        },
-        {
-          "name": "RootSetCategoriesOnPostMutationPayload",
-          "namespacedName": "RootSetCategoriesOnPostMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "post"
-            },
-            {
-              "name": "postID"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of setting categories on a post"
-        },
-        {
-          "name": "RootSetCommentMetaMutationPayload",
-          "namespacedName": "RootSetCommentMetaMutationPayload",
-          "fields": [
-            {
-              "name": "comment"
-            },
-            {
-              "name": "commentID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a set meta mutation on a comment"
-        },
-        {
-          "name": "RootSetFeaturedImageOnCustomPostMutationPayload",
-          "namespacedName": "RootSetFeaturedImageOnCustomPostMutationPayload",
-          "fields": [
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of setting the featured image to a custom post"
-        },
-        {
-          "name": "RootSetGenericCategoryTermMetaMutationPayload",
-          "namespacedName": "RootSetGenericCategoryTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a set meta mutation on a category term"
-        },
-        {
-          "name": "RootSetGenericCustomPostMetaMutationPayload",
-          "namespacedName": "RootSetGenericCustomPostMetaMutationPayload",
-          "fields": [
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a set meta mutation on a custom post"
-        },
-        {
-          "name": "RootSetGenericTagTermMetaMutationPayload",
-          "namespacedName": "RootSetGenericTagTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a set meta mutation on a tag term"
-        },
-        {
-          "name": "RootSetPostCategoryTermMetaMutationPayload",
-          "namespacedName": "RootSetPostCategoryTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a set meta mutation on a post's category term"
-        },
-        {
-          "name": "RootSetPostTagTermMetaMutationPayload",
-          "namespacedName": "RootSetPostTagTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a set meta mutation on a post's tag term"
-        },
-        {
-          "name": "RootSetTagsOnCustomPostMutationPayload",
-          "namespacedName": "RootSetTagsOnCustomPostMutationPayload",
-          "fields": [
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of setting tags on a custom post"
-        },
-        {
-          "name": "RootSetTagsOnPostMutationPayload",
-          "namespacedName": "RootSetTagsOnPostMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "post"
-            },
-            {
-              "name": "postID"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of setting tags on a post"
-        },
-        {
-          "name": "RootSetUserMetaMutationPayload",
-          "namespacedName": "RootSetUserMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "user"
-            },
-            {
-              "name": "userID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing a set meta mutation on a user"
-        },
-        {
-          "name": "RootUpdateCommentMetaMutationPayload",
-          "namespacedName": "RootUpdateCommentMetaMutationPayload",
-          "fields": [
-            {
-              "name": "comment"
-            },
-            {
-              "name": "commentID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update meta mutation on a comment"
-        },
-        {
-          "name": "RootUpdateCommentMutationPayload",
-          "namespacedName": "RootUpdateCommentMutationPayload",
-          "fields": [
-            {
-              "name": "comment"
-            },
-            {
-              "name": "commentID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of updating a comment"
-        },
-        {
-          "name": "RootUpdateCustomPostMutationPayload",
-          "namespacedName": "RootUpdateCustomPostMutationPayload",
-          "fields": [
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update mutation on a custom post"
-        },
-        {
-          "name": "RootUpdateGenericCategoryTermMetaMutationPayload",
-          "namespacedName": "RootUpdateGenericCategoryTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update meta mutation on a category term"
-        },
-        {
-          "name": "RootUpdateGenericCategoryTermMutationPayload",
-          "namespacedName": "RootUpdateGenericCategoryTermMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update mutation on a category term"
-        },
-        {
-          "name": "RootUpdateGenericCustomPostMetaMutationPayload",
-          "namespacedName": "RootUpdateGenericCustomPostMetaMutationPayload",
-          "fields": [
-            {
-              "name": "customPost"
-            },
-            {
-              "name": "customPostID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update meta mutation on a custom post"
-        },
-        {
-          "name": "RootUpdateGenericTagTermMetaMutationPayload",
-          "namespacedName": "RootUpdateGenericTagTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update meta mutation on a tag term"
-        },
-        {
-          "name": "RootUpdateGenericTagTermMutationPayload",
-          "namespacedName": "RootUpdateGenericTagTermMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update mutation on a tag term"
-        },
-        {
-          "name": "RootUpdateMediaItemMutationPayload",
-          "namespacedName": "RootUpdateMediaItemMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "mediaItem"
-            },
-            {
-              "name": "mediaItemID"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of updating the metadata for an attachment"
-        },
-        {
-          "name": "RootUpdateMenuMutationPayload",
-          "namespacedName": "RootUpdateMenuMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "menu"
-            },
-            {
-              "name": "menuID"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of updating a menu"
-        },
-        {
-          "name": "RootUpdatePageMutationPayload",
-          "namespacedName": "RootUpdatePageMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "page"
-            },
-            {
-              "name": "pageID"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update mutation on a page"
-        },
-        {
-          "name": "RootUpdatePostCategoryTermMetaMutationPayload",
-          "namespacedName": "RootUpdatePostCategoryTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update meta mutation on a post's category term"
-        },
-        {
-          "name": "RootUpdatePostCategoryTermMutationPayload",
-          "namespacedName": "RootUpdatePostCategoryTermMutationPayload",
-          "fields": [
-            {
-              "name": "category"
-            },
-            {
-              "name": "categoryID"
-            },
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update mutation on a post category term"
-        },
-        {
-          "name": "RootUpdatePostMutationPayload",
-          "namespacedName": "RootUpdatePostMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "post"
-            },
-            {
-              "name": "postID"
-            },
-            {
-              "name": "status"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update mutation on a post"
-        },
-        {
-          "name": "RootUpdatePostTagTermMetaMutationPayload",
-          "namespacedName": "RootUpdatePostTagTermMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update meta mutation on a post's tag term"
-        },
-        {
-          "name": "RootUpdatePostTagTermMutationPayload",
-          "namespacedName": "RootUpdatePostTagTermMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "tag"
-            },
-            {
-              "name": "tagID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update mutation on a post tag term"
-        },
-        {
-          "name": "RootUpdateUserMetaMutationPayload",
-          "namespacedName": "RootUpdateUserMetaMutationPayload",
-          "fields": [
-            {
-              "name": "errors"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "user"
-            },
-            {
-              "name": "userID"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Payload of executing an update meta mutation on a user"
-        },
-        {
-          "name": "TagTermDoesNotExistErrorPayload",
-          "namespacedName": "TagTermDoesNotExistErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The requested tag does not exist\""
-        },
-        {
-          "name": "TaxonomyIsNotValidErrorPayload",
-          "namespacedName": "TaxonomyIsNotValidErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The requested taxonomy does not exist\""
-        },
-        {
-          "name": "User",
-          "namespacedName": "User",
-          "fields": [
-            {
-              "name": "avatar"
-            },
-            {
-              "name": "capabilities"
-            },
-            {
-              "name": "customPostCount"
-            },
-            {
-              "name": "customPosts"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "displayName"
-            },
-            {
-              "name": "email"
-            },
-            {
-              "name": "firstName"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "hasAnyCapability"
-            },
-            {
-              "name": "hasAnyRole"
-            },
-            {
-              "name": "hasCapability"
-            },
-            {
-              "name": "hasRole"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "lastName"
-            },
-            {
-              "name": "locale"
-            },
-            {
-              "name": "meta"
-            },
-            {
-              "name": "metaKeys"
-            },
-            {
-              "name": "metaValue"
-            },
-            {
-              "name": "metaValues"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "nicename"
-            },
-            {
-              "name": "nickname"
-            },
-            {
-              "name": "postCount"
-            },
-            {
-              "name": "posts"
-            },
-            {
-              "name": "registeredDate"
-            },
-            {
-              "name": "registeredDateStr"
-            },
-            {
-              "name": "roleNames"
-            },
-            {
-              "name": "roles"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "slug"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            },
-            {
-              "name": "username"
-            },
-            {
-              "name": "websiteURL"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of a user"
-        },
-        {
-          "name": "UserAvatar",
-          "namespacedName": "UserAvatar",
-          "fields": [
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "self"
-            },
-            {
-              "name": "size"
-            },
-            {
-              "name": "src"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "User avatar"
-        },
-        {
-          "name": "UserDoesNotExistErrorPayload",
-          "namespacedName": "UserDoesNotExistErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user does not exist\""
-        },
-        {
-          "name": "UserHasNoPermissionToCreateMenusErrorPayload",
-          "namespacedName": "UserHasNoPermissionToCreateMenusErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user has no permission to create menus\""
-        },
-        {
-          "name": "UserHasNoPermissionToUploadFilesErrorPayload",
-          "namespacedName": "UserHasNoPermissionToUploadFilesErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user has no permission to upload files\""
-        },
-        {
-          "name": "UserHasNoPermissionToUploadFilesForOtherUsersErrorPayload",
-          "namespacedName": "UserHasNoPermissionToUploadFilesForOtherUsersErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user has no permission to upload files for other users\""
-        },
-        {
-          "name": "UserIsLoggedInErrorPayload",
-          "namespacedName": "UserIsLoggedInErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user is already logged-in\""
-        },
-        {
-          "name": "UserIsNotLoggedInErrorPayload",
-          "namespacedName": "UserIsNotLoggedInErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Error payload for: \"The user is not logged-in\""
-        },
-        {
-          "name": "UserRole",
-          "namespacedName": "UserRole",
-          "fields": [
-            {
-              "name": "capabilities"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "self"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "User roles"
-        },
-        {
-          "name": "_DirectiveExtensions",
-          "namespacedName": "_DirectiveExtensions",
-          "fields": [
-            {
-              "name": "fieldDirectiveSupportedTypeNamesOrDescriptions"
-            },
-            {
-              "name": "needsDataToExecute"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Extensions (custom metadata) added to the directive"
-        },
-        {
-          "name": "_EnumValueExtensions",
-          "namespacedName": "_EnumValueExtensions",
-          "fields": [
-            {
-              "name": "isSensitiveDataElement"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Extensions (custom metadata) added to the enum value"
-        },
-        {
-          "name": "_FieldExtensions",
-          "namespacedName": "_FieldExtensions",
-          "fields": [
-            {
-              "name": "isGlobal"
-            },
-            {
-              "name": "isMutation"
-            },
-            {
-              "name": "isSensitiveDataElement"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Extensions (custom metadata) added to the field"
-        },
-        {
-          "name": "_InputValueExtensions",
-          "namespacedName": "_InputValueExtensions",
-          "fields": [
-            {
-              "name": "isSensitiveDataElement"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Extensions (custom metadata) added to the input value"
-        },
-        {
-          "name": "_NamedTypeExtensions",
-          "namespacedName": "_NamedTypeExtensions",
-          "fields": [
-            {
-              "name": "elementName"
-            },
-            {
-              "name": "namespacedName"
-            },
-            {
-              "name": "possibleValues"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Extensions (custom metadata) added to the GraphQL type (for all 'named' types: Object, Interface, Union, Scalar, Enum and InputObject)"
-        },
-        {
-          "name": "_SchemaExtensions",
-          "namespacedName": "_SchemaExtensions",
-          "fields": [
-            {
-              "name": "isNamespaced"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Extensions (custom metadata) added to the GraphQL schema"
-        },
-        {
-          "name": "__Directive",
-          "namespacedName": "__Directive",
-          "fields": [
-            {
-              "name": "args"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "extensions"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "isRepeatable"
-            },
-            {
-              "name": "locations"
-            },
-            {
-              "name": "name"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "A GraphQL directive in the data graph"
-        },
-        {
-          "name": "__EnumValue",
-          "namespacedName": "__EnumValue",
-          "fields": [
-            {
-              "name": "deprecationReason"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "extensions"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "isDeprecated"
-            },
-            {
-              "name": "name"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of an Enum value in GraphQL"
-        },
-        {
-          "name": "__Field",
-          "namespacedName": "__Field",
-          "fields": [
-            {
-              "name": "args"
-            },
-            {
-              "name": "deprecationReason"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "extensions"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "isDeprecated"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "type"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of a GraphQL type's field"
-        },
-        {
-          "name": "__InputValue",
-          "namespacedName": "__InputValue",
-          "fields": [
-            {
-              "name": "defaultValue"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "extensions"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "type"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of an input object in GraphQL"
-        },
-        {
-          "name": "__Schema",
-          "namespacedName": "__Schema",
-          "fields": [
-            {
-              "name": "directives"
-            },
-            {
-              "name": "extensions"
-            },
-            {
-              "name": "globalFields"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "mutationType"
-            },
-            {
-              "name": "queryType"
-            },
-            {
-              "name": "subscriptionType"
-            },
-            {
-              "name": "type"
-            },
-            {
-              "name": "types"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Schema type, to implement the introspection fields"
-        },
-        {
-          "name": "__Type",
-          "namespacedName": "__Type",
-          "fields": [
-            {
-              "name": "description"
-            },
-            {
-              "name": "enumValues"
-            },
-            {
-              "name": "extensions"
-            },
-            {
-              "name": "fields"
-            },
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            },
-            {
-              "name": "inputFields"
-            },
-            {
-              "name": "interfaces"
-            },
-            {
-              "name": "isOneOf"
-            },
-            {
-              "name": "kind"
-            },
-            {
-              "name": "name"
-            },
-            {
-              "name": "ofType"
-            },
-            {
-              "name": "possibleTypes"
-            },
-            {
-              "name": "specifiedByURL"
-            }
-          ],
-          "kind": "OBJECT",
-          "description": "Representation of each GraphQL type in the graph"
-        },
-        {
-          "name": "AnyBuiltInScalar",
-          "namespacedName": "AnyBuiltInScalar",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Wildcard type representing any of GraphQL's built-in types (String, Int, Boolean, Float or ID)"
-        },
-        {
-          "name": "AnyScalar",
-          "namespacedName": "AnyScalar",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Wildcard type representing any of GraphQL's scalar types, including built-in types (String, Int, Boolean, Float or ID) and custom types"
-        },
-        {
-          "name": "BlockTypeAttributeFieldTypeEnumString",
-          "namespacedName": "BlockTypeAttributeFieldTypeEnumString",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "JSON-Schema \"type\" of a block attribute. Includes `null`, so it can't be a GraphQL Enum (which disallows that name).. Possible values: `array`, `boolean`, `integer`, `null`, `number`, `object`, `string`."
-        },
-        {
-          "name": "Boolean",
-          "namespacedName": "Boolean",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "The Boolean scalar type represents `true` or `false`."
-        },
-        {
-          "name": "CategoryTaxonomyEnumString",
-          "namespacedName": "CategoryTaxonomyEnumString",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Category taxonomies (available for querying via the API). Possible values: `additional-dummy-category`, `additional-post-category`, `category`, `dummy-category`, `dummy-category-two`."
-        },
-        {
-          "name": "CustomPostEnumString",
-          "namespacedName": "CustomPostEnumString",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Custom post types (available for querying via the API). Possible values: `dummy-cpt`, `dummy-cpt-four`, `dummy-cpt-three`, `dummy-cpt-two`, `page`, `post`, `wp_block`."
-        },
-        {
-          "name": "DangerouslyNonSpecificScalar",
-          "namespacedName": "DangerouslyNonSpecificScalar",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Special scalar type which is not coerced or validated. In particular, it does not need to validate if it is an array or not, as GraphQL requires based on the applied WrappingType (such as `[String]`)."
-        },
-        {
-          "name": "Date",
-          "namespacedName": "Date",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Date scalar. It follows the ISO 8601 specification, with format \"Y-m-d\")"
-        },
-        {
-          "name": "DateTime",
-          "namespacedName": "DateTime",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "DateTime scalar. It follows the ISO 8601 specification, with format \"Y-m-d\\TH:i:sP\")"
-        },
-        {
-          "name": "Email",
-          "namespacedName": "Email",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Email scalar, such as leo@mysite.com"
-        },
-        {
-          "name": "HTML",
-          "namespacedName": "HTML",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "HTML scalar, such as \"<p>Hello <strong>world<\/strong>!<\/p>\""
-        },
-        {
-          "name": "ID",
-          "namespacedName": "ID",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "The ID scalar type represents a unique identifier."
-        },
-        {
-          "name": "Int",
-          "namespacedName": "Int",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "The Int scalar type represents non-fractional signed whole numeric values."
-        },
-        {
-          "name": "JSONObject",
-          "namespacedName": "JSONObject",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Custom scalar representing a JSON Object of unrestricted shape"
-        },
-        {
-          "name": "ListValueJSONObject",
-          "namespacedName": "ListValueJSONObject",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Custom scalar representing a JSON Object where values are lists (of anything)"
-        },
-        {
-          "name": "MenuLocationEnumString",
-          "namespacedName": "MenuLocationEnumString",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Menu Locations. Possible values: `footer`, `primary`, `quaternary`, `secondary`, `tertiary`."
-        },
-        {
-          "name": "NullableListValueJSONObject",
-          "namespacedName": "NullableListValueJSONObject",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Custom scalar representing a JSON Object where values are lists (of anything) or null"
-        },
-        {
-          "name": "Numeric",
-          "namespacedName": "Numeric",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Wildcard type representing any of the numeric types (Int or Float)"
-        },
-        {
-          "name": "PageBuilderProvidersEnumString",
-          "namespacedName": "PageBuilderProvidersEnumString",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Page builder providers. No values available"
-        },
-        {
-          "name": "PostCategoryTaxonomyEnumString",
-          "namespacedName": "PostCategoryTaxonomyEnumString",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Post category taxonomies (available for querying via the API). Possible values: `additional-post-category`, `category`."
-        },
-        {
-          "name": "PostTagTaxonomyEnumString",
-          "namespacedName": "PostTagTaxonomyEnumString",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Post tag taxonomies (available for querying via the API). Possible values: `additional-post-tag`, `post_tag`."
-        },
-        {
-          "name": "String",
-          "namespacedName": "String",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "The String scalar type represents textual data, represented as UTF-8 character sequences."
-        },
-        {
-          "name": "TagTaxonomyEnumString",
-          "namespacedName": "TagTaxonomyEnumString",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "Tag taxonomies (available for querying via the API). Possible values: `additional-dummy-tag`, `additional-post-tag`, `dummy-tag`, `dummy-tag-two`, `post_tag`."
-        },
-        {
-          "name": "URL",
-          "namespacedName": "URL",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "URL scalar, such as https:\/\/mysite.com\/my-fabulous-page"
-        },
-        {
-          "name": "URLAbsolutePath",
-          "namespacedName": "URLAbsolutePath",
-          "fields": null,
-          "kind": "SCALAR",
-          "description": "URL Absolute Path scalar, such as \"\/my-fabulous-page\" in URL \"https:\/\/mysite.com\/my-fabulous-page\". The absolute path starts with \"\/\", followed by the URL relative path"
-        },
-        {
-          "name": "Block",
-          "namespacedName": "Block",
-          "fields": [
-            {
-              "name": "attributes"
-            },
-            {
-              "name": "contentSource"
-            },
-            {
-              "name": "innerBlocks"
-            },
-            {
-              "name": "name"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "Entities representing a Block"
-        },
-        {
-          "name": "Category",
-          "namespacedName": "Category",
-          "fields": [
-            {
-              "name": "count"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "name"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "Entities representing a category"
-        },
-        {
-          "name": "Commentable",
-          "namespacedName": "Commentable",
-          "fields": [
-            {
-              "name": "areCommentsOpen"
-            },
-            {
-              "name": "commentCount"
-            },
-            {
-              "name": "comments"
-            },
-            {
-              "name": "hasComments"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "The entity can receive comments"
-        },
-        {
-          "name": "CustomPost",
-          "namespacedName": "CustomPost",
-          "fields": [
-            {
-              "name": "content"
-            },
-            {
-              "name": "customPostType"
-            },
-            {
-              "name": "date"
-            },
-            {
-              "name": "dateStr"
-            },
-            {
-              "name": "excerpt"
-            },
-            {
-              "name": "isStatus"
-            },
-            {
-              "name": "modifiedDate"
-            },
-            {
-              "name": "modifiedDateStr"
-            },
-            {
-              "name": "rawContent"
-            },
-            {
-              "name": "rawExcerpt"
-            },
-            {
-              "name": "rawTitle"
-            },
-            {
-              "name": "slug"
-            },
-            {
-              "name": "slugPath"
-            },
-            {
-              "name": "status"
-            },
-            {
-              "name": "title"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "Entities representing a custom post"
-        },
-        {
-          "name": "ErrorPayload",
-          "namespacedName": "ErrorPayload",
-          "fields": [
-            {
-              "name": "message"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "Entities representing an Error payload"
-        },
-        {
-          "name": "IdentifiableObject",
-          "namespacedName": "IdentifiableObject",
-          "fields": [
-            {
-              "name": "globalID"
-            },
-            {
-              "name": "id"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "An object that can be uniquely identifiable within its type via an 'ID', and within the whole schema via a 'global ID'"
-        },
-        {
-          "name": "Queryable",
-          "namespacedName": "Queryable",
-          "fields": [
-            {
-              "name": "slug"
-            },
-            {
-              "name": "url"
-            },
-            {
-              "name": "urlPath"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "Entities that can be queried through an URL"
-        },
-        {
-          "name": "Tag",
-          "namespacedName": "Tag",
-          "fields": [
-            {
-              "name": "count"
-            },
-            {
-              "name": "description"
-            },
-            {
-              "name": "name"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "Entities representing a tag"
-        },
-        {
-          "name": "WithAuthor",
-          "namespacedName": "WithAuthor",
-          "fields": [
-            {
-              "name": "author"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "Entities that have an author"
-        },
-        {
-          "name": "WithFeaturedImage",
-          "namespacedName": "WithFeaturedImage",
-          "fields": [
-            {
-              "name": "featuredImage"
-            },
-            {
-              "name": "hasFeaturedImage"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "Fields concerning an entity's featured image"
-        },
-        {
-          "name": "WithMeta",
-          "namespacedName": "WithMeta",
-          "fields": [
-            {
-              "name": "meta"
-            },
-            {
-              "name": "metaKeys"
-            },
-            {
-              "name": "metaValue"
-            },
-            {
-              "name": "metaValues"
-            }
-          ],
-          "kind": "INTERFACE",
-          "description": "Fields with meta values"
-        },
-        {
-          "name": "AuthorByInput",
-          "namespacedName": "AuthorByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the custom post author"
-        },
-        {
-          "name": "BlockTypeAttributesFilterInput",
-          "namespacedName": "BlockTypeAttributesFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter the attributes of a block type"
-        },
-        {
-          "name": "BlockTypeSupportsFilterInput",
-          "namespacedName": "BlockTypeSupportsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Filter block types by their `supports` configuration"
-        },
-        {
-          "name": "CategoriesByInput",
-          "namespacedName": "CategoriesByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "CategoryByFilterInput",
-          "namespacedName": "CategoryByFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a category"
-        },
-        {
-          "name": "CategoryByInput",
-          "namespacedName": "CategoryByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "CategoryPaginationInput",
-          "namespacedName": "CategoryPaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate categories"
-        },
-        {
-          "name": "CommentByInput",
-          "namespacedName": "CommentByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a comment"
-        },
-        {
-          "name": "CommentContentInput",
-          "namespacedName": "CommentContentInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "CommentMetaQueryInput",
-          "namespacedName": "CommentMetaQueryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Filter by meta key and value. The key must be allowed access in the Settings. See: https:\/\/developer.wordpress.org\/reference\/classes\/wp_meta_query\/"
-        },
-        {
-          "name": "CommentResponsePaginationInput",
-          "namespacedName": "CommentResponsePaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate response comments"
-        },
-        {
-          "name": "CommentResponsesFilterInput",
-          "namespacedName": "CommentResponsesFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter comment responses"
-        },
-        {
-          "name": "CommentSortInput",
-          "namespacedName": "CommentSortInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to sort custom posts"
-        },
-        {
-          "name": "CreateMediaItemFromContentInput",
-          "namespacedName": "CreateMediaItemFromContentInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Provide the data to create and upload the attachment"
-        },
-        {
-          "name": "CreateMediaItemFromInput",
-          "namespacedName": "CreateMediaItemFromInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "CreateMediaItemFromURLInput",
-          "namespacedName": "CreateMediaItemFromURLInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Create and upload the attachment from a URL"
-        },
-        {
-          "name": "CustomPostByInput",
-          "namespacedName": "CustomPostByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a custom post"
-        },
-        {
-          "name": "CustomPostCategoriesFilterInput",
-          "namespacedName": "CustomPostCategoriesFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter categories from a custom post"
-        },
-        {
-          "name": "CustomPostCommentPaginationInput",
-          "namespacedName": "CustomPostCommentPaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate custom post comments"
-        },
-        {
-          "name": "CustomPostCommentsFilterInput",
-          "namespacedName": "CustomPostCommentsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter comments from custom posts"
-        },
-        {
-          "name": "CustomPostContentInput",
-          "namespacedName": "CustomPostContentInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "CustomPostMetaQueryInput",
-          "namespacedName": "CustomPostMetaQueryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Filter by meta key and value. The key must be allowed access in the Settings. See: https:\/\/developer.wordpress.org\/reference\/classes\/wp_meta_query\/"
-        },
-        {
-          "name": "CustomPostPaginationInput",
-          "namespacedName": "CustomPostPaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate custom posts"
-        },
-        {
-          "name": "CustomPostParentByInput",
-          "namespacedName": "CustomPostParentByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the custom post parent"
-        },
-        {
-          "name": "CustomPostSortInput",
-          "namespacedName": "CustomPostSortInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to sort custom posts"
-        },
-        {
-          "name": "CustomPostTagsFilterInput",
-          "namespacedName": "CustomPostTagsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter tags from a custom post"
-        },
-        {
-          "name": "DateQueryInput",
-          "namespacedName": "DateQueryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "FeaturedImageByInput",
-          "namespacedName": "FeaturedImageByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the custom post's featured image"
-        },
-        {
-          "name": "FilterByAuthorInput",
-          "namespacedName": "FilterByAuthorInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Filter by author"
-        },
-        {
-          "name": "FilterByTaxonomyTermsInput",
-          "namespacedName": "FilterByTaxonomyTermsInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "FilterCommentsByCommentAuthorInput",
-          "namespacedName": "FilterCommentsByCommentAuthorInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Filter comments by comment author"
-        },
-        {
-          "name": "FilterCommentsByCustomPostAuthorInput",
-          "namespacedName": "FilterCommentsByCustomPostAuthorInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Filter comments by custom post author"
-        },
-        {
-          "name": "FilterCustomPostsByCategoriesInput",
-          "namespacedName": "FilterCustomPostsByCategoriesInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter custom posts by categories"
-        },
-        {
-          "name": "FilterCustomPostsByTagsInput",
-          "namespacedName": "FilterCustomPostsByTagsInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter custom posts by tags"
-        },
-        {
-          "name": "FilterPostsByCategoriesInput",
-          "namespacedName": "FilterPostsByCategoriesInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter custom posts by categories"
-        },
-        {
-          "name": "FilterPostsByTagsInput",
-          "namespacedName": "FilterPostsByTagsInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter custom posts by tags"
-        },
-        {
-          "name": "IncludeBlockPropertiesInput",
-          "namespacedName": "IncludeBlockPropertiesInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to configure which properties to include in the block data"
-        },
-        {
-          "name": "IncludeExcludeFilterInput",
-          "namespacedName": "IncludeExcludeFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to filter by including or excluding items"
-        },
-        {
-          "name": "LoginCredentialsInput",
-          "namespacedName": "LoginCredentialsInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "LoginUserByInput",
-          "namespacedName": "LoginUserByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "MediaItemByInput",
-          "namespacedName": "MediaItemByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a media item"
-        },
-        {
-          "name": "MediaItemSortInput",
-          "namespacedName": "MediaItemSortInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to sort custom posts"
-        },
-        {
-          "name": "MenuByInput",
-          "namespacedName": "MenuByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a menu"
-        },
-        {
-          "name": "MenuItemInput",
-          "namespacedName": "MenuItemInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input for a Menu Item"
-        },
-        {
-          "name": "MenuItemsByInput",
-          "namespacedName": "MenuItemsByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to select how to provide the menu items"
-        },
-        {
-          "name": "MenuSortInput",
-          "namespacedName": "MenuSortInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to sort custom posts"
-        },
-        {
-          "name": "MetaKeysFilterInput",
-          "namespacedName": "MetaKeysFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter the 'metaKeys' field"
-        },
-        {
-          "name": "MetaQueryCompareByArrayValueInput",
-          "namespacedName": "MetaQueryCompareByArrayValueInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "MetaQueryCompareByInput",
-          "namespacedName": "MetaQueryCompareByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "MetaQueryCompareByKeyInput",
-          "namespacedName": "MetaQueryCompareByKeyInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "MetaQueryCompareByNumericValueInput",
-          "namespacedName": "MetaQueryCompareByNumericValueInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "MetaQueryCompareByStringValueInput",
-          "namespacedName": "MetaQueryCompareByStringValueInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "PageByInput",
-          "namespacedName": "PageByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a page"
-        },
-        {
-          "name": "PageContentInput",
-          "namespacedName": "PageContentInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "PagePaginationInput",
-          "namespacedName": "PagePaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate pages"
-        },
-        {
-          "name": "PostByInput",
-          "namespacedName": "PostByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a post"
-        },
-        {
-          "name": "PostCategoryByFilterInput",
-          "namespacedName": "PostCategoryByFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a category"
-        },
-        {
-          "name": "PostContentInput",
-          "namespacedName": "PostContentInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "PostPaginationInput",
-          "namespacedName": "PostPaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate posts"
-        },
-        {
-          "name": "PostTagByFilterInput",
-          "namespacedName": "PostTagByFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a tag"
-        },
-        {
-          "name": "RootAddCategoryMetaInput",
-          "namespacedName": "RootAddCategoryMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to add meta to a category term"
-        },
-        {
-          "name": "RootAddCommentMetaInput",
-          "namespacedName": "RootAddCommentMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to add meta to a comment"
-        },
-        {
-          "name": "RootAddCommentToCustomPostInput",
-          "namespacedName": "RootAddCommentToCustomPostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to add a comment to a custom post"
-        },
-        {
-          "name": "RootAddCustomPostMetaInput",
-          "namespacedName": "RootAddCustomPostMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to add meta to a custom post"
-        },
-        {
-          "name": "RootAddTagMetaInput",
-          "namespacedName": "RootAddTagMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to add meta to a tag term"
-        },
-        {
-          "name": "RootAddUserMetaInput",
-          "namespacedName": "RootAddUserMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to add meta to a user"
-        },
-        {
-          "name": "RootBlockTypesFilterInput",
-          "namespacedName": "RootBlockTypesFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter the registered block types"
-        },
-        {
-          "name": "RootCategoriesFilterInput",
-          "namespacedName": "RootCategoriesFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter categories"
-        },
-        {
-          "name": "RootCommentPaginationInput",
-          "namespacedName": "RootCommentPaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate comments"
-        },
-        {
-          "name": "RootCommentsFilterInput",
-          "namespacedName": "RootCommentsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter comments"
-        },
-        {
-          "name": "RootCreateCustomPostInput",
-          "namespacedName": "RootCreateCustomPostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a custom post"
-        },
-        {
-          "name": "RootCreateGenericCategoryInput",
-          "namespacedName": "RootCreateGenericCategoryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to create a category term"
-        },
-        {
-          "name": "RootCreateGenericTagInput",
-          "namespacedName": "RootCreateGenericTagInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to create a tag term"
-        },
-        {
-          "name": "RootCreateMediaItemInput",
-          "namespacedName": "RootCreateMediaItemInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to upload an attachment"
-        },
-        {
-          "name": "RootCreateMenuInput",
-          "namespacedName": "RootCreateMenuInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to create a menu"
-        },
-        {
-          "name": "RootCreatePageInput",
-          "namespacedName": "RootCreatePageInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a custom post"
-        },
-        {
-          "name": "RootCreatePostCategoryInput",
-          "namespacedName": "RootCreatePostCategoryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to create a category term"
-        },
-        {
-          "name": "RootCreatePostInput",
-          "namespacedName": "RootCreatePostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a custom post"
-        },
-        {
-          "name": "RootCreatePostTagInput",
-          "namespacedName": "RootCreatePostTagInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to create a tag term"
-        },
-        {
-          "name": "RootCustomPostsFilterInput",
-          "namespacedName": "RootCustomPostsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter custom posts"
-        },
-        {
-          "name": "RootDeleteCategoryMetaInput",
-          "namespacedName": "RootDeleteCategoryMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a category term's meta entry"
-        },
-        {
-          "name": "RootDeleteCommentInput",
-          "namespacedName": "RootDeleteCommentInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a comment"
-        },
-        {
-          "name": "RootDeleteCommentMetaInput",
-          "namespacedName": "RootDeleteCommentMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete an entity's meta entry"
-        },
-        {
-          "name": "RootDeleteCustomPostInput",
-          "namespacedName": "RootDeleteCustomPostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a custom post"
-        },
-        {
-          "name": "RootDeleteCustomPostMetaInput",
-          "namespacedName": "RootDeleteCustomPostMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a custom post's meta entry"
-        },
-        {
-          "name": "RootDeleteGenericCategoryInput",
-          "namespacedName": "RootDeleteGenericCategoryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a category term"
-        },
-        {
-          "name": "RootDeleteGenericTagInput",
-          "namespacedName": "RootDeleteGenericTagInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a tag term"
-        },
-        {
-          "name": "RootDeleteMediaItemInput",
-          "namespacedName": "RootDeleteMediaItemInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete an attachment"
-        },
-        {
-          "name": "RootDeleteMenuInput",
-          "namespacedName": "RootDeleteMenuInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a menu"
-        },
-        {
-          "name": "RootDeletePageInput",
-          "namespacedName": "RootDeletePageInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a page"
-        },
-        {
-          "name": "RootDeletePostCategoryInput",
-          "namespacedName": "RootDeletePostCategoryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a category term"
-        },
-        {
-          "name": "RootDeletePostInput",
-          "namespacedName": "RootDeletePostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a post"
-        },
-        {
-          "name": "RootDeletePostTagInput",
-          "namespacedName": "RootDeletePostTagInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a tag term"
-        },
-        {
-          "name": "RootDeleteTagMetaInput",
-          "namespacedName": "RootDeleteTagMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a tag term's meta entry"
-        },
-        {
-          "name": "RootDeleteUserMetaInput",
-          "namespacedName": "RootDeleteUserMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to delete a user's meta entry"
-        },
-        {
-          "name": "RootMediaItemPaginationInput",
-          "namespacedName": "RootMediaItemPaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate media items"
-        },
-        {
-          "name": "RootMediaItemsFilterInput",
-          "namespacedName": "RootMediaItemsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter media items"
-        },
-        {
-          "name": "RootMenuPaginationInput",
-          "namespacedName": "RootMenuPaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate menus"
-        },
-        {
-          "name": "RootMenusFilterInput",
-          "namespacedName": "RootMenusFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter menus"
-        },
-        {
-          "name": "RootMyCommentsFilterInput",
-          "namespacedName": "RootMyCommentsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter the logged-in user's comments"
-        },
-        {
-          "name": "RootMyCustomPostsFilterInput",
-          "namespacedName": "RootMyCustomPostsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter the logged-in user's custom posts"
-        },
-        {
-          "name": "RootMyMediaItemsFilterInput",
-          "namespacedName": "RootMyMediaItemsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter the logged-in user's media items"
-        },
-        {
-          "name": "RootMyPagesFilterInput",
-          "namespacedName": "RootMyPagesFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter the logged-in user's pages"
-        },
-        {
-          "name": "RootMyPostsFilterInput",
-          "namespacedName": "RootMyPostsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter the logged-in user's posts"
-        },
-        {
-          "name": "RootPagesFilterInput",
-          "namespacedName": "RootPagesFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter pages"
-        },
-        {
-          "name": "RootPostCategoriesFilterInput",
-          "namespacedName": "RootPostCategoriesFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter categories"
-        },
-        {
-          "name": "RootPostTagsFilterInput",
-          "namespacedName": "RootPostTagsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter tags"
-        },
-        {
-          "name": "RootPostsFilterInput",
-          "namespacedName": "RootPostsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter posts"
-        },
-        {
-          "name": "RootRemoveFeaturedImageFromCustomPostInput",
-          "namespacedName": "RootRemoveFeaturedImageFromCustomPostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to remove the featured image from a custom post"
-        },
-        {
-          "name": "RootReplyCommentInput",
-          "namespacedName": "RootReplyCommentInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to add a comment to a custom post"
-        },
-        {
-          "name": "RootSetCategoriesOnCustomPostInput",
-          "namespacedName": "RootSetCategoriesOnCustomPostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to set categories on a custom post"
-        },
-        {
-          "name": "RootSetCategoriesOnPostInput",
-          "namespacedName": "RootSetCategoriesOnPostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to set categories on a custom post"
-        },
-        {
-          "name": "RootSetCategoryMetaInput",
-          "namespacedName": "RootSetCategoryMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to set a category term's meta entries"
-        },
-        {
-          "name": "RootSetCommentMetaInput",
-          "namespacedName": "RootSetCommentMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to set entries on a comment"
-        },
-        {
-          "name": "RootSetCustomPostMetaInput",
-          "namespacedName": "RootSetCustomPostMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to set entries on a custom post"
-        },
-        {
-          "name": "RootSetFeaturedImageOnCustomPostInput",
-          "namespacedName": "RootSetFeaturedImageOnCustomPostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to set the featured image on a custom post"
-        },
-        {
-          "name": "RootSetTagMetaInput",
-          "namespacedName": "RootSetTagMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to set a tag term's meta entries"
-        },
-        {
-          "name": "RootSetTagsOnCustomPostInput",
-          "namespacedName": "RootSetTagsOnCustomPostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to set tags on a custom post"
-        },
-        {
-          "name": "RootSetTagsOnPostInput",
-          "namespacedName": "RootSetTagsOnPostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to set tags on a custom post"
-        },
-        {
-          "name": "RootSetUserMetaInput",
-          "namespacedName": "RootSetUserMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to set entries on a user"
-        },
-        {
-          "name": "RootTagsFilterInput",
-          "namespacedName": "RootTagsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter tags"
-        },
-        {
-          "name": "RootUpdateCategoryMetaInput",
-          "namespacedName": "RootUpdateCategoryMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a category term's meta"
-        },
-        {
-          "name": "RootUpdateCommentInput",
-          "namespacedName": "RootUpdateCommentInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a comment"
-        },
-        {
-          "name": "RootUpdateCommentMetaInput",
-          "namespacedName": "RootUpdateCommentMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a comment's meta"
-        },
-        {
-          "name": "RootUpdateCustomPostInput",
-          "namespacedName": "RootUpdateCustomPostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a custom post"
-        },
-        {
-          "name": "RootUpdateCustomPostMetaInput",
-          "namespacedName": "RootUpdateCustomPostMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a custom post's meta"
-        },
-        {
-          "name": "RootUpdateGenericCategoryInput",
-          "namespacedName": "RootUpdateGenericCategoryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a category term"
-        },
-        {
-          "name": "RootUpdateGenericTagInput",
-          "namespacedName": "RootUpdateGenericTagInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a tag term"
-        },
-        {
-          "name": "RootUpdateMediaItemInput",
-          "namespacedName": "RootUpdateMediaItemInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update the metadata for an attachment"
-        },
-        {
-          "name": "RootUpdateMenuInput",
-          "namespacedName": "RootUpdateMenuInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a menu"
-        },
-        {
-          "name": "RootUpdatePageInput",
-          "namespacedName": "RootUpdatePageInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a custom post"
-        },
-        {
-          "name": "RootUpdatePostCategoryInput",
-          "namespacedName": "RootUpdatePostCategoryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a category term"
-        },
-        {
-          "name": "RootUpdatePostInput",
-          "namespacedName": "RootUpdatePostInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a custom post"
-        },
-        {
-          "name": "RootUpdatePostTagInput",
-          "namespacedName": "RootUpdatePostTagInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a tag term"
-        },
-        {
-          "name": "RootUpdateTagMetaInput",
-          "namespacedName": "RootUpdateTagMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a tag term's meta"
-        },
-        {
-          "name": "RootUpdateUserMetaInput",
-          "namespacedName": "RootUpdateUserMetaInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to update a user's meta"
-        },
-        {
-          "name": "TagByFilterInput",
-          "namespacedName": "TagByFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a tag"
-        },
-        {
-          "name": "TagByInput",
-          "namespacedName": "TagByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "TagPaginationInput",
-          "namespacedName": "TagPaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate tags"
-        },
-        {
-          "name": "TagsByInput",
-          "namespacedName": "TagsByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": null
-        },
-        {
-          "name": "TaxonomyCustomPostsFilterInput",
-          "namespacedName": "TaxonomyCustomPostsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter a taxonomy's custom posts"
-        },
-        {
-          "name": "TaxonomyMetaQueryInput",
-          "namespacedName": "TaxonomyMetaQueryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Filter by meta key and value. The key must be allowed access in the Settings. See: https:\/\/developer.wordpress.org\/reference\/classes\/wp_meta_query\/"
-        },
-        {
-          "name": "TaxonomySortInput",
-          "namespacedName": "TaxonomySortInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to sort custom posts"
-        },
-        {
-          "name": "TaxonomyTaxonomiesFilterInput",
-          "namespacedName": "TaxonomyTaxonomiesFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter child taxonomies"
-        },
-        {
-          "name": "UserByInput",
-          "namespacedName": "UserByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to fetch a user"
-        },
-        {
-          "name": "UserCustomPostsFilterInput",
-          "namespacedName": "UserCustomPostsFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter the user's custom posts"
-        },
-        {
-          "name": "UserMetaQueryInput",
-          "namespacedName": "UserMetaQueryInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Filter by meta key and value. The key must be allowed access in the Settings. See: https:\/\/developer.wordpress.org\/reference\/classes\/wp_meta_query\/"
-        },
-        {
-          "name": "UserPaginationInput",
-          "namespacedName": "UserPaginationInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to paginate users"
-        },
-        {
-          "name": "UserSearchByInput",
-          "namespacedName": "UserSearchByInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Oneof input to specify the property and data to search users"
-        },
-        {
-          "name": "UserSortInput",
-          "namespacedName": "UserSortInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to sort custom posts"
-        },
-        {
-          "name": "UsersFilterInput",
-          "namespacedName": "UsersFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter users"
-        },
-        {
-          "name": "WithParentCustomPostChildrenFilterInput",
-          "namespacedName": "WithParentCustomPostChildrenFilterInput",
-          "fields": null,
-          "kind": "INPUT_OBJECT",
-          "description": "Input to filter the custom post children"
-        },
-        {
-          "name": "CommentOrderByEnum",
-          "namespacedName": "CommentOrderByEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "CommentStatusEnum",
-          "namespacedName": "CommentStatusEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "CommentTypeEnum",
-          "namespacedName": "CommentTypeEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "CustomPostOrderByEnum",
-          "namespacedName": "CustomPostOrderByEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "CustomPostStatusEnum",
-          "namespacedName": "CustomPostStatusEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "DirectiveKindEnum",
-          "namespacedName": "DirectiveKindEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "DirectiveLocation",
-          "namespacedName": "DirectiveLocation",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "FilterCustomPostStatusEnum",
-          "namespacedName": "FilterCustomPostStatusEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "MediaItemOrderByEnum",
-          "namespacedName": "MediaItemOrderByEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "MenuItemTypeEnum",
-          "namespacedName": "MenuItemTypeEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "MenuOrderByEnum",
-          "namespacedName": "MenuOrderByEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "MetaQueryCompareByArrayValueOperatorEnum",
-          "namespacedName": "MetaQueryCompareByArrayValueOperatorEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": "Operators to compare against an array value"
-        },
-        {
-          "name": "MetaQueryCompareByKeyOperatorEnum",
-          "namespacedName": "MetaQueryCompareByKeyOperatorEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": "Operators to compare against the meta key"
-        },
-        {
-          "name": "MetaQueryCompareByNumericValueOperatorEnum",
-          "namespacedName": "MetaQueryCompareByNumericValueOperatorEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": "Operators to compare against a numeric value"
-        },
-        {
-          "name": "MetaQueryCompareByStringValueOperatorEnum",
-          "namespacedName": "MetaQueryCompareByStringValueOperatorEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": "Operators to compare against a string value"
-        },
-        {
-          "name": "MetaQueryValueTypesEnum",
-          "namespacedName": "MetaQueryValueTypesEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": "Custom field type"
-        },
-        {
-          "name": "OperationStatusEnum",
-          "namespacedName": "OperationStatusEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "OrderEnum",
-          "namespacedName": "OrderEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "RelationEnum",
-          "namespacedName": "RelationEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": "The logical relationship between array values in query args (for meta query, date parameters, and others) when there is more than one"
-        },
-        {
-          "name": "TaxonomyOrderByEnum",
-          "namespacedName": "TaxonomyOrderByEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "TypeKind",
-          "namespacedName": "TypeKind",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "UserOrderByEnum",
-          "namespacedName": "UserOrderByEnum",
-          "fields": null,
-          "kind": "ENUM",
-          "description": null
-        },
-        {
-          "name": "BlockUnion",
-          "namespacedName": "BlockUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Block' types"
-        },
-        {
-          "name": "CategoryUnion",
-          "namespacedName": "CategoryUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'category' type resolvers"
-        },
-        {
-          "name": "CustomPostUnion",
-          "namespacedName": "CustomPostUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'custom post' type resolvers"
-        },
-        {
-          "name": "RootAddCommentMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootAddCommentMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when adding meta on a comment"
-        },
-        {
-          "name": "RootAddCommentToCustomPostMutationErrorPayloadUnion",
-          "namespacedName": "RootAddCommentToCustomPostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when adding a comment to a custom post"
-        },
-        {
-          "name": "RootAddGenericCategoryTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootAddGenericCategoryTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when adding meta on a category term"
-        },
-        {
-          "name": "RootAddGenericCustomPostMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootAddGenericCustomPostMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when adding meta on a custom post"
-        },
-        {
-          "name": "RootAddGenericTagTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootAddGenericTagTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when adding meta on a tag term"
-        },
-        {
-          "name": "RootAddPostCategoryTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootAddPostCategoryTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when adding meta on a post's category term"
-        },
-        {
-          "name": "RootAddPostTagTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootAddPostTagTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when adding meta on a post's tag term"
-        },
-        {
-          "name": "RootAddUserMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootAddUserMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when adding meta on a user"
-        },
-        {
-          "name": "RootCreateCustomPostMutationErrorPayloadUnion",
-          "namespacedName": "RootCreateCustomPostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when creating a custom post"
-        },
-        {
-          "name": "RootCreateGenericCategoryTermMutationErrorPayloadUnion",
-          "namespacedName": "RootCreateGenericCategoryTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when creating a category term"
-        },
-        {
-          "name": "RootCreateGenericTagTermMutationErrorPayloadUnion",
-          "namespacedName": "RootCreateGenericTagTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when creating a tag term"
-        },
-        {
-          "name": "RootCreateMediaItemMutationErrorPayloadUnion",
-          "namespacedName": "RootCreateMediaItemMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when uploading an attachment"
-        },
-        {
-          "name": "RootCreateMenuMutationErrorPayloadUnion",
-          "namespacedName": "RootCreateMenuMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when creating a menu"
-        },
-        {
-          "name": "RootCreatePageMutationErrorPayloadUnion",
-          "namespacedName": "RootCreatePageMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when creating a page"
-        },
-        {
-          "name": "RootCreatePostCategoryTermMutationErrorPayloadUnion",
-          "namespacedName": "RootCreatePostCategoryTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when creating a post category term"
-        },
-        {
-          "name": "RootCreatePostMutationErrorPayloadUnion",
-          "namespacedName": "RootCreatePostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when creating a post"
-        },
-        {
-          "name": "RootCreatePostTagTermMutationErrorPayloadUnion",
-          "namespacedName": "RootCreatePostTagTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when creating a post tag term"
-        },
-        {
-          "name": "RootDeleteCommentMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteCommentMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting meta on a comment"
-        },
-        {
-          "name": "RootDeleteCommentMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteCommentMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting a comment"
-        },
-        {
-          "name": "RootDeleteCustomPostMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteCustomPostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting a custom post"
-        },
-        {
-          "name": "RootDeleteGenericCategoryTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteGenericCategoryTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting meta on a category term"
-        },
-        {
-          "name": "RootDeleteGenericCategoryTermMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteGenericCategoryTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting a category term"
-        },
-        {
-          "name": "RootDeleteGenericCustomPostMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteGenericCustomPostMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting meta on a custom post"
-        },
-        {
-          "name": "RootDeleteGenericTagTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteGenericTagTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting meta on a tag term"
-        },
-        {
-          "name": "RootDeleteGenericTagTermMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteGenericTagTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting a tag term"
-        },
-        {
-          "name": "RootDeleteMediaItemMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteMediaItemMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting an attachment"
-        },
-        {
-          "name": "RootDeleteMenuMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteMenuMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting a menu"
-        },
-        {
-          "name": "RootDeletePageMutationErrorPayloadUnion",
-          "namespacedName": "RootDeletePageMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting a page"
-        },
-        {
-          "name": "RootDeletePostCategoryTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootDeletePostCategoryTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting meta on a post's category term"
-        },
-        {
-          "name": "RootDeletePostCategoryTermMutationErrorPayloadUnion",
-          "namespacedName": "RootDeletePostCategoryTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting a post category term"
-        },
-        {
-          "name": "RootDeletePostMutationErrorPayloadUnion",
-          "namespacedName": "RootDeletePostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting a post"
-        },
-        {
-          "name": "RootDeletePostTagTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootDeletePostTagTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting meta on a post's tag term"
-        },
-        {
-          "name": "RootDeletePostTagTermMutationErrorPayloadUnion",
-          "namespacedName": "RootDeletePostTagTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting a post tag term"
-        },
-        {
-          "name": "RootDeleteUserMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootDeleteUserMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when deleting meta on a user"
-        },
-        {
-          "name": "RootLoginUserMutationErrorPayloadUnion",
-          "namespacedName": "RootLoginUserMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when logging a user in"
-        },
-        {
-          "name": "RootLogoutUserMutationErrorPayloadUnion",
-          "namespacedName": "RootLogoutUserMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when logging a user out"
-        },
-        {
-          "name": "RootRemoveFeaturedImageFromCustomPostMutationErrorPayloadUnion",
-          "namespacedName": "RootRemoveFeaturedImageFromCustomPostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when removing a featured image from a custom post"
-        },
-        {
-          "name": "RootReplyCommentMutationErrorPayloadUnion",
-          "namespacedName": "RootReplyCommentMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when replying to a comment"
-        },
-        {
-          "name": "RootSetCategoriesOnCustomPostMutationErrorPayloadUnion",
-          "namespacedName": "RootSetCategoriesOnCustomPostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting categories on a custom post"
-        },
-        {
-          "name": "RootSetCategoriesOnPostMutationErrorPayloadUnion",
-          "namespacedName": "RootSetCategoriesOnPostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting categories on a post"
-        },
-        {
-          "name": "RootSetCommentMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootSetCommentMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting meta on a comment"
-        },
-        {
-          "name": "RootSetFeaturedImageOnCustomPostMutationErrorPayloadUnion",
-          "namespacedName": "RootSetFeaturedImageOnCustomPostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting a featured image to a custom post"
-        },
-        {
-          "name": "RootSetGenericCategoryTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootSetGenericCategoryTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting meta on a category term"
-        },
-        {
-          "name": "RootSetGenericCustomPostMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootSetGenericCustomPostMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting meta on a custom post"
-        },
-        {
-          "name": "RootSetGenericTagTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootSetGenericTagTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting meta on a tag term"
-        },
-        {
-          "name": "RootSetPostCategoryTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootSetPostCategoryTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting meta on a post's category term"
-        },
-        {
-          "name": "RootSetPostTagTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootSetPostTagTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting meta on a post's tag term"
-        },
-        {
-          "name": "RootSetTagsOnCustomPostMutationErrorPayloadUnion",
-          "namespacedName": "RootSetTagsOnCustomPostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting tags on a custom post"
-        },
-        {
-          "name": "RootSetTagsOnPostMutationErrorPayloadUnion",
-          "namespacedName": "RootSetTagsOnPostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting tags on a post"
-        },
-        {
-          "name": "RootSetUserMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootSetUserMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when setting meta on a user"
-        },
-        {
-          "name": "RootUpdateCommentMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateCommentMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating meta on a comment"
-        },
-        {
-          "name": "RootUpdateCommentMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateCommentMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating a comment"
-        },
-        {
-          "name": "RootUpdateCustomPostMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateCustomPostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating a custom post"
-        },
-        {
-          "name": "RootUpdateGenericCategoryTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateGenericCategoryTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating meta on a category term"
-        },
-        {
-          "name": "RootUpdateGenericCategoryTermMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateGenericCategoryTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating a category term"
-        },
-        {
-          "name": "RootUpdateGenericCustomPostMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateGenericCustomPostMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating meta on a custom post"
-        },
-        {
-          "name": "RootUpdateGenericTagTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateGenericTagTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating meta on a tag term"
-        },
-        {
-          "name": "RootUpdateGenericTagTermMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateGenericTagTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating a tag term"
-        },
-        {
-          "name": "RootUpdateMediaItemMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateMediaItemMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating the metadata for an attachment"
-        },
-        {
-          "name": "RootUpdateMenuMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateMenuMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating a menu"
-        },
-        {
-          "name": "RootUpdatePageMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdatePageMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating a page"
-        },
-        {
-          "name": "RootUpdatePostCategoryTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdatePostCategoryTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating meta on a post's category term"
-        },
-        {
-          "name": "RootUpdatePostCategoryTermMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdatePostCategoryTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating a post category term"
-        },
-        {
-          "name": "RootUpdatePostMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdatePostMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating a post"
-        },
-        {
-          "name": "RootUpdatePostTagTermMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdatePostTagTermMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating meta on a post's tag term"
-        },
-        {
-          "name": "RootUpdatePostTagTermMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdatePostTagTermMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating a post tag term"
-        },
-        {
-          "name": "RootUpdateUserMetaMutationErrorPayloadUnion",
-          "namespacedName": "RootUpdateUserMetaMutationErrorPayloadUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'Error Payload' types when updating meta on a user"
-        },
-        {
-          "name": "TagUnion",
-          "namespacedName": "TagUnion",
-          "fields": null,
-          "kind": "UNION",
-          "description": "Union of 'tag' type resolvers"
+    "data": {
+        "__schema": {
+            "types": [
+                {
+                    "name": "AccessToMetaKeyIsNotAllowedErrorPayload",
+                    "namespacedName": "AccessToMetaKeyIsNotAllowedErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"Access to the meta key is not allowed\""
+                },
+                {
+                    "name": "BlockType",
+                    "namespacedName": "BlockType",
+                    "fields": [
+                        {
+                            "name": "attributeNames"
+                        },
+                        {
+                            "name": "attributes"
+                        },
+                        {
+                            "name": "hasRenderCallback"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "supports"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "A block type registered in the WordPress block registry"
+                },
+                {
+                    "name": "BlockTypeAttribute",
+                    "namespacedName": "BlockTypeAttribute",
+                    "fields": [
+                        {
+                            "name": "autoGenerateControl"
+                        },
+                        {
+                            "name": "blockTypeName"
+                        },
+                        {
+                            "name": "default"
+                        },
+                        {
+                            "name": "enum"
+                        },
+                        {
+                            "name": "fieldType"
+                        },
+                        {
+                            "name": "label"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "role"
+                        },
+                        {
+                            "name": "schema"
+                        },
+                        {
+                            "name": "source"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "A registered attribute of a block type, as defined in its block.json schema"
+                },
+                {
+                    "name": "CannotDeleteYourselfErrorPayload",
+                    "namespacedName": "CannotDeleteYourselfErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user cannot delete themselves\""
+                },
+                {
+                    "name": "CategoryTermDoesNotExistErrorPayload",
+                    "namespacedName": "CategoryTermDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The requested category does not exist\""
+                },
+                {
+                    "name": "Comment",
+                    "namespacedName": "Comment",
+                    "fields": [
+                        {
+                            "name": "approved"
+                        },
+                        {
+                            "name": "author"
+                        },
+                        {
+                            "name": "authorEmail"
+                        },
+                        {
+                            "name": "authorIP"
+                        },
+                        {
+                            "name": "authorName"
+                        },
+                        {
+                            "name": "authorURL"
+                        },
+                        {
+                            "name": "content"
+                        },
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "date"
+                        },
+                        {
+                            "name": "dateStr"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "karma"
+                        },
+                        {
+                            "name": "meta"
+                        },
+                        {
+                            "name": "metaKeys"
+                        },
+                        {
+                            "name": "metaValue"
+                        },
+                        {
+                            "name": "metaValues"
+                        },
+                        {
+                            "name": "parent"
+                        },
+                        {
+                            "name": "rawContent"
+                        },
+                        {
+                            "name": "responseCount"
+                        },
+                        {
+                            "name": "responses"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "type"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Comments added to custom posts"
+                },
+                {
+                    "name": "CommentAuthorEmailIsMissingErrorPayload",
+                    "namespacedName": "CommentAuthorEmailIsMissingErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The comment's author email is missing\""
+                },
+                {
+                    "name": "CommentAuthorNameIsMissingErrorPayload",
+                    "namespacedName": "CommentAuthorNameIsMissingErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The comment's author name is missing\""
+                },
+                {
+                    "name": "CommentDoesNotExistErrorPayload",
+                    "namespacedName": "CommentDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The comment does not exist\""
+                },
+                {
+                    "name": "CommentDoesNotSupportTrashErrorPayload",
+                    "namespacedName": "CommentDoesNotSupportTrashErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The comment does not support being sent to the trash\""
+                },
+                {
+                    "name": "CommentHasAlreadyBeenTrashedErrorPayload",
+                    "namespacedName": "CommentHasAlreadyBeenTrashedErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The comment has already been sent to the trash\""
+                },
+                {
+                    "name": "CommentParentCommentDoesNotExistErrorPayload",
+                    "namespacedName": "CommentParentCommentDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The comment's parent does not exist\""
+                },
+                {
+                    "name": "CommentsAreNotOpenForCustomPostErrorPayload",
+                    "namespacedName": "CommentsAreNotOpenForCustomPostErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"Comments are not open for the custom post\""
+                },
+                {
+                    "name": "CommentsAreNotSupportedByCustomPostTypeErrorPayload",
+                    "namespacedName": "CommentsAreNotSupportedByCustomPostTypeErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"Comments are not supported by the custom post type\""
+                },
+                {
+                    "name": "CustomPostAncestorRecursionErrorPayload",
+                    "namespacedName": "CustomPostAncestorRecursionErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The custom post is an ancestor of itself\""
+                },
+                {
+                    "name": "CustomPostDoesNotExistErrorPayload",
+                    "namespacedName": "CustomPostDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The requested custom post does not exist\""
+                },
+                {
+                    "name": "CustomPostDoesNotHaveExpectedTypeErrorPayload",
+                    "namespacedName": "CustomPostDoesNotHaveExpectedTypeErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The requested custom post does not have the expected type\""
+                },
+                {
+                    "name": "CustomPostDoesNotSupportTrashErrorPayload",
+                    "namespacedName": "CustomPostDoesNotSupportTrashErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The custom post does not support being sent to the trash\""
+                },
+                {
+                    "name": "CustomPostHasAlreadyBeenTrashedErrorPayload",
+                    "namespacedName": "CustomPostHasAlreadyBeenTrashedErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The custom post has already been sent to the trash\""
+                },
+                {
+                    "name": "EmailAlreadyExistsErrorPayload",
+                    "namespacedName": "EmailAlreadyExistsErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The email already exists\""
+                },
+                {
+                    "name": "EntityMetaAlreadyHasSingleEntryErrorPayload",
+                    "namespacedName": "EntityMetaAlreadyHasSingleEntryErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The taxonomy term already has the single meta entry\""
+                },
+                {
+                    "name": "EntityMetaEntryAlreadyHasValueErrorPayload",
+                    "namespacedName": "EntityMetaEntryAlreadyHasValueErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The taxonomy term already has the meta entry with the provided update value\""
+                },
+                {
+                    "name": "EntityMetaKeyDoesNotExistErrorPayload",
+                    "namespacedName": "EntityMetaKeyDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The taxonomy term doesn't have a meta entry with that key\""
+                },
+                {
+                    "name": "EntityMetaKeyWithValueDoesNotExistErrorPayload",
+                    "namespacedName": "EntityMetaKeyWithValueDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The taxonomy term doesn't have a meta entry with that key\""
+                },
+                {
+                    "name": "FeaturedImageIsNotSupportedByCustomPostTypeErrorPayload",
+                    "namespacedName": "FeaturedImageIsNotSupportedByCustomPostTypeErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"Setting the featured image is not supported by the custom post type\""
+                },
+                {
+                    "name": "GeneralBlock",
+                    "namespacedName": "GeneralBlock",
+                    "fields": [
+                        {
+                            "name": "attributes"
+                        },
+                        {
+                            "name": "contentSource"
+                        },
+                        {
+                            "name": "innerBlocks"
+                        },
+                        {
+                            "name": "name"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of a Block that works for all blocks, retrieving the block attributes as a non-strictly-typed JSON object"
+                },
+                {
+                    "name": "GenericCategory",
+                    "namespacedName": "GenericCategory",
+                    "fields": [
+                        {
+                            "name": "ancestors"
+                        },
+                        {
+                            "name": "count"
+                        },
+                        {
+                            "name": "customPostCount"
+                        },
+                        {
+                            "name": "customPosts"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "meta"
+                        },
+                        {
+                            "name": "metaKeys"
+                        },
+                        {
+                            "name": "metaValue"
+                        },
+                        {
+                            "name": "metaValues"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "parent"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "slugPath"
+                        },
+                        {
+                            "name": "taxonomy"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "A category that does not have its own type in the schema"
+                },
+                {
+                    "name": "GenericCustomPost",
+                    "namespacedName": "GenericCustomPost",
+                    "fields": [
+                        {
+                            "name": "ancestors"
+                        },
+                        {
+                            "name": "areCommentsOpen"
+                        },
+                        {
+                            "name": "author"
+                        },
+                        {
+                            "name": "blockDataItems"
+                        },
+                        {
+                            "name": "blockFlattenedDataItems"
+                        },
+                        {
+                            "name": "blocks"
+                        },
+                        {
+                            "name": "categories"
+                        },
+                        {
+                            "name": "categoryCount"
+                        },
+                        {
+                            "name": "categoryNames"
+                        },
+                        {
+                            "name": "childCount"
+                        },
+                        {
+                            "name": "children"
+                        },
+                        {
+                            "name": "commentCount"
+                        },
+                        {
+                            "name": "comments"
+                        },
+                        {
+                            "name": "content"
+                        },
+                        {
+                            "name": "customPostType"
+                        },
+                        {
+                            "name": "date"
+                        },
+                        {
+                            "name": "dateStr"
+                        },
+                        {
+                            "name": "excerpt"
+                        },
+                        {
+                            "name": "featuredImage"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "hasComments"
+                        },
+                        {
+                            "name": "hasFeaturedImage"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "isStatus"
+                        },
+                        {
+                            "name": "menuOrder"
+                        },
+                        {
+                            "name": "meta"
+                        },
+                        {
+                            "name": "metaKeys"
+                        },
+                        {
+                            "name": "metaValue"
+                        },
+                        {
+                            "name": "metaValues"
+                        },
+                        {
+                            "name": "modifiedDate"
+                        },
+                        {
+                            "name": "modifiedDateStr"
+                        },
+                        {
+                            "name": "parent"
+                        },
+                        {
+                            "name": "rawContent"
+                        },
+                        {
+                            "name": "rawExcerpt"
+                        },
+                        {
+                            "name": "rawStatus"
+                        },
+                        {
+                            "name": "rawTitle"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "slugPath"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tagCount"
+                        },
+                        {
+                            "name": "tagNames"
+                        },
+                        {
+                            "name": "tags"
+                        },
+                        {
+                            "name": "title"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        },
+                        {
+                            "name": "wpAdminEditURL"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "A custom post that does not have its own type in the schema"
+                },
+                {
+                    "name": "GenericErrorPayload",
+                    "namespacedName": "GenericErrorPayload",
+                    "fields": [
+                        {
+                            "name": "code"
+                        },
+                        {
+                            "name": "data"
+                        },
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Generic error payload"
+                },
+                {
+                    "name": "GenericTag",
+                    "namespacedName": "GenericTag",
+                    "fields": [
+                        {
+                            "name": "count"
+                        },
+                        {
+                            "name": "customPostCount"
+                        },
+                        {
+                            "name": "customPosts"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "meta"
+                        },
+                        {
+                            "name": "metaKeys"
+                        },
+                        {
+                            "name": "metaValue"
+                        },
+                        {
+                            "name": "metaValues"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "taxonomy"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "A tag that does not have its own type in the schema"
+                },
+                {
+                    "name": "InvalidEmailErrorPayload",
+                    "namespacedName": "InvalidEmailErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The email is invalid\""
+                },
+                {
+                    "name": "InvalidUserEmailErrorPayload",
+                    "namespacedName": "InvalidUserEmailErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"No user is registered with the provided email\""
+                },
+                {
+                    "name": "InvalidUsernameErrorPayload",
+                    "namespacedName": "InvalidUsernameErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"No user is registered with the provided username\""
+                },
+                {
+                    "name": "LoggedInUserHasNoAssigningTermsToTaxonomyCapabilityErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoAssigningTermsToTaxonomyCapabilityErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to assign terms to a taxonomy\""
+                },
+                {
+                    "name": "LoggedInUserHasNoDeletingTaxonomyTermCapabilityErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoDeletingTaxonomyTermCapabilityErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to delete a taxonomy term\""
+                },
+                {
+                    "name": "LoggedInUserHasNoEditingCustomPostCapabilityErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoEditingCustomPostCapabilityErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to edit custom posts\""
+                },
+                {
+                    "name": "LoggedInUserHasNoEditingMediaCapabilityErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoEditingMediaCapabilityErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user cannot edit media items\""
+                },
+                {
+                    "name": "LoggedInUserHasNoEditingMenuCapabilityErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoEditingMenuCapabilityErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user cannot edit menus\""
+                },
+                {
+                    "name": "LoggedInUserHasNoEditingPageCapabilityErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoEditingPageCapabilityErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to edit pages\""
+                },
+                {
+                    "name": "LoggedInUserHasNoEditingTaxonomyTermsCapabilityErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoEditingTaxonomyTermsCapabilityErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to edit taxonomy terms\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToCreateUsersErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToCreateUsersErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user does not have permission to create users\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToDeleteCommentErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToDeleteCommentErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user has no permission to delete the comment\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToDeleteCustomPostErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToDeleteCustomPostErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to delete the requested custom post\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToDeleteMediaItemErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToDeleteMediaItemErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user has no permission to delete the media item\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToDeleteMenuErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToDeleteMenuErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user has no permission to delete the menu\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToDeleteUserErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToDeleteUserErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user does not have permission to delete the user\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToEditCommentErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToEditCommentErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to edit the comment\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToEditCustomPostErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToEditCustomPostErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to edit the requested custom post\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToEditMediaItemErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToEditMediaItemErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user has no permission to edit the media item\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToEditMenuErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToEditMenuErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user has no permission to edit the menu\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToEditUserErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToEditUserErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to edit the user\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPermissionToEditUserRolesErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPermissionToEditUserRolesErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user does not have permission to edit the user roles\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPublishingCustomPostCapabilityErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPublishingCustomPostCapabilityErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to publish custom posts\""
+                },
+                {
+                    "name": "LoggedInUserHasNoPublishingPageCapabilityErrorPayload",
+                    "namespacedName": "LoggedInUserHasNoPublishingPageCapabilityErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The logged-in user has no permission to publish pages\""
+                },
+                {
+                    "name": "Media",
+                    "namespacedName": "Media",
+                    "fields": [
+                        {
+                            "name": "altText"
+                        },
+                        {
+                            "name": "author"
+                        },
+                        {
+                            "name": "caption"
+                        },
+                        {
+                            "name": "date"
+                        },
+                        {
+                            "name": "dateStr"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "height"
+                        },
+                        {
+                            "name": "heights"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "mimeType"
+                        },
+                        {
+                            "name": "modifiedDate"
+                        },
+                        {
+                            "name": "modifiedDateStr"
+                        },
+                        {
+                            "name": "parentCustomPost"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "sizes"
+                        },
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "src"
+                        },
+                        {
+                            "name": "srcPath"
+                        },
+                        {
+                            "name": "srcSet"
+                        },
+                        {
+                            "name": "srcs"
+                        },
+                        {
+                            "name": "title"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        },
+                        {
+                            "name": "width"
+                        },
+                        {
+                            "name": "widths"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Media elements (such as images, videos, etc), attached to a post or independent"
+                },
+                {
+                    "name": "MediaItemDoesNotExistErrorPayload",
+                    "namespacedName": "MediaItemDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The requested media item does not exist\""
+                },
+                {
+                    "name": "MediaItemDoesNotSupportTrashErrorPayload",
+                    "namespacedName": "MediaItemDoesNotSupportTrashErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The media item does not support being sent to the trash\""
+                },
+                {
+                    "name": "MediaItemHasAlreadyBeenTrashedErrorPayload",
+                    "namespacedName": "MediaItemHasAlreadyBeenTrashedErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The media item has already been sent to the trash\""
+                },
+                {
+                    "name": "Menu",
+                    "namespacedName": "Menu",
+                    "fields": [
+                        {
+                            "name": "count"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "itemDataEntries"
+                        },
+                        {
+                            "name": "items"
+                        },
+                        {
+                            "name": "locations"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "slug"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of a navigation menu"
+                },
+                {
+                    "name": "MenuDoesNotExistErrorPayload",
+                    "namespacedName": "MenuDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The requested menu does not exist\""
+                },
+                {
+                    "name": "MenuItem",
+                    "namespacedName": "MenuItem",
+                    "fields": [
+                        {
+                            "name": "children"
+                        },
+                        {
+                            "name": "cssClasses"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "itemType"
+                        },
+                        {
+                            "name": "label"
+                        },
+                        {
+                            "name": "linkRelationship"
+                        },
+                        {
+                            "name": "localURLPath"
+                        },
+                        {
+                            "name": "objectID"
+                        },
+                        {
+                            "name": "objectType"
+                        },
+                        {
+                            "name": "parentID"
+                        },
+                        {
+                            "name": "rawLabel"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "target"
+                        },
+                        {
+                            "name": "titleAttribute"
+                        },
+                        {
+                            "name": "url"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Items (links, pages, etc) added to a menu"
+                },
+                {
+                    "name": "MutationRoot",
+                    "namespacedName": "MutationRoot",
+                    "fields": [
+                        {
+                            "name": "addCategoryMeta"
+                        },
+                        {
+                            "name": "addCategoryMetas"
+                        },
+                        {
+                            "name": "addCommentMeta"
+                        },
+                        {
+                            "name": "addCommentMetas"
+                        },
+                        {
+                            "name": "addCommentToCustomPost"
+                        },
+                        {
+                            "name": "addCommentToCustomPosts"
+                        },
+                        {
+                            "name": "addCustomPostMeta"
+                        },
+                        {
+                            "name": "addCustomPostMetas"
+                        },
+                        {
+                            "name": "addPostCategoryMeta"
+                        },
+                        {
+                            "name": "addPostCategoryMetas"
+                        },
+                        {
+                            "name": "addPostTagMeta"
+                        },
+                        {
+                            "name": "addPostTagMetas"
+                        },
+                        {
+                            "name": "addTagMeta"
+                        },
+                        {
+                            "name": "addTagMetas"
+                        },
+                        {
+                            "name": "addUserMeta"
+                        },
+                        {
+                            "name": "addUserMetas"
+                        },
+                        {
+                            "name": "createCategories"
+                        },
+                        {
+                            "name": "createCategory"
+                        },
+                        {
+                            "name": "createCustomPost"
+                        },
+                        {
+                            "name": "createCustomPosts"
+                        },
+                        {
+                            "name": "createMediaItem"
+                        },
+                        {
+                            "name": "createMediaItems"
+                        },
+                        {
+                            "name": "createMenu"
+                        },
+                        {
+                            "name": "createMenus"
+                        },
+                        {
+                            "name": "createPage"
+                        },
+                        {
+                            "name": "createPages"
+                        },
+                        {
+                            "name": "createPost"
+                        },
+                        {
+                            "name": "createPostCategories"
+                        },
+                        {
+                            "name": "createPostCategory"
+                        },
+                        {
+                            "name": "createPostTag"
+                        },
+                        {
+                            "name": "createPostTags"
+                        },
+                        {
+                            "name": "createPosts"
+                        },
+                        {
+                            "name": "createTag"
+                        },
+                        {
+                            "name": "createTags"
+                        },
+                        {
+                            "name": "createUser"
+                        },
+                        {
+                            "name": "createUsers"
+                        },
+                        {
+                            "name": "deleteCategories"
+                        },
+                        {
+                            "name": "deleteCategory"
+                        },
+                        {
+                            "name": "deleteCategoryMeta"
+                        },
+                        {
+                            "name": "deleteCategoryMetas"
+                        },
+                        {
+                            "name": "deleteComment"
+                        },
+                        {
+                            "name": "deleteCommentMeta"
+                        },
+                        {
+                            "name": "deleteCommentMetas"
+                        },
+                        {
+                            "name": "deleteComments"
+                        },
+                        {
+                            "name": "deleteCustomPost"
+                        },
+                        {
+                            "name": "deleteCustomPostMeta"
+                        },
+                        {
+                            "name": "deleteCustomPostMetas"
+                        },
+                        {
+                            "name": "deleteCustomPosts"
+                        },
+                        {
+                            "name": "deleteMediaItem"
+                        },
+                        {
+                            "name": "deleteMediaItems"
+                        },
+                        {
+                            "name": "deleteMenu"
+                        },
+                        {
+                            "name": "deleteMenus"
+                        },
+                        {
+                            "name": "deletePage"
+                        },
+                        {
+                            "name": "deletePages"
+                        },
+                        {
+                            "name": "deletePost"
+                        },
+                        {
+                            "name": "deletePostCategories"
+                        },
+                        {
+                            "name": "deletePostCategory"
+                        },
+                        {
+                            "name": "deletePostCategoryMeta"
+                        },
+                        {
+                            "name": "deletePostCategoryMetas"
+                        },
+                        {
+                            "name": "deletePostTag"
+                        },
+                        {
+                            "name": "deletePostTagMeta"
+                        },
+                        {
+                            "name": "deletePostTagMetas"
+                        },
+                        {
+                            "name": "deletePostTags"
+                        },
+                        {
+                            "name": "deletePosts"
+                        },
+                        {
+                            "name": "deleteTag"
+                        },
+                        {
+                            "name": "deleteTagMeta"
+                        },
+                        {
+                            "name": "deleteTagMetas"
+                        },
+                        {
+                            "name": "deleteTags"
+                        },
+                        {
+                            "name": "deleteUser"
+                        },
+                        {
+                            "name": "deleteUserMeta"
+                        },
+                        {
+                            "name": "deleteUserMetas"
+                        },
+                        {
+                            "name": "deleteUsers"
+                        },
+                        {
+                            "name": "loginUser"
+                        },
+                        {
+                            "name": "logoutUser"
+                        },
+                        {
+                            "name": "removeFeaturedImageFromCustomPost"
+                        },
+                        {
+                            "name": "removeFeaturedImageFromCustomPosts"
+                        },
+                        {
+                            "name": "replyComment"
+                        },
+                        {
+                            "name": "replyComments"
+                        },
+                        {
+                            "name": "setCategoriesOnCustomPost"
+                        },
+                        {
+                            "name": "setCategoriesOnCustomPosts"
+                        },
+                        {
+                            "name": "setCategoriesOnPost"
+                        },
+                        {
+                            "name": "setCategoriesOnPosts"
+                        },
+                        {
+                            "name": "setCategoryMeta"
+                        },
+                        {
+                            "name": "setCategoryMetas"
+                        },
+                        {
+                            "name": "setCommentMeta"
+                        },
+                        {
+                            "name": "setCommentMetas"
+                        },
+                        {
+                            "name": "setCustomPostMeta"
+                        },
+                        {
+                            "name": "setCustomPostMetas"
+                        },
+                        {
+                            "name": "setFeaturedImageOnCustomPost"
+                        },
+                        {
+                            "name": "setFeaturedImageOnCustomPosts"
+                        },
+                        {
+                            "name": "setPostCategoryMeta"
+                        },
+                        {
+                            "name": "setPostCategoryMetas"
+                        },
+                        {
+                            "name": "setPostTagMeta"
+                        },
+                        {
+                            "name": "setPostTagMetas"
+                        },
+                        {
+                            "name": "setTagMeta"
+                        },
+                        {
+                            "name": "setTagMetas"
+                        },
+                        {
+                            "name": "setTagsOnCustomPost"
+                        },
+                        {
+                            "name": "setTagsOnCustomPosts"
+                        },
+                        {
+                            "name": "setTagsOnPost"
+                        },
+                        {
+                            "name": "setTagsOnPosts"
+                        },
+                        {
+                            "name": "setUserMeta"
+                        },
+                        {
+                            "name": "setUserMetas"
+                        },
+                        {
+                            "name": "updateCategories"
+                        },
+                        {
+                            "name": "updateCategory"
+                        },
+                        {
+                            "name": "updateCategoryMeta"
+                        },
+                        {
+                            "name": "updateCategoryMetas"
+                        },
+                        {
+                            "name": "updateComment"
+                        },
+                        {
+                            "name": "updateCommentMeta"
+                        },
+                        {
+                            "name": "updateCommentMetas"
+                        },
+                        {
+                            "name": "updateComments"
+                        },
+                        {
+                            "name": "updateCustomPost"
+                        },
+                        {
+                            "name": "updateCustomPostMeta"
+                        },
+                        {
+                            "name": "updateCustomPostMetas"
+                        },
+                        {
+                            "name": "updateCustomPosts"
+                        },
+                        {
+                            "name": "updateMediaItem"
+                        },
+                        {
+                            "name": "updateMediaItems"
+                        },
+                        {
+                            "name": "updateMenu"
+                        },
+                        {
+                            "name": "updateMenus"
+                        },
+                        {
+                            "name": "updatePage"
+                        },
+                        {
+                            "name": "updatePages"
+                        },
+                        {
+                            "name": "updatePost"
+                        },
+                        {
+                            "name": "updatePostCategories"
+                        },
+                        {
+                            "name": "updatePostCategory"
+                        },
+                        {
+                            "name": "updatePostCategoryMeta"
+                        },
+                        {
+                            "name": "updatePostCategoryMetas"
+                        },
+                        {
+                            "name": "updatePostTag"
+                        },
+                        {
+                            "name": "updatePostTagMeta"
+                        },
+                        {
+                            "name": "updatePostTagMetas"
+                        },
+                        {
+                            "name": "updatePostTags"
+                        },
+                        {
+                            "name": "updatePosts"
+                        },
+                        {
+                            "name": "updateTag"
+                        },
+                        {
+                            "name": "updateTagMeta"
+                        },
+                        {
+                            "name": "updateTagMetas"
+                        },
+                        {
+                            "name": "updateTags"
+                        },
+                        {
+                            "name": "updateUser"
+                        },
+                        {
+                            "name": "updateUserMeta"
+                        },
+                        {
+                            "name": "updateUserMetas"
+                        },
+                        {
+                            "name": "updateUsers"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Mutation type, starting from which mutations are executed"
+                },
+                {
+                    "name": "Page",
+                    "namespacedName": "Page",
+                    "fields": [
+                        {
+                            "name": "ancestors"
+                        },
+                        {
+                            "name": "areCommentsOpen"
+                        },
+                        {
+                            "name": "author"
+                        },
+                        {
+                            "name": "blockDataItems"
+                        },
+                        {
+                            "name": "blockFlattenedDataItems"
+                        },
+                        {
+                            "name": "blocks"
+                        },
+                        {
+                            "name": "childCount"
+                        },
+                        {
+                            "name": "children"
+                        },
+                        {
+                            "name": "commentCount"
+                        },
+                        {
+                            "name": "comments"
+                        },
+                        {
+                            "name": "content"
+                        },
+                        {
+                            "name": "customPostType"
+                        },
+                        {
+                            "name": "date"
+                        },
+                        {
+                            "name": "dateStr"
+                        },
+                        {
+                            "name": "excerpt"
+                        },
+                        {
+                            "name": "featuredImage"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "hasComments"
+                        },
+                        {
+                            "name": "hasFeaturedImage"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "isStatus"
+                        },
+                        {
+                            "name": "menuOrder"
+                        },
+                        {
+                            "name": "meta"
+                        },
+                        {
+                            "name": "metaKeys"
+                        },
+                        {
+                            "name": "metaValue"
+                        },
+                        {
+                            "name": "metaValues"
+                        },
+                        {
+                            "name": "modifiedDate"
+                        },
+                        {
+                            "name": "modifiedDateStr"
+                        },
+                        {
+                            "name": "parent"
+                        },
+                        {
+                            "name": "rawContent"
+                        },
+                        {
+                            "name": "rawExcerpt"
+                        },
+                        {
+                            "name": "rawStatus"
+                        },
+                        {
+                            "name": "rawTitle"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "slugPath"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "title"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        },
+                        {
+                            "name": "wpAdminEditURL"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of a page"
+                },
+                {
+                    "name": "PasswordIsIncorrectErrorPayload",
+                    "namespacedName": "PasswordIsIncorrectErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The password is incorrect\""
+                },
+                {
+                    "name": "Post",
+                    "namespacedName": "Post",
+                    "fields": [
+                        {
+                            "name": "areCommentsOpen"
+                        },
+                        {
+                            "name": "author"
+                        },
+                        {
+                            "name": "blockDataItems"
+                        },
+                        {
+                            "name": "blockFlattenedDataItems"
+                        },
+                        {
+                            "name": "blocks"
+                        },
+                        {
+                            "name": "categories"
+                        },
+                        {
+                            "name": "categoryCount"
+                        },
+                        {
+                            "name": "categoryNames"
+                        },
+                        {
+                            "name": "commentCount"
+                        },
+                        {
+                            "name": "comments"
+                        },
+                        {
+                            "name": "content"
+                        },
+                        {
+                            "name": "customPostType"
+                        },
+                        {
+                            "name": "date"
+                        },
+                        {
+                            "name": "dateStr"
+                        },
+                        {
+                            "name": "excerpt"
+                        },
+                        {
+                            "name": "featuredImage"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "hasComments"
+                        },
+                        {
+                            "name": "hasFeaturedImage"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "isStatus"
+                        },
+                        {
+                            "name": "isSticky"
+                        },
+                        {
+                            "name": "menuOrder"
+                        },
+                        {
+                            "name": "meta"
+                        },
+                        {
+                            "name": "metaKeys"
+                        },
+                        {
+                            "name": "metaValue"
+                        },
+                        {
+                            "name": "metaValues"
+                        },
+                        {
+                            "name": "modifiedDate"
+                        },
+                        {
+                            "name": "modifiedDateStr"
+                        },
+                        {
+                            "name": "postFormat"
+                        },
+                        {
+                            "name": "rawContent"
+                        },
+                        {
+                            "name": "rawExcerpt"
+                        },
+                        {
+                            "name": "rawStatus"
+                        },
+                        {
+                            "name": "rawTitle"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "slugPath"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tagCount"
+                        },
+                        {
+                            "name": "tagNames"
+                        },
+                        {
+                            "name": "tags"
+                        },
+                        {
+                            "name": "title"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        },
+                        {
+                            "name": "wpAdminEditURL"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of a post"
+                },
+                {
+                    "name": "PostCategory",
+                    "namespacedName": "PostCategory",
+                    "fields": [
+                        {
+                            "name": "ancestors"
+                        },
+                        {
+                            "name": "childCount"
+                        },
+                        {
+                            "name": "childNames"
+                        },
+                        {
+                            "name": "children"
+                        },
+                        {
+                            "name": "count"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "meta"
+                        },
+                        {
+                            "name": "metaKeys"
+                        },
+                        {
+                            "name": "metaValue"
+                        },
+                        {
+                            "name": "metaValues"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "parent"
+                        },
+                        {
+                            "name": "postCount"
+                        },
+                        {
+                            "name": "posts"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "slugPath"
+                        },
+                        {
+                            "name": "taxonomy"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of a category, added to a post (taxonomy: \"category\")"
+                },
+                {
+                    "name": "PostTag",
+                    "namespacedName": "PostTag",
+                    "fields": [
+                        {
+                            "name": "count"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "meta"
+                        },
+                        {
+                            "name": "metaKeys"
+                        },
+                        {
+                            "name": "metaValue"
+                        },
+                        {
+                            "name": "metaValues"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "postCount"
+                        },
+                        {
+                            "name": "posts"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "taxonomy"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of a tag, added to a post (taxonomy: \"post_tag\")"
+                },
+                {
+                    "name": "QueryRoot",
+                    "namespacedName": "QueryRoot",
+                    "fields": [
+                        {
+                            "name": "blockTypes"
+                        },
+                        {
+                            "name": "capabilities"
+                        },
+                        {
+                            "name": "categories"
+                        },
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryCount"
+                        },
+                        {
+                            "name": "categoryNames"
+                        },
+                        {
+                            "name": "comment"
+                        },
+                        {
+                            "name": "commentCount"
+                        },
+                        {
+                            "name": "comments"
+                        },
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostCount"
+                        },
+                        {
+                            "name": "customPosts"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "imageSizeNames"
+                        },
+                        {
+                            "name": "isGutenbergEditorEnabled"
+                        },
+                        {
+                            "name": "isUserLoggedIn"
+                        },
+                        {
+                            "name": "loggedInUserID"
+                        },
+                        {
+                            "name": "me"
+                        },
+                        {
+                            "name": "mediaItem"
+                        },
+                        {
+                            "name": "mediaItemCount"
+                        },
+                        {
+                            "name": "mediaItems"
+                        },
+                        {
+                            "name": "menu"
+                        },
+                        {
+                            "name": "menuCount"
+                        },
+                        {
+                            "name": "menus"
+                        },
+                        {
+                            "name": "myComment"
+                        },
+                        {
+                            "name": "myCommentCount"
+                        },
+                        {
+                            "name": "myComments"
+                        },
+                        {
+                            "name": "myCustomPost"
+                        },
+                        {
+                            "name": "myCustomPostCount"
+                        },
+                        {
+                            "name": "myCustomPosts"
+                        },
+                        {
+                            "name": "myMediaItem"
+                        },
+                        {
+                            "name": "myMediaItemCount"
+                        },
+                        {
+                            "name": "myMediaItems"
+                        },
+                        {
+                            "name": "myPage"
+                        },
+                        {
+                            "name": "myPageCount"
+                        },
+                        {
+                            "name": "myPages"
+                        },
+                        {
+                            "name": "myPost"
+                        },
+                        {
+                            "name": "myPostCount"
+                        },
+                        {
+                            "name": "myPosts"
+                        },
+                        {
+                            "name": "optionNames"
+                        },
+                        {
+                            "name": "optionObjectValue"
+                        },
+                        {
+                            "name": "optionObjectValues"
+                        },
+                        {
+                            "name": "optionValue"
+                        },
+                        {
+                            "name": "optionValues"
+                        },
+                        {
+                            "name": "options"
+                        },
+                        {
+                            "name": "page"
+                        },
+                        {
+                            "name": "pageBuilders"
+                        },
+                        {
+                            "name": "pageCount"
+                        },
+                        {
+                            "name": "pages"
+                        },
+                        {
+                            "name": "post"
+                        },
+                        {
+                            "name": "postCategories"
+                        },
+                        {
+                            "name": "postCategory"
+                        },
+                        {
+                            "name": "postCategoryCount"
+                        },
+                        {
+                            "name": "postCategoryNames"
+                        },
+                        {
+                            "name": "postCount"
+                        },
+                        {
+                            "name": "postTag"
+                        },
+                        {
+                            "name": "postTagCount"
+                        },
+                        {
+                            "name": "postTagNames"
+                        },
+                        {
+                            "name": "postTags"
+                        },
+                        {
+                            "name": "posts"
+                        },
+                        {
+                            "name": "roleNames"
+                        },
+                        {
+                            "name": "roles"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "siteLanguage"
+                        },
+                        {
+                            "name": "siteLocale"
+                        },
+                        {
+                            "name": "siteURL"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagCount"
+                        },
+                        {
+                            "name": "tagNames"
+                        },
+                        {
+                            "name": "tags"
+                        },
+                        {
+                            "name": "useGutenbergEditorWithCustomPostType"
+                        },
+                        {
+                            "name": "useWhichPageBuilderWithCustomPostType"
+                        },
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "userCount"
+                        },
+                        {
+                            "name": "users"
+                        },
+                        {
+                            "name": "_urlToCustomPostID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Query type, starting from which the query is executed"
+                },
+                {
+                    "name": "ReassignUserDoesNotExistErrorPayload",
+                    "namespacedName": "ReassignUserDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user to reassign the content to does not exist\""
+                },
+                {
+                    "name": "Root",
+                    "namespacedName": "Root",
+                    "fields": [
+                        {
+                            "name": "addCategoryMeta"
+                        },
+                        {
+                            "name": "addCategoryMetas"
+                        },
+                        {
+                            "name": "addCommentMeta"
+                        },
+                        {
+                            "name": "addCommentMetas"
+                        },
+                        {
+                            "name": "addCommentToCustomPost"
+                        },
+                        {
+                            "name": "addCommentToCustomPosts"
+                        },
+                        {
+                            "name": "addCustomPostMeta"
+                        },
+                        {
+                            "name": "addCustomPostMetas"
+                        },
+                        {
+                            "name": "addPostCategoryMeta"
+                        },
+                        {
+                            "name": "addPostCategoryMetas"
+                        },
+                        {
+                            "name": "addPostTagMeta"
+                        },
+                        {
+                            "name": "addPostTagMetas"
+                        },
+                        {
+                            "name": "addTagMeta"
+                        },
+                        {
+                            "name": "addTagMetas"
+                        },
+                        {
+                            "name": "addUserMeta"
+                        },
+                        {
+                            "name": "addUserMetas"
+                        },
+                        {
+                            "name": "blockTypes"
+                        },
+                        {
+                            "name": "capabilities"
+                        },
+                        {
+                            "name": "categories"
+                        },
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryCount"
+                        },
+                        {
+                            "name": "categoryNames"
+                        },
+                        {
+                            "name": "comment"
+                        },
+                        {
+                            "name": "commentCount"
+                        },
+                        {
+                            "name": "comments"
+                        },
+                        {
+                            "name": "createCategories"
+                        },
+                        {
+                            "name": "createCategory"
+                        },
+                        {
+                            "name": "createCustomPost"
+                        },
+                        {
+                            "name": "createCustomPosts"
+                        },
+                        {
+                            "name": "createMediaItem"
+                        },
+                        {
+                            "name": "createMediaItems"
+                        },
+                        {
+                            "name": "createMenu"
+                        },
+                        {
+                            "name": "createMenus"
+                        },
+                        {
+                            "name": "createPage"
+                        },
+                        {
+                            "name": "createPages"
+                        },
+                        {
+                            "name": "createPost"
+                        },
+                        {
+                            "name": "createPostCategories"
+                        },
+                        {
+                            "name": "createPostCategory"
+                        },
+                        {
+                            "name": "createPostTag"
+                        },
+                        {
+                            "name": "createPostTags"
+                        },
+                        {
+                            "name": "createPosts"
+                        },
+                        {
+                            "name": "createTag"
+                        },
+                        {
+                            "name": "createTags"
+                        },
+                        {
+                            "name": "createUser"
+                        },
+                        {
+                            "name": "createUsers"
+                        },
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostCount"
+                        },
+                        {
+                            "name": "customPosts"
+                        },
+                        {
+                            "name": "deleteCategories"
+                        },
+                        {
+                            "name": "deleteCategory"
+                        },
+                        {
+                            "name": "deleteCategoryMeta"
+                        },
+                        {
+                            "name": "deleteCategoryMetas"
+                        },
+                        {
+                            "name": "deleteComment"
+                        },
+                        {
+                            "name": "deleteCommentMeta"
+                        },
+                        {
+                            "name": "deleteCommentMetas"
+                        },
+                        {
+                            "name": "deleteComments"
+                        },
+                        {
+                            "name": "deleteCustomPost"
+                        },
+                        {
+                            "name": "deleteCustomPostMeta"
+                        },
+                        {
+                            "name": "deleteCustomPostMetas"
+                        },
+                        {
+                            "name": "deleteCustomPosts"
+                        },
+                        {
+                            "name": "deleteMediaItem"
+                        },
+                        {
+                            "name": "deleteMediaItems"
+                        },
+                        {
+                            "name": "deleteMenu"
+                        },
+                        {
+                            "name": "deleteMenus"
+                        },
+                        {
+                            "name": "deletePage"
+                        },
+                        {
+                            "name": "deletePages"
+                        },
+                        {
+                            "name": "deletePost"
+                        },
+                        {
+                            "name": "deletePostCategories"
+                        },
+                        {
+                            "name": "deletePostCategory"
+                        },
+                        {
+                            "name": "deletePostCategoryMeta"
+                        },
+                        {
+                            "name": "deletePostCategoryMetas"
+                        },
+                        {
+                            "name": "deletePostTag"
+                        },
+                        {
+                            "name": "deletePostTagMeta"
+                        },
+                        {
+                            "name": "deletePostTagMetas"
+                        },
+                        {
+                            "name": "deletePostTags"
+                        },
+                        {
+                            "name": "deletePosts"
+                        },
+                        {
+                            "name": "deleteTag"
+                        },
+                        {
+                            "name": "deleteTagMeta"
+                        },
+                        {
+                            "name": "deleteTagMetas"
+                        },
+                        {
+                            "name": "deleteTags"
+                        },
+                        {
+                            "name": "deleteUser"
+                        },
+                        {
+                            "name": "deleteUserMeta"
+                        },
+                        {
+                            "name": "deleteUserMetas"
+                        },
+                        {
+                            "name": "deleteUsers"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "imageSizeNames"
+                        },
+                        {
+                            "name": "isGutenbergEditorEnabled"
+                        },
+                        {
+                            "name": "isUserLoggedIn"
+                        },
+                        {
+                            "name": "loggedInUserID"
+                        },
+                        {
+                            "name": "loginUser"
+                        },
+                        {
+                            "name": "logoutUser"
+                        },
+                        {
+                            "name": "me"
+                        },
+                        {
+                            "name": "mediaItem"
+                        },
+                        {
+                            "name": "mediaItemCount"
+                        },
+                        {
+                            "name": "mediaItems"
+                        },
+                        {
+                            "name": "menu"
+                        },
+                        {
+                            "name": "menuCount"
+                        },
+                        {
+                            "name": "menus"
+                        },
+                        {
+                            "name": "myComment"
+                        },
+                        {
+                            "name": "myCommentCount"
+                        },
+                        {
+                            "name": "myComments"
+                        },
+                        {
+                            "name": "myCustomPost"
+                        },
+                        {
+                            "name": "myCustomPostCount"
+                        },
+                        {
+                            "name": "myCustomPosts"
+                        },
+                        {
+                            "name": "myMediaItem"
+                        },
+                        {
+                            "name": "myMediaItemCount"
+                        },
+                        {
+                            "name": "myMediaItems"
+                        },
+                        {
+                            "name": "myPage"
+                        },
+                        {
+                            "name": "myPageCount"
+                        },
+                        {
+                            "name": "myPages"
+                        },
+                        {
+                            "name": "myPost"
+                        },
+                        {
+                            "name": "myPostCount"
+                        },
+                        {
+                            "name": "myPosts"
+                        },
+                        {
+                            "name": "optionNames"
+                        },
+                        {
+                            "name": "optionObjectValue"
+                        },
+                        {
+                            "name": "optionObjectValues"
+                        },
+                        {
+                            "name": "optionValue"
+                        },
+                        {
+                            "name": "optionValues"
+                        },
+                        {
+                            "name": "options"
+                        },
+                        {
+                            "name": "page"
+                        },
+                        {
+                            "name": "pageBuilders"
+                        },
+                        {
+                            "name": "pageCount"
+                        },
+                        {
+                            "name": "pages"
+                        },
+                        {
+                            "name": "post"
+                        },
+                        {
+                            "name": "postCategories"
+                        },
+                        {
+                            "name": "postCategory"
+                        },
+                        {
+                            "name": "postCategoryCount"
+                        },
+                        {
+                            "name": "postCategoryNames"
+                        },
+                        {
+                            "name": "postCount"
+                        },
+                        {
+                            "name": "postTag"
+                        },
+                        {
+                            "name": "postTagCount"
+                        },
+                        {
+                            "name": "postTagNames"
+                        },
+                        {
+                            "name": "postTags"
+                        },
+                        {
+                            "name": "posts"
+                        },
+                        {
+                            "name": "removeFeaturedImageFromCustomPost"
+                        },
+                        {
+                            "name": "removeFeaturedImageFromCustomPosts"
+                        },
+                        {
+                            "name": "replyComment"
+                        },
+                        {
+                            "name": "replyComments"
+                        },
+                        {
+                            "name": "roleNames"
+                        },
+                        {
+                            "name": "roles"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "setCategoriesOnCustomPost"
+                        },
+                        {
+                            "name": "setCategoriesOnCustomPosts"
+                        },
+                        {
+                            "name": "setCategoriesOnPost"
+                        },
+                        {
+                            "name": "setCategoriesOnPosts"
+                        },
+                        {
+                            "name": "setCategoryMeta"
+                        },
+                        {
+                            "name": "setCategoryMetas"
+                        },
+                        {
+                            "name": "setCommentMeta"
+                        },
+                        {
+                            "name": "setCommentMetas"
+                        },
+                        {
+                            "name": "setCustomPostMeta"
+                        },
+                        {
+                            "name": "setCustomPostMetas"
+                        },
+                        {
+                            "name": "setFeaturedImageOnCustomPost"
+                        },
+                        {
+                            "name": "setFeaturedImageOnCustomPosts"
+                        },
+                        {
+                            "name": "setPostCategoryMeta"
+                        },
+                        {
+                            "name": "setPostCategoryMetas"
+                        },
+                        {
+                            "name": "setPostTagMeta"
+                        },
+                        {
+                            "name": "setPostTagMetas"
+                        },
+                        {
+                            "name": "setTagMeta"
+                        },
+                        {
+                            "name": "setTagMetas"
+                        },
+                        {
+                            "name": "setTagsOnCustomPost"
+                        },
+                        {
+                            "name": "setTagsOnCustomPosts"
+                        },
+                        {
+                            "name": "setTagsOnPost"
+                        },
+                        {
+                            "name": "setTagsOnPosts"
+                        },
+                        {
+                            "name": "setUserMeta"
+                        },
+                        {
+                            "name": "setUserMetas"
+                        },
+                        {
+                            "name": "siteLanguage"
+                        },
+                        {
+                            "name": "siteLocale"
+                        },
+                        {
+                            "name": "siteURL"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagCount"
+                        },
+                        {
+                            "name": "tagNames"
+                        },
+                        {
+                            "name": "tags"
+                        },
+                        {
+                            "name": "updateCategories"
+                        },
+                        {
+                            "name": "updateCategory"
+                        },
+                        {
+                            "name": "updateCategoryMeta"
+                        },
+                        {
+                            "name": "updateCategoryMetas"
+                        },
+                        {
+                            "name": "updateComment"
+                        },
+                        {
+                            "name": "updateCommentMeta"
+                        },
+                        {
+                            "name": "updateCommentMetas"
+                        },
+                        {
+                            "name": "updateComments"
+                        },
+                        {
+                            "name": "updateCustomPost"
+                        },
+                        {
+                            "name": "updateCustomPostMeta"
+                        },
+                        {
+                            "name": "updateCustomPostMetas"
+                        },
+                        {
+                            "name": "updateCustomPosts"
+                        },
+                        {
+                            "name": "updateMediaItem"
+                        },
+                        {
+                            "name": "updateMediaItems"
+                        },
+                        {
+                            "name": "updateMenu"
+                        },
+                        {
+                            "name": "updateMenus"
+                        },
+                        {
+                            "name": "updatePage"
+                        },
+                        {
+                            "name": "updatePages"
+                        },
+                        {
+                            "name": "updatePost"
+                        },
+                        {
+                            "name": "updatePostCategories"
+                        },
+                        {
+                            "name": "updatePostCategory"
+                        },
+                        {
+                            "name": "updatePostCategoryMeta"
+                        },
+                        {
+                            "name": "updatePostCategoryMetas"
+                        },
+                        {
+                            "name": "updatePostTag"
+                        },
+                        {
+                            "name": "updatePostTagMeta"
+                        },
+                        {
+                            "name": "updatePostTagMetas"
+                        },
+                        {
+                            "name": "updatePostTags"
+                        },
+                        {
+                            "name": "updatePosts"
+                        },
+                        {
+                            "name": "updateTag"
+                        },
+                        {
+                            "name": "updateTagMeta"
+                        },
+                        {
+                            "name": "updateTagMetas"
+                        },
+                        {
+                            "name": "updateTags"
+                        },
+                        {
+                            "name": "updateUser"
+                        },
+                        {
+                            "name": "updateUserMeta"
+                        },
+                        {
+                            "name": "updateUserMetas"
+                        },
+                        {
+                            "name": "updateUsers"
+                        },
+                        {
+                            "name": "useGutenbergEditorWithCustomPostType"
+                        },
+                        {
+                            "name": "useWhichPageBuilderWithCustomPostType"
+                        },
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "userCount"
+                        },
+                        {
+                            "name": "users"
+                        },
+                        {
+                            "name": "_urlToCustomPostID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Root type, starting from which the query is executed"
+                },
+                {
+                    "name": "RootAddCommentMetaMutationPayload",
+                    "namespacedName": "RootAddCommentMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "comment"
+                        },
+                        {
+                            "name": "commentID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of adding meta to a comment"
+                },
+                {
+                    "name": "RootAddCommentToCustomPostMutationPayload",
+                    "namespacedName": "RootAddCommentToCustomPostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "comment"
+                        },
+                        {
+                            "name": "commentID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of adding a comment to a custom post"
+                },
+                {
+                    "name": "RootAddGenericCategoryTermMetaMutationPayload",
+                    "namespacedName": "RootAddGenericCategoryTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of adding meta to a category term"
+                },
+                {
+                    "name": "RootAddGenericCustomPostMetaMutationPayload",
+                    "namespacedName": "RootAddGenericCustomPostMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of adding meta to a custom post"
+                },
+                {
+                    "name": "RootAddGenericTagTermMetaMutationPayload",
+                    "namespacedName": "RootAddGenericTagTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of adding meta to a tag term"
+                },
+                {
+                    "name": "RootAddPostCategoryTermMetaMutationPayload",
+                    "namespacedName": "RootAddPostCategoryTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of adding meta to a posts's category term"
+                },
+                {
+                    "name": "RootAddPostTagTermMetaMutationPayload",
+                    "namespacedName": "RootAddPostTagTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of adding meta to a posts's tag term"
+                },
+                {
+                    "name": "RootAddUserMetaMutationPayload",
+                    "namespacedName": "RootAddUserMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "userID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of adding meta to a user"
+                },
+                {
+                    "name": "RootCreateCustomPostMutationPayload",
+                    "namespacedName": "RootCreateCustomPostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of creating a custom post"
+                },
+                {
+                    "name": "RootCreateGenericCategoryTermMutationPayload",
+                    "namespacedName": "RootCreateGenericCategoryTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of creating a category term"
+                },
+                {
+                    "name": "RootCreateGenericTagTermMutationPayload",
+                    "namespacedName": "RootCreateGenericTagTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of creating a tag term"
+                },
+                {
+                    "name": "RootCreateMediaItemMutationPayload",
+                    "namespacedName": "RootCreateMediaItemMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "mediaItem"
+                        },
+                        {
+                            "name": "mediaItemID"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of uploading an attachment"
+                },
+                {
+                    "name": "RootCreateMenuMutationPayload",
+                    "namespacedName": "RootCreateMenuMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "menu"
+                        },
+                        {
+                            "name": "menuID"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of creating a menu"
+                },
+                {
+                    "name": "RootCreatePageMutationPayload",
+                    "namespacedName": "RootCreatePageMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "page"
+                        },
+                        {
+                            "name": "pageID"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of creating a page"
+                },
+                {
+                    "name": "RootCreatePostCategoryTermMutationPayload",
+                    "namespacedName": "RootCreatePostCategoryTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of creating a post category term"
+                },
+                {
+                    "name": "RootCreatePostMutationPayload",
+                    "namespacedName": "RootCreatePostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "post"
+                        },
+                        {
+                            "name": "postID"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of creating a post"
+                },
+                {
+                    "name": "RootCreatePostTagTermMutationPayload",
+                    "namespacedName": "RootCreatePostTagTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of creating a post tag term"
+                },
+                {
+                    "name": "RootCreateUserMutationPayload",
+                    "namespacedName": "RootCreateUserMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "userID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of creating a user"
+                },
+                {
+                    "name": "RootDeleteCommentMetaMutationPayload",
+                    "namespacedName": "RootDeleteCommentMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "comment"
+                        },
+                        {
+                            "name": "commentID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete meta mutation on a comment"
+                },
+                {
+                    "name": "RootDeleteCommentMutationPayload",
+                    "namespacedName": "RootDeleteCommentMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of deleting a comment"
+                },
+                {
+                    "name": "RootDeleteCustomPostMutationPayload",
+                    "namespacedName": "RootDeleteCustomPostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete mutation on a custom post"
+                },
+                {
+                    "name": "RootDeleteGenericCategoryTermMetaMutationPayload",
+                    "namespacedName": "RootDeleteGenericCategoryTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete meta mutation on a category term"
+                },
+                {
+                    "name": "RootDeleteGenericCategoryTermMutationPayload",
+                    "namespacedName": "RootDeleteGenericCategoryTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete mutation on a category term"
+                },
+                {
+                    "name": "RootDeleteGenericCustomPostMetaMutationPayload",
+                    "namespacedName": "RootDeleteGenericCustomPostMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete meta mutation on a custom post"
+                },
+                {
+                    "name": "RootDeleteGenericTagTermMetaMutationPayload",
+                    "namespacedName": "RootDeleteGenericTagTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete meta mutation on a tag term"
+                },
+                {
+                    "name": "RootDeleteGenericTagTermMutationPayload",
+                    "namespacedName": "RootDeleteGenericTagTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete mutation on a tag term"
+                },
+                {
+                    "name": "RootDeleteMediaItemMutationPayload",
+                    "namespacedName": "RootDeleteMediaItemMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of deleting an attachment"
+                },
+                {
+                    "name": "RootDeleteMenuMutationPayload",
+                    "namespacedName": "RootDeleteMenuMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of deleting a menu"
+                },
+                {
+                    "name": "RootDeletePageMutationPayload",
+                    "namespacedName": "RootDeletePageMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete mutation on a page"
+                },
+                {
+                    "name": "RootDeletePostCategoryTermMetaMutationPayload",
+                    "namespacedName": "RootDeletePostCategoryTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete meta mutation on a post's category term"
+                },
+                {
+                    "name": "RootDeletePostCategoryTermMutationPayload",
+                    "namespacedName": "RootDeletePostCategoryTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete mutation on a post category term"
+                },
+                {
+                    "name": "RootDeletePostMutationPayload",
+                    "namespacedName": "RootDeletePostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete mutation on a post"
+                },
+                {
+                    "name": "RootDeletePostTagTermMetaMutationPayload",
+                    "namespacedName": "RootDeletePostTagTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete meta mutation on a post's tag term"
+                },
+                {
+                    "name": "RootDeletePostTagTermMutationPayload",
+                    "namespacedName": "RootDeletePostTagTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete mutation on a post tag term"
+                },
+                {
+                    "name": "RootDeleteUserMetaMutationPayload",
+                    "namespacedName": "RootDeleteUserMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "userID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a delete meta mutation on a user"
+                },
+                {
+                    "name": "RootDeleteUserMutationPayload",
+                    "namespacedName": "RootDeleteUserMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of deleting a user"
+                },
+                {
+                    "name": "RootLoginUserMutationPayload",
+                    "namespacedName": "RootLoginUserMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "userID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of logging the user in"
+                },
+                {
+                    "name": "RootLogoutUserMutationPayload",
+                    "namespacedName": "RootLogoutUserMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "userID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of logging the user out"
+                },
+                {
+                    "name": "RootRemoveFeaturedImageFromCustomPostMutationPayload",
+                    "namespacedName": "RootRemoveFeaturedImageFromCustomPostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of removing the featured image from a custom post"
+                },
+                {
+                    "name": "RootReplyCommentMutationPayload",
+                    "namespacedName": "RootReplyCommentMutationPayload",
+                    "fields": [
+                        {
+                            "name": "comment"
+                        },
+                        {
+                            "name": "commentID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of replying to a comment"
+                },
+                {
+                    "name": "RootSetCategoriesOnCustomPostMutationPayload",
+                    "namespacedName": "RootSetCategoriesOnCustomPostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of setting categories on a custom post"
+                },
+                {
+                    "name": "RootSetCategoriesOnPostMutationPayload",
+                    "namespacedName": "RootSetCategoriesOnPostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "post"
+                        },
+                        {
+                            "name": "postID"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of setting categories on a post"
+                },
+                {
+                    "name": "RootSetCommentMetaMutationPayload",
+                    "namespacedName": "RootSetCommentMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "comment"
+                        },
+                        {
+                            "name": "commentID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a set meta mutation on a comment"
+                },
+                {
+                    "name": "RootSetFeaturedImageOnCustomPostMutationPayload",
+                    "namespacedName": "RootSetFeaturedImageOnCustomPostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of setting the featured image to a custom post"
+                },
+                {
+                    "name": "RootSetGenericCategoryTermMetaMutationPayload",
+                    "namespacedName": "RootSetGenericCategoryTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a set meta mutation on a category term"
+                },
+                {
+                    "name": "RootSetGenericCustomPostMetaMutationPayload",
+                    "namespacedName": "RootSetGenericCustomPostMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a set meta mutation on a custom post"
+                },
+                {
+                    "name": "RootSetGenericTagTermMetaMutationPayload",
+                    "namespacedName": "RootSetGenericTagTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a set meta mutation on a tag term"
+                },
+                {
+                    "name": "RootSetPostCategoryTermMetaMutationPayload",
+                    "namespacedName": "RootSetPostCategoryTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a set meta mutation on a post's category term"
+                },
+                {
+                    "name": "RootSetPostTagTermMetaMutationPayload",
+                    "namespacedName": "RootSetPostTagTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a set meta mutation on a post's tag term"
+                },
+                {
+                    "name": "RootSetTagsOnCustomPostMutationPayload",
+                    "namespacedName": "RootSetTagsOnCustomPostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of setting tags on a custom post"
+                },
+                {
+                    "name": "RootSetTagsOnPostMutationPayload",
+                    "namespacedName": "RootSetTagsOnPostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "post"
+                        },
+                        {
+                            "name": "postID"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of setting tags on a post"
+                },
+                {
+                    "name": "RootSetUserMetaMutationPayload",
+                    "namespacedName": "RootSetUserMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "userID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing a set meta mutation on a user"
+                },
+                {
+                    "name": "RootUpdateCommentMetaMutationPayload",
+                    "namespacedName": "RootUpdateCommentMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "comment"
+                        },
+                        {
+                            "name": "commentID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update meta mutation on a comment"
+                },
+                {
+                    "name": "RootUpdateCommentMutationPayload",
+                    "namespacedName": "RootUpdateCommentMutationPayload",
+                    "fields": [
+                        {
+                            "name": "comment"
+                        },
+                        {
+                            "name": "commentID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of updating a comment"
+                },
+                {
+                    "name": "RootUpdateCustomPostMutationPayload",
+                    "namespacedName": "RootUpdateCustomPostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update mutation on a custom post"
+                },
+                {
+                    "name": "RootUpdateGenericCategoryTermMetaMutationPayload",
+                    "namespacedName": "RootUpdateGenericCategoryTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update meta mutation on a category term"
+                },
+                {
+                    "name": "RootUpdateGenericCategoryTermMutationPayload",
+                    "namespacedName": "RootUpdateGenericCategoryTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update mutation on a category term"
+                },
+                {
+                    "name": "RootUpdateGenericCustomPostMetaMutationPayload",
+                    "namespacedName": "RootUpdateGenericCustomPostMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "customPost"
+                        },
+                        {
+                            "name": "customPostID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update meta mutation on a custom post"
+                },
+                {
+                    "name": "RootUpdateGenericTagTermMetaMutationPayload",
+                    "namespacedName": "RootUpdateGenericTagTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update meta mutation on a tag term"
+                },
+                {
+                    "name": "RootUpdateGenericTagTermMutationPayload",
+                    "namespacedName": "RootUpdateGenericTagTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update mutation on a tag term"
+                },
+                {
+                    "name": "RootUpdateMediaItemMutationPayload",
+                    "namespacedName": "RootUpdateMediaItemMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "mediaItem"
+                        },
+                        {
+                            "name": "mediaItemID"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of updating the metadata for an attachment"
+                },
+                {
+                    "name": "RootUpdateMenuMutationPayload",
+                    "namespacedName": "RootUpdateMenuMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "menu"
+                        },
+                        {
+                            "name": "menuID"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of updating a menu"
+                },
+                {
+                    "name": "RootUpdatePageMutationPayload",
+                    "namespacedName": "RootUpdatePageMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "page"
+                        },
+                        {
+                            "name": "pageID"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update mutation on a page"
+                },
+                {
+                    "name": "RootUpdatePostCategoryTermMetaMutationPayload",
+                    "namespacedName": "RootUpdatePostCategoryTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update meta mutation on a post's category term"
+                },
+                {
+                    "name": "RootUpdatePostCategoryTermMutationPayload",
+                    "namespacedName": "RootUpdatePostCategoryTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "category"
+                        },
+                        {
+                            "name": "categoryID"
+                        },
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update mutation on a post category term"
+                },
+                {
+                    "name": "RootUpdatePostMutationPayload",
+                    "namespacedName": "RootUpdatePostMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "post"
+                        },
+                        {
+                            "name": "postID"
+                        },
+                        {
+                            "name": "status"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update mutation on a post"
+                },
+                {
+                    "name": "RootUpdatePostTagTermMetaMutationPayload",
+                    "namespacedName": "RootUpdatePostTagTermMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update meta mutation on a post's tag term"
+                },
+                {
+                    "name": "RootUpdatePostTagTermMutationPayload",
+                    "namespacedName": "RootUpdatePostTagTermMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "tag"
+                        },
+                        {
+                            "name": "tagID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update mutation on a post tag term"
+                },
+                {
+                    "name": "RootUpdateUserMetaMutationPayload",
+                    "namespacedName": "RootUpdateUserMetaMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "userID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of executing an update meta mutation on a user"
+                },
+                {
+                    "name": "RootUpdateUserMutationPayload",
+                    "namespacedName": "RootUpdateUserMutationPayload",
+                    "fields": [
+                        {
+                            "name": "errors"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "user"
+                        },
+                        {
+                            "name": "userID"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Payload of updating a user"
+                },
+                {
+                    "name": "TagTermDoesNotExistErrorPayload",
+                    "namespacedName": "TagTermDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The requested tag does not exist\""
+                },
+                {
+                    "name": "TaxonomyIsNotValidErrorPayload",
+                    "namespacedName": "TaxonomyIsNotValidErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The requested taxonomy does not exist\""
+                },
+                {
+                    "name": "User",
+                    "namespacedName": "User",
+                    "fields": [
+                        {
+                            "name": "avatar"
+                        },
+                        {
+                            "name": "capabilities"
+                        },
+                        {
+                            "name": "customPostCount"
+                        },
+                        {
+                            "name": "customPosts"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "displayName"
+                        },
+                        {
+                            "name": "email"
+                        },
+                        {
+                            "name": "firstName"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "hasAnyCapability"
+                        },
+                        {
+                            "name": "hasAnyRole"
+                        },
+                        {
+                            "name": "hasCapability"
+                        },
+                        {
+                            "name": "hasRole"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "lastName"
+                        },
+                        {
+                            "name": "locale"
+                        },
+                        {
+                            "name": "meta"
+                        },
+                        {
+                            "name": "metaKeys"
+                        },
+                        {
+                            "name": "metaValue"
+                        },
+                        {
+                            "name": "metaValues"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "nicename"
+                        },
+                        {
+                            "name": "nickname"
+                        },
+                        {
+                            "name": "postCount"
+                        },
+                        {
+                            "name": "posts"
+                        },
+                        {
+                            "name": "registeredDate"
+                        },
+                        {
+                            "name": "registeredDateStr"
+                        },
+                        {
+                            "name": "roleNames"
+                        },
+                        {
+                            "name": "roles"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        },
+                        {
+                            "name": "username"
+                        },
+                        {
+                            "name": "websiteURL"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of a user"
+                },
+                {
+                    "name": "UserAvatar",
+                    "namespacedName": "UserAvatar",
+                    "fields": [
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "self"
+                        },
+                        {
+                            "name": "size"
+                        },
+                        {
+                            "name": "src"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "User avatar"
+                },
+                {
+                    "name": "UserDoesNotExistErrorPayload",
+                    "namespacedName": "UserDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user does not exist\""
+                },
+                {
+                    "name": "UserHasNoPermissionToCreateMenusErrorPayload",
+                    "namespacedName": "UserHasNoPermissionToCreateMenusErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user has no permission to create menus\""
+                },
+                {
+                    "name": "UserHasNoPermissionToUploadFilesErrorPayload",
+                    "namespacedName": "UserHasNoPermissionToUploadFilesErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user has no permission to upload files\""
+                },
+                {
+                    "name": "UserHasNoPermissionToUploadFilesForOtherUsersErrorPayload",
+                    "namespacedName": "UserHasNoPermissionToUploadFilesForOtherUsersErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user has no permission to upload files for other users\""
+                },
+                {
+                    "name": "UserIsLoggedInErrorPayload",
+                    "namespacedName": "UserIsLoggedInErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user is already logged-in\""
+                },
+                {
+                    "name": "UserIsNotLoggedInErrorPayload",
+                    "namespacedName": "UserIsNotLoggedInErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user is not logged-in\""
+                },
+                {
+                    "name": "UserRole",
+                    "namespacedName": "UserRole",
+                    "fields": [
+                        {
+                            "name": "capabilities"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "self"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "User roles"
+                },
+                {
+                    "name": "UserRoleDoesNotExistErrorPayload",
+                    "namespacedName": "UserRoleDoesNotExistErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The user role does not exist\""
+                },
+                {
+                    "name": "UsernameAlreadyExistsErrorPayload",
+                    "namespacedName": "UsernameAlreadyExistsErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Error payload for: \"The username already exists\""
+                },
+                {
+                    "name": "_DirectiveExtensions",
+                    "namespacedName": "_DirectiveExtensions",
+                    "fields": [
+                        {
+                            "name": "fieldDirectiveSupportedTypeNamesOrDescriptions"
+                        },
+                        {
+                            "name": "needsDataToExecute"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Extensions (custom metadata) added to the directive"
+                },
+                {
+                    "name": "_EnumValueExtensions",
+                    "namespacedName": "_EnumValueExtensions",
+                    "fields": [
+                        {
+                            "name": "isSensitiveDataElement"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Extensions (custom metadata) added to the enum value"
+                },
+                {
+                    "name": "_FieldExtensions",
+                    "namespacedName": "_FieldExtensions",
+                    "fields": [
+                        {
+                            "name": "isGlobal"
+                        },
+                        {
+                            "name": "isMutation"
+                        },
+                        {
+                            "name": "isSensitiveDataElement"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Extensions (custom metadata) added to the field"
+                },
+                {
+                    "name": "_InputValueExtensions",
+                    "namespacedName": "_InputValueExtensions",
+                    "fields": [
+                        {
+                            "name": "isSensitiveDataElement"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Extensions (custom metadata) added to the input value"
+                },
+                {
+                    "name": "_NamedTypeExtensions",
+                    "namespacedName": "_NamedTypeExtensions",
+                    "fields": [
+                        {
+                            "name": "elementName"
+                        },
+                        {
+                            "name": "namespacedName"
+                        },
+                        {
+                            "name": "possibleValues"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Extensions (custom metadata) added to the GraphQL type (for all 'named' types: Object, Interface, Union, Scalar, Enum and InputObject)"
+                },
+                {
+                    "name": "_SchemaExtensions",
+                    "namespacedName": "_SchemaExtensions",
+                    "fields": [
+                        {
+                            "name": "isNamespaced"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Extensions (custom metadata) added to the GraphQL schema"
+                },
+                {
+                    "name": "__Directive",
+                    "namespacedName": "__Directive",
+                    "fields": [
+                        {
+                            "name": "args"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "extensions"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "isRepeatable"
+                        },
+                        {
+                            "name": "locations"
+                        },
+                        {
+                            "name": "name"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "A GraphQL directive in the data graph"
+                },
+                {
+                    "name": "__EnumValue",
+                    "namespacedName": "__EnumValue",
+                    "fields": [
+                        {
+                            "name": "deprecationReason"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "extensions"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "isDeprecated"
+                        },
+                        {
+                            "name": "name"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of an Enum value in GraphQL"
+                },
+                {
+                    "name": "__Field",
+                    "namespacedName": "__Field",
+                    "fields": [
+                        {
+                            "name": "args"
+                        },
+                        {
+                            "name": "deprecationReason"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "extensions"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "isDeprecated"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "type"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of a GraphQL type's field"
+                },
+                {
+                    "name": "__InputValue",
+                    "namespacedName": "__InputValue",
+                    "fields": [
+                        {
+                            "name": "defaultValue"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "extensions"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "type"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of an input object in GraphQL"
+                },
+                {
+                    "name": "__Schema",
+                    "namespacedName": "__Schema",
+                    "fields": [
+                        {
+                            "name": "directives"
+                        },
+                        {
+                            "name": "extensions"
+                        },
+                        {
+                            "name": "globalFields"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "mutationType"
+                        },
+                        {
+                            "name": "queryType"
+                        },
+                        {
+                            "name": "subscriptionType"
+                        },
+                        {
+                            "name": "type"
+                        },
+                        {
+                            "name": "types"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Schema type, to implement the introspection fields"
+                },
+                {
+                    "name": "__Type",
+                    "namespacedName": "__Type",
+                    "fields": [
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "enumValues"
+                        },
+                        {
+                            "name": "extensions"
+                        },
+                        {
+                            "name": "fields"
+                        },
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        },
+                        {
+                            "name": "inputFields"
+                        },
+                        {
+                            "name": "interfaces"
+                        },
+                        {
+                            "name": "isOneOf"
+                        },
+                        {
+                            "name": "kind"
+                        },
+                        {
+                            "name": "name"
+                        },
+                        {
+                            "name": "ofType"
+                        },
+                        {
+                            "name": "possibleTypes"
+                        },
+                        {
+                            "name": "specifiedByURL"
+                        }
+                    ],
+                    "kind": "OBJECT",
+                    "description": "Representation of each GraphQL type in the graph"
+                },
+                {
+                    "name": "AnyBuiltInScalar",
+                    "namespacedName": "AnyBuiltInScalar",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Wildcard type representing any of GraphQL's built-in types (String, Int, Boolean, Float or ID)"
+                },
+                {
+                    "name": "AnyScalar",
+                    "namespacedName": "AnyScalar",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Wildcard type representing any of GraphQL's scalar types, including built-in types (String, Int, Boolean, Float or ID) and custom types"
+                },
+                {
+                    "name": "BlockTypeAttributeFieldTypeEnumString",
+                    "namespacedName": "BlockTypeAttributeFieldTypeEnumString",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "JSON-Schema \"type\" of a block attribute. Includes `null`, so it can't be a GraphQL Enum (which disallows that name).. Possible values: `array`, `boolean`, `integer`, `null`, `number`, `object`, `string`."
+                },
+                {
+                    "name": "Boolean",
+                    "namespacedName": "Boolean",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "The Boolean scalar type represents `true` or `false`."
+                },
+                {
+                    "name": "CategoryTaxonomyEnumString",
+                    "namespacedName": "CategoryTaxonomyEnumString",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Category taxonomies (available for querying via the API). Possible values: `additional-dummy-category`, `additional-post-category`, `category`, `dummy-category`, `dummy-category-two`."
+                },
+                {
+                    "name": "CustomPostEnumString",
+                    "namespacedName": "CustomPostEnumString",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Custom post types (available for querying via the API). Possible values: `dummy-cpt`, `dummy-cpt-four`, `dummy-cpt-three`, `dummy-cpt-two`, `page`, `post`, `wp_block`."
+                },
+                {
+                    "name": "DangerouslyNonSpecificScalar",
+                    "namespacedName": "DangerouslyNonSpecificScalar",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Special scalar type which is not coerced or validated. In particular, it does not need to validate if it is an array or not, as GraphQL requires based on the applied WrappingType (such as `[String]`)."
+                },
+                {
+                    "name": "Date",
+                    "namespacedName": "Date",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Date scalar. It follows the ISO 8601 specification, with format \"Y-m-d\")"
+                },
+                {
+                    "name": "DateTime",
+                    "namespacedName": "DateTime",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "DateTime scalar. It follows the ISO 8601 specification, with format \"Y-m-d\\TH:i:sP\")"
+                },
+                {
+                    "name": "Email",
+                    "namespacedName": "Email",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Email scalar, such as leo@mysite.com"
+                },
+                {
+                    "name": "HTML",
+                    "namespacedName": "HTML",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "HTML scalar, such as \"<p>Hello <strong>world<\/strong>!<\/p>\""
+                },
+                {
+                    "name": "ID",
+                    "namespacedName": "ID",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "The ID scalar type represents a unique identifier."
+                },
+                {
+                    "name": "Int",
+                    "namespacedName": "Int",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "The Int scalar type represents non-fractional signed whole numeric values."
+                },
+                {
+                    "name": "JSONObject",
+                    "namespacedName": "JSONObject",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Custom scalar representing a JSON Object of unrestricted shape"
+                },
+                {
+                    "name": "ListValueJSONObject",
+                    "namespacedName": "ListValueJSONObject",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Custom scalar representing a JSON Object where values are lists (of anything)"
+                },
+                {
+                    "name": "MenuLocationEnumString",
+                    "namespacedName": "MenuLocationEnumString",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Menu Locations. Possible values: `footer`, `primary`, `quaternary`, `secondary`, `tertiary`."
+                },
+                {
+                    "name": "NullableListValueJSONObject",
+                    "namespacedName": "NullableListValueJSONObject",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Custom scalar representing a JSON Object where values are lists (of anything) or null"
+                },
+                {
+                    "name": "Numeric",
+                    "namespacedName": "Numeric",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Wildcard type representing any of the numeric types (Int or Float)"
+                },
+                {
+                    "name": "PageBuilderProvidersEnumString",
+                    "namespacedName": "PageBuilderProvidersEnumString",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Page builder providers. No values available"
+                },
+                {
+                    "name": "PostCategoryTaxonomyEnumString",
+                    "namespacedName": "PostCategoryTaxonomyEnumString",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Post category taxonomies (available for querying via the API). Possible values: `additional-post-category`, `category`."
+                },
+                {
+                    "name": "PostTagTaxonomyEnumString",
+                    "namespacedName": "PostTagTaxonomyEnumString",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Post tag taxonomies (available for querying via the API). Possible values: `additional-post-tag`, `post_tag`."
+                },
+                {
+                    "name": "String",
+                    "namespacedName": "String",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "The String scalar type represents textual data, represented as UTF-8 character sequences."
+                },
+                {
+                    "name": "TagTaxonomyEnumString",
+                    "namespacedName": "TagTaxonomyEnumString",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "Tag taxonomies (available for querying via the API). Possible values: `additional-dummy-tag`, `additional-post-tag`, `dummy-tag`, `dummy-tag-two`, `post_tag`."
+                },
+                {
+                    "name": "URL",
+                    "namespacedName": "URL",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "URL scalar, such as https:\/\/mysite.com\/my-fabulous-page"
+                },
+                {
+                    "name": "URLAbsolutePath",
+                    "namespacedName": "URLAbsolutePath",
+                    "fields": null,
+                    "kind": "SCALAR",
+                    "description": "URL Absolute Path scalar, such as \"\/my-fabulous-page\" in URL \"https:\/\/mysite.com\/my-fabulous-page\". The absolute path starts with \"\/\", followed by the URL relative path"
+                },
+                {
+                    "name": "Block",
+                    "namespacedName": "Block",
+                    "fields": [
+                        {
+                            "name": "attributes"
+                        },
+                        {
+                            "name": "contentSource"
+                        },
+                        {
+                            "name": "innerBlocks"
+                        },
+                        {
+                            "name": "name"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "Entities representing a Block"
+                },
+                {
+                    "name": "Category",
+                    "namespacedName": "Category",
+                    "fields": [
+                        {
+                            "name": "count"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "name"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "Entities representing a category"
+                },
+                {
+                    "name": "Commentable",
+                    "namespacedName": "Commentable",
+                    "fields": [
+                        {
+                            "name": "areCommentsOpen"
+                        },
+                        {
+                            "name": "commentCount"
+                        },
+                        {
+                            "name": "comments"
+                        },
+                        {
+                            "name": "hasComments"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "The entity can receive comments"
+                },
+                {
+                    "name": "CustomPost",
+                    "namespacedName": "CustomPost",
+                    "fields": [
+                        {
+                            "name": "content"
+                        },
+                        {
+                            "name": "customPostType"
+                        },
+                        {
+                            "name": "date"
+                        },
+                        {
+                            "name": "dateStr"
+                        },
+                        {
+                            "name": "excerpt"
+                        },
+                        {
+                            "name": "isStatus"
+                        },
+                        {
+                            "name": "modifiedDate"
+                        },
+                        {
+                            "name": "modifiedDateStr"
+                        },
+                        {
+                            "name": "rawContent"
+                        },
+                        {
+                            "name": "rawExcerpt"
+                        },
+                        {
+                            "name": "rawTitle"
+                        },
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "slugPath"
+                        },
+                        {
+                            "name": "status"
+                        },
+                        {
+                            "name": "title"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "Entities representing a custom post"
+                },
+                {
+                    "name": "ErrorPayload",
+                    "namespacedName": "ErrorPayload",
+                    "fields": [
+                        {
+                            "name": "message"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "Entities representing an Error payload"
+                },
+                {
+                    "name": "IdentifiableObject",
+                    "namespacedName": "IdentifiableObject",
+                    "fields": [
+                        {
+                            "name": "globalID"
+                        },
+                        {
+                            "name": "id"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "An object that can be uniquely identifiable within its type via an 'ID', and within the whole schema via a 'global ID'"
+                },
+                {
+                    "name": "Queryable",
+                    "namespacedName": "Queryable",
+                    "fields": [
+                        {
+                            "name": "slug"
+                        },
+                        {
+                            "name": "url"
+                        },
+                        {
+                            "name": "urlPath"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "Entities that can be queried through an URL"
+                },
+                {
+                    "name": "Tag",
+                    "namespacedName": "Tag",
+                    "fields": [
+                        {
+                            "name": "count"
+                        },
+                        {
+                            "name": "description"
+                        },
+                        {
+                            "name": "name"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "Entities representing a tag"
+                },
+                {
+                    "name": "WithAuthor",
+                    "namespacedName": "WithAuthor",
+                    "fields": [
+                        {
+                            "name": "author"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "Entities that have an author"
+                },
+                {
+                    "name": "WithFeaturedImage",
+                    "namespacedName": "WithFeaturedImage",
+                    "fields": [
+                        {
+                            "name": "featuredImage"
+                        },
+                        {
+                            "name": "hasFeaturedImage"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "Fields concerning an entity's featured image"
+                },
+                {
+                    "name": "WithMeta",
+                    "namespacedName": "WithMeta",
+                    "fields": [
+                        {
+                            "name": "meta"
+                        },
+                        {
+                            "name": "metaKeys"
+                        },
+                        {
+                            "name": "metaValue"
+                        },
+                        {
+                            "name": "metaValues"
+                        }
+                    ],
+                    "kind": "INTERFACE",
+                    "description": "Fields with meta values"
+                },
+                {
+                    "name": "AuthorByInput",
+                    "namespacedName": "AuthorByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the custom post author"
+                },
+                {
+                    "name": "BlockTypeAttributesFilterInput",
+                    "namespacedName": "BlockTypeAttributesFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter the attributes of a block type"
+                },
+                {
+                    "name": "BlockTypeSupportsFilterInput",
+                    "namespacedName": "BlockTypeSupportsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Filter block types by their `supports` configuration"
+                },
+                {
+                    "name": "CategoriesByInput",
+                    "namespacedName": "CategoriesByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "CategoryByFilterInput",
+                    "namespacedName": "CategoryByFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a category"
+                },
+                {
+                    "name": "CategoryByInput",
+                    "namespacedName": "CategoryByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "CategoryPaginationInput",
+                    "namespacedName": "CategoryPaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate categories"
+                },
+                {
+                    "name": "CommentByInput",
+                    "namespacedName": "CommentByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a comment"
+                },
+                {
+                    "name": "CommentContentInput",
+                    "namespacedName": "CommentContentInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "CommentMetaQueryInput",
+                    "namespacedName": "CommentMetaQueryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Filter by meta key and value. The key must be allowed access in the Settings. See: https:\/\/developer.wordpress.org\/reference\/classes\/wp_meta_query\/"
+                },
+                {
+                    "name": "CommentResponsePaginationInput",
+                    "namespacedName": "CommentResponsePaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate response comments"
+                },
+                {
+                    "name": "CommentResponsesFilterInput",
+                    "namespacedName": "CommentResponsesFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter comment responses"
+                },
+                {
+                    "name": "CommentSortInput",
+                    "namespacedName": "CommentSortInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to sort custom posts"
+                },
+                {
+                    "name": "CreateMediaItemFromContentInput",
+                    "namespacedName": "CreateMediaItemFromContentInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Provide the data to create and upload the attachment"
+                },
+                {
+                    "name": "CreateMediaItemFromInput",
+                    "namespacedName": "CreateMediaItemFromInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "CreateMediaItemFromURLInput",
+                    "namespacedName": "CreateMediaItemFromURLInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Create and upload the attachment from a URL"
+                },
+                {
+                    "name": "CustomPostByInput",
+                    "namespacedName": "CustomPostByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a custom post"
+                },
+                {
+                    "name": "CustomPostCategoriesFilterInput",
+                    "namespacedName": "CustomPostCategoriesFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter categories from a custom post"
+                },
+                {
+                    "name": "CustomPostCommentPaginationInput",
+                    "namespacedName": "CustomPostCommentPaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate custom post comments"
+                },
+                {
+                    "name": "CustomPostCommentsFilterInput",
+                    "namespacedName": "CustomPostCommentsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter comments from custom posts"
+                },
+                {
+                    "name": "CustomPostContentInput",
+                    "namespacedName": "CustomPostContentInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "CustomPostMetaQueryInput",
+                    "namespacedName": "CustomPostMetaQueryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Filter by meta key and value. The key must be allowed access in the Settings. See: https:\/\/developer.wordpress.org\/reference\/classes\/wp_meta_query\/"
+                },
+                {
+                    "name": "CustomPostPaginationInput",
+                    "namespacedName": "CustomPostPaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate custom posts"
+                },
+                {
+                    "name": "CustomPostParentByInput",
+                    "namespacedName": "CustomPostParentByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the custom post parent"
+                },
+                {
+                    "name": "CustomPostSortInput",
+                    "namespacedName": "CustomPostSortInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to sort custom posts"
+                },
+                {
+                    "name": "CustomPostTagsFilterInput",
+                    "namespacedName": "CustomPostTagsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter tags from a custom post"
+                },
+                {
+                    "name": "DateQueryInput",
+                    "namespacedName": "DateQueryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "FeaturedImageByInput",
+                    "namespacedName": "FeaturedImageByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the custom post's featured image"
+                },
+                {
+                    "name": "FilterByAuthorInput",
+                    "namespacedName": "FilterByAuthorInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Filter by author"
+                },
+                {
+                    "name": "FilterByTaxonomyTermsInput",
+                    "namespacedName": "FilterByTaxonomyTermsInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "FilterCommentsByCommentAuthorInput",
+                    "namespacedName": "FilterCommentsByCommentAuthorInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Filter comments by comment author"
+                },
+                {
+                    "name": "FilterCommentsByCustomPostAuthorInput",
+                    "namespacedName": "FilterCommentsByCustomPostAuthorInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Filter comments by custom post author"
+                },
+                {
+                    "name": "FilterCustomPostsByCategoriesInput",
+                    "namespacedName": "FilterCustomPostsByCategoriesInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter custom posts by categories"
+                },
+                {
+                    "name": "FilterCustomPostsByTagsInput",
+                    "namespacedName": "FilterCustomPostsByTagsInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter custom posts by tags"
+                },
+                {
+                    "name": "FilterPostsByCategoriesInput",
+                    "namespacedName": "FilterPostsByCategoriesInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter custom posts by categories"
+                },
+                {
+                    "name": "FilterPostsByTagsInput",
+                    "namespacedName": "FilterPostsByTagsInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter custom posts by tags"
+                },
+                {
+                    "name": "IncludeBlockPropertiesInput",
+                    "namespacedName": "IncludeBlockPropertiesInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to configure which properties to include in the block data"
+                },
+                {
+                    "name": "IncludeExcludeFilterInput",
+                    "namespacedName": "IncludeExcludeFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to filter by including or excluding items"
+                },
+                {
+                    "name": "LoginCredentialsInput",
+                    "namespacedName": "LoginCredentialsInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "LoginUserByInput",
+                    "namespacedName": "LoginUserByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "MediaItemByInput",
+                    "namespacedName": "MediaItemByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a media item"
+                },
+                {
+                    "name": "MediaItemSortInput",
+                    "namespacedName": "MediaItemSortInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to sort custom posts"
+                },
+                {
+                    "name": "MenuByInput",
+                    "namespacedName": "MenuByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a menu"
+                },
+                {
+                    "name": "MenuItemInput",
+                    "namespacedName": "MenuItemInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input for a Menu Item"
+                },
+                {
+                    "name": "MenuItemsByInput",
+                    "namespacedName": "MenuItemsByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to select how to provide the menu items"
+                },
+                {
+                    "name": "MenuSortInput",
+                    "namespacedName": "MenuSortInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to sort custom posts"
+                },
+                {
+                    "name": "MetaKeysFilterInput",
+                    "namespacedName": "MetaKeysFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter the 'metaKeys' field"
+                },
+                {
+                    "name": "MetaQueryCompareByArrayValueInput",
+                    "namespacedName": "MetaQueryCompareByArrayValueInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "MetaQueryCompareByInput",
+                    "namespacedName": "MetaQueryCompareByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "MetaQueryCompareByKeyInput",
+                    "namespacedName": "MetaQueryCompareByKeyInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "MetaQueryCompareByNumericValueInput",
+                    "namespacedName": "MetaQueryCompareByNumericValueInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "MetaQueryCompareByStringValueInput",
+                    "namespacedName": "MetaQueryCompareByStringValueInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "PageByInput",
+                    "namespacedName": "PageByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a page"
+                },
+                {
+                    "name": "PageContentInput",
+                    "namespacedName": "PageContentInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "PagePaginationInput",
+                    "namespacedName": "PagePaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate pages"
+                },
+                {
+                    "name": "PostByInput",
+                    "namespacedName": "PostByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a post"
+                },
+                {
+                    "name": "PostCategoryByFilterInput",
+                    "namespacedName": "PostCategoryByFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a category"
+                },
+                {
+                    "name": "PostContentInput",
+                    "namespacedName": "PostContentInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "PostPaginationInput",
+                    "namespacedName": "PostPaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate posts"
+                },
+                {
+                    "name": "PostTagByFilterInput",
+                    "namespacedName": "PostTagByFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a tag"
+                },
+                {
+                    "name": "RootAddCategoryMetaInput",
+                    "namespacedName": "RootAddCategoryMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to add meta to a category term"
+                },
+                {
+                    "name": "RootAddCommentMetaInput",
+                    "namespacedName": "RootAddCommentMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to add meta to a comment"
+                },
+                {
+                    "name": "RootAddCommentToCustomPostInput",
+                    "namespacedName": "RootAddCommentToCustomPostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to add a comment to a custom post"
+                },
+                {
+                    "name": "RootAddCustomPostMetaInput",
+                    "namespacedName": "RootAddCustomPostMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to add meta to a custom post"
+                },
+                {
+                    "name": "RootAddTagMetaInput",
+                    "namespacedName": "RootAddTagMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to add meta to a tag term"
+                },
+                {
+                    "name": "RootAddUserMetaInput",
+                    "namespacedName": "RootAddUserMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to add meta to a user"
+                },
+                {
+                    "name": "RootBlockTypesFilterInput",
+                    "namespacedName": "RootBlockTypesFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter the registered block types"
+                },
+                {
+                    "name": "RootCategoriesFilterInput",
+                    "namespacedName": "RootCategoriesFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter categories"
+                },
+                {
+                    "name": "RootCommentPaginationInput",
+                    "namespacedName": "RootCommentPaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate comments"
+                },
+                {
+                    "name": "RootCommentsFilterInput",
+                    "namespacedName": "RootCommentsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter comments"
+                },
+                {
+                    "name": "RootCreateCustomPostInput",
+                    "namespacedName": "RootCreateCustomPostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a custom post"
+                },
+                {
+                    "name": "RootCreateGenericCategoryInput",
+                    "namespacedName": "RootCreateGenericCategoryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to create a category term"
+                },
+                {
+                    "name": "RootCreateGenericTagInput",
+                    "namespacedName": "RootCreateGenericTagInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to create a tag term"
+                },
+                {
+                    "name": "RootCreateMediaItemInput",
+                    "namespacedName": "RootCreateMediaItemInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to upload an attachment"
+                },
+                {
+                    "name": "RootCreateMenuInput",
+                    "namespacedName": "RootCreateMenuInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to create a menu"
+                },
+                {
+                    "name": "RootCreatePageInput",
+                    "namespacedName": "RootCreatePageInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a custom post"
+                },
+                {
+                    "name": "RootCreatePostCategoryInput",
+                    "namespacedName": "RootCreatePostCategoryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to create a category term"
+                },
+                {
+                    "name": "RootCreatePostInput",
+                    "namespacedName": "RootCreatePostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a custom post"
+                },
+                {
+                    "name": "RootCreatePostTagInput",
+                    "namespacedName": "RootCreatePostTagInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to create a tag term"
+                },
+                {
+                    "name": "RootCreateUserInput",
+                    "namespacedName": "RootCreateUserInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to create a user"
+                },
+                {
+                    "name": "RootCustomPostsFilterInput",
+                    "namespacedName": "RootCustomPostsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter custom posts"
+                },
+                {
+                    "name": "RootDeleteCategoryMetaInput",
+                    "namespacedName": "RootDeleteCategoryMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a category term's meta entry"
+                },
+                {
+                    "name": "RootDeleteCommentInput",
+                    "namespacedName": "RootDeleteCommentInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a comment"
+                },
+                {
+                    "name": "RootDeleteCommentMetaInput",
+                    "namespacedName": "RootDeleteCommentMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete an entity's meta entry"
+                },
+                {
+                    "name": "RootDeleteCustomPostInput",
+                    "namespacedName": "RootDeleteCustomPostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a custom post"
+                },
+                {
+                    "name": "RootDeleteCustomPostMetaInput",
+                    "namespacedName": "RootDeleteCustomPostMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a custom post's meta entry"
+                },
+                {
+                    "name": "RootDeleteGenericCategoryInput",
+                    "namespacedName": "RootDeleteGenericCategoryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a category term"
+                },
+                {
+                    "name": "RootDeleteGenericTagInput",
+                    "namespacedName": "RootDeleteGenericTagInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a tag term"
+                },
+                {
+                    "name": "RootDeleteMediaItemInput",
+                    "namespacedName": "RootDeleteMediaItemInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete an attachment"
+                },
+                {
+                    "name": "RootDeleteMenuInput",
+                    "namespacedName": "RootDeleteMenuInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a menu"
+                },
+                {
+                    "name": "RootDeletePageInput",
+                    "namespacedName": "RootDeletePageInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a page"
+                },
+                {
+                    "name": "RootDeletePostCategoryInput",
+                    "namespacedName": "RootDeletePostCategoryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a category term"
+                },
+                {
+                    "name": "RootDeletePostInput",
+                    "namespacedName": "RootDeletePostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a post"
+                },
+                {
+                    "name": "RootDeletePostTagInput",
+                    "namespacedName": "RootDeletePostTagInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a tag term"
+                },
+                {
+                    "name": "RootDeleteTagMetaInput",
+                    "namespacedName": "RootDeleteTagMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a tag term's meta entry"
+                },
+                {
+                    "name": "RootDeleteUserInput",
+                    "namespacedName": "RootDeleteUserInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a user"
+                },
+                {
+                    "name": "RootDeleteUserMetaInput",
+                    "namespacedName": "RootDeleteUserMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to delete a user's meta entry"
+                },
+                {
+                    "name": "RootMediaItemPaginationInput",
+                    "namespacedName": "RootMediaItemPaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate media items"
+                },
+                {
+                    "name": "RootMediaItemsFilterInput",
+                    "namespacedName": "RootMediaItemsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter media items"
+                },
+                {
+                    "name": "RootMenuPaginationInput",
+                    "namespacedName": "RootMenuPaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate menus"
+                },
+                {
+                    "name": "RootMenusFilterInput",
+                    "namespacedName": "RootMenusFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter menus"
+                },
+                {
+                    "name": "RootMyCommentsFilterInput",
+                    "namespacedName": "RootMyCommentsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter the logged-in user's comments"
+                },
+                {
+                    "name": "RootMyCustomPostsFilterInput",
+                    "namespacedName": "RootMyCustomPostsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter the logged-in user's custom posts"
+                },
+                {
+                    "name": "RootMyMediaItemsFilterInput",
+                    "namespacedName": "RootMyMediaItemsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter the logged-in user's media items"
+                },
+                {
+                    "name": "RootMyPagesFilterInput",
+                    "namespacedName": "RootMyPagesFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter the logged-in user's pages"
+                },
+                {
+                    "name": "RootMyPostsFilterInput",
+                    "namespacedName": "RootMyPostsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter the logged-in user's posts"
+                },
+                {
+                    "name": "RootPagesFilterInput",
+                    "namespacedName": "RootPagesFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter pages"
+                },
+                {
+                    "name": "RootPostCategoriesFilterInput",
+                    "namespacedName": "RootPostCategoriesFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter categories"
+                },
+                {
+                    "name": "RootPostTagsFilterInput",
+                    "namespacedName": "RootPostTagsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter tags"
+                },
+                {
+                    "name": "RootPostsFilterInput",
+                    "namespacedName": "RootPostsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter posts"
+                },
+                {
+                    "name": "RootRemoveFeaturedImageFromCustomPostInput",
+                    "namespacedName": "RootRemoveFeaturedImageFromCustomPostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to remove the featured image from a custom post"
+                },
+                {
+                    "name": "RootReplyCommentInput",
+                    "namespacedName": "RootReplyCommentInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to add a comment to a custom post"
+                },
+                {
+                    "name": "RootSetCategoriesOnCustomPostInput",
+                    "namespacedName": "RootSetCategoriesOnCustomPostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to set categories on a custom post"
+                },
+                {
+                    "name": "RootSetCategoriesOnPostInput",
+                    "namespacedName": "RootSetCategoriesOnPostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to set categories on a custom post"
+                },
+                {
+                    "name": "RootSetCategoryMetaInput",
+                    "namespacedName": "RootSetCategoryMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to set a category term's meta entries"
+                },
+                {
+                    "name": "RootSetCommentMetaInput",
+                    "namespacedName": "RootSetCommentMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to set entries on a comment"
+                },
+                {
+                    "name": "RootSetCustomPostMetaInput",
+                    "namespacedName": "RootSetCustomPostMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to set entries on a custom post"
+                },
+                {
+                    "name": "RootSetFeaturedImageOnCustomPostInput",
+                    "namespacedName": "RootSetFeaturedImageOnCustomPostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to set the featured image on a custom post"
+                },
+                {
+                    "name": "RootSetTagMetaInput",
+                    "namespacedName": "RootSetTagMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to set a tag term's meta entries"
+                },
+                {
+                    "name": "RootSetTagsOnCustomPostInput",
+                    "namespacedName": "RootSetTagsOnCustomPostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to set tags on a custom post"
+                },
+                {
+                    "name": "RootSetTagsOnPostInput",
+                    "namespacedName": "RootSetTagsOnPostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to set tags on a custom post"
+                },
+                {
+                    "name": "RootSetUserMetaInput",
+                    "namespacedName": "RootSetUserMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to set entries on a user"
+                },
+                {
+                    "name": "RootTagsFilterInput",
+                    "namespacedName": "RootTagsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter tags"
+                },
+                {
+                    "name": "RootUpdateCategoryMetaInput",
+                    "namespacedName": "RootUpdateCategoryMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a category term's meta"
+                },
+                {
+                    "name": "RootUpdateCommentInput",
+                    "namespacedName": "RootUpdateCommentInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a comment"
+                },
+                {
+                    "name": "RootUpdateCommentMetaInput",
+                    "namespacedName": "RootUpdateCommentMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a comment's meta"
+                },
+                {
+                    "name": "RootUpdateCustomPostInput",
+                    "namespacedName": "RootUpdateCustomPostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a custom post"
+                },
+                {
+                    "name": "RootUpdateCustomPostMetaInput",
+                    "namespacedName": "RootUpdateCustomPostMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a custom post's meta"
+                },
+                {
+                    "name": "RootUpdateGenericCategoryInput",
+                    "namespacedName": "RootUpdateGenericCategoryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a category term"
+                },
+                {
+                    "name": "RootUpdateGenericTagInput",
+                    "namespacedName": "RootUpdateGenericTagInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a tag term"
+                },
+                {
+                    "name": "RootUpdateMediaItemInput",
+                    "namespacedName": "RootUpdateMediaItemInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update the metadata for an attachment"
+                },
+                {
+                    "name": "RootUpdateMenuInput",
+                    "namespacedName": "RootUpdateMenuInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a menu"
+                },
+                {
+                    "name": "RootUpdatePageInput",
+                    "namespacedName": "RootUpdatePageInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a custom post"
+                },
+                {
+                    "name": "RootUpdatePostCategoryInput",
+                    "namespacedName": "RootUpdatePostCategoryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a category term"
+                },
+                {
+                    "name": "RootUpdatePostInput",
+                    "namespacedName": "RootUpdatePostInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a custom post"
+                },
+                {
+                    "name": "RootUpdatePostTagInput",
+                    "namespacedName": "RootUpdatePostTagInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a tag term"
+                },
+                {
+                    "name": "RootUpdateTagMetaInput",
+                    "namespacedName": "RootUpdateTagMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a tag term's meta"
+                },
+                {
+                    "name": "RootUpdateUserInput",
+                    "namespacedName": "RootUpdateUserInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a user"
+                },
+                {
+                    "name": "RootUpdateUserMetaInput",
+                    "namespacedName": "RootUpdateUserMetaInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to update a user's meta"
+                },
+                {
+                    "name": "TagByFilterInput",
+                    "namespacedName": "TagByFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a tag"
+                },
+                {
+                    "name": "TagByInput",
+                    "namespacedName": "TagByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "TagPaginationInput",
+                    "namespacedName": "TagPaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate tags"
+                },
+                {
+                    "name": "TagsByInput",
+                    "namespacedName": "TagsByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": null
+                },
+                {
+                    "name": "TaxonomyCustomPostsFilterInput",
+                    "namespacedName": "TaxonomyCustomPostsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter a taxonomy's custom posts"
+                },
+                {
+                    "name": "TaxonomyMetaQueryInput",
+                    "namespacedName": "TaxonomyMetaQueryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Filter by meta key and value. The key must be allowed access in the Settings. See: https:\/\/developer.wordpress.org\/reference\/classes\/wp_meta_query\/"
+                },
+                {
+                    "name": "TaxonomySortInput",
+                    "namespacedName": "TaxonomySortInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to sort custom posts"
+                },
+                {
+                    "name": "TaxonomyTaxonomiesFilterInput",
+                    "namespacedName": "TaxonomyTaxonomiesFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter child taxonomies"
+                },
+                {
+                    "name": "UserByInput",
+                    "namespacedName": "UserByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to fetch a user"
+                },
+                {
+                    "name": "UserCustomPostsFilterInput",
+                    "namespacedName": "UserCustomPostsFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter the user's custom posts"
+                },
+                {
+                    "name": "UserMetaQueryInput",
+                    "namespacedName": "UserMetaQueryInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Filter by meta key and value. The key must be allowed access in the Settings. See: https:\/\/developer.wordpress.org\/reference\/classes\/wp_meta_query\/"
+                },
+                {
+                    "name": "UserPaginationInput",
+                    "namespacedName": "UserPaginationInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to paginate users"
+                },
+                {
+                    "name": "UserSearchByInput",
+                    "namespacedName": "UserSearchByInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Oneof input to specify the property and data to search users"
+                },
+                {
+                    "name": "UserSortInput",
+                    "namespacedName": "UserSortInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to sort custom posts"
+                },
+                {
+                    "name": "UsersFilterInput",
+                    "namespacedName": "UsersFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter users"
+                },
+                {
+                    "name": "WithParentCustomPostChildrenFilterInput",
+                    "namespacedName": "WithParentCustomPostChildrenFilterInput",
+                    "fields": null,
+                    "kind": "INPUT_OBJECT",
+                    "description": "Input to filter the custom post children"
+                },
+                {
+                    "name": "CommentOrderByEnum",
+                    "namespacedName": "CommentOrderByEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "CommentStatusEnum",
+                    "namespacedName": "CommentStatusEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "CommentTypeEnum",
+                    "namespacedName": "CommentTypeEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "CustomPostOrderByEnum",
+                    "namespacedName": "CustomPostOrderByEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "CustomPostStatusEnum",
+                    "namespacedName": "CustomPostStatusEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "DirectiveKindEnum",
+                    "namespacedName": "DirectiveKindEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "DirectiveLocation",
+                    "namespacedName": "DirectiveLocation",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "FilterCustomPostStatusEnum",
+                    "namespacedName": "FilterCustomPostStatusEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "MediaItemOrderByEnum",
+                    "namespacedName": "MediaItemOrderByEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "MenuItemTypeEnum",
+                    "namespacedName": "MenuItemTypeEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "MenuOrderByEnum",
+                    "namespacedName": "MenuOrderByEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "MetaQueryCompareByArrayValueOperatorEnum",
+                    "namespacedName": "MetaQueryCompareByArrayValueOperatorEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": "Operators to compare against an array value"
+                },
+                {
+                    "name": "MetaQueryCompareByKeyOperatorEnum",
+                    "namespacedName": "MetaQueryCompareByKeyOperatorEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": "Operators to compare against the meta key"
+                },
+                {
+                    "name": "MetaQueryCompareByNumericValueOperatorEnum",
+                    "namespacedName": "MetaQueryCompareByNumericValueOperatorEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": "Operators to compare against a numeric value"
+                },
+                {
+                    "name": "MetaQueryCompareByStringValueOperatorEnum",
+                    "namespacedName": "MetaQueryCompareByStringValueOperatorEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": "Operators to compare against a string value"
+                },
+                {
+                    "name": "MetaQueryValueTypesEnum",
+                    "namespacedName": "MetaQueryValueTypesEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": "Custom field type"
+                },
+                {
+                    "name": "OperationStatusEnum",
+                    "namespacedName": "OperationStatusEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "OrderEnum",
+                    "namespacedName": "OrderEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "RelationEnum",
+                    "namespacedName": "RelationEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": "The logical relationship between array values in query args (for meta query, date parameters, and others) when there is more than one"
+                },
+                {
+                    "name": "TaxonomyOrderByEnum",
+                    "namespacedName": "TaxonomyOrderByEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "TypeKind",
+                    "namespacedName": "TypeKind",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "UserOrderByEnum",
+                    "namespacedName": "UserOrderByEnum",
+                    "fields": null,
+                    "kind": "ENUM",
+                    "description": null
+                },
+                {
+                    "name": "BlockUnion",
+                    "namespacedName": "BlockUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Block' types"
+                },
+                {
+                    "name": "CategoryUnion",
+                    "namespacedName": "CategoryUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'category' type resolvers"
+                },
+                {
+                    "name": "CustomPostUnion",
+                    "namespacedName": "CustomPostUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'custom post' type resolvers"
+                },
+                {
+                    "name": "RootAddCommentMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootAddCommentMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when adding meta on a comment"
+                },
+                {
+                    "name": "RootAddCommentToCustomPostMutationErrorPayloadUnion",
+                    "namespacedName": "RootAddCommentToCustomPostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when adding a comment to a custom post"
+                },
+                {
+                    "name": "RootAddGenericCategoryTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootAddGenericCategoryTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when adding meta on a category term"
+                },
+                {
+                    "name": "RootAddGenericCustomPostMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootAddGenericCustomPostMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when adding meta on a custom post"
+                },
+                {
+                    "name": "RootAddGenericTagTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootAddGenericTagTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when adding meta on a tag term"
+                },
+                {
+                    "name": "RootAddPostCategoryTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootAddPostCategoryTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when adding meta on a post's category term"
+                },
+                {
+                    "name": "RootAddPostTagTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootAddPostTagTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when adding meta on a post's tag term"
+                },
+                {
+                    "name": "RootAddUserMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootAddUserMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when adding meta on a user"
+                },
+                {
+                    "name": "RootCreateCustomPostMutationErrorPayloadUnion",
+                    "namespacedName": "RootCreateCustomPostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when creating a custom post"
+                },
+                {
+                    "name": "RootCreateGenericCategoryTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootCreateGenericCategoryTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when creating a category term"
+                },
+                {
+                    "name": "RootCreateGenericTagTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootCreateGenericTagTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when creating a tag term"
+                },
+                {
+                    "name": "RootCreateMediaItemMutationErrorPayloadUnion",
+                    "namespacedName": "RootCreateMediaItemMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when uploading an attachment"
+                },
+                {
+                    "name": "RootCreateMenuMutationErrorPayloadUnion",
+                    "namespacedName": "RootCreateMenuMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when creating a menu"
+                },
+                {
+                    "name": "RootCreatePageMutationErrorPayloadUnion",
+                    "namespacedName": "RootCreatePageMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when creating a page"
+                },
+                {
+                    "name": "RootCreatePostCategoryTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootCreatePostCategoryTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when creating a post category term"
+                },
+                {
+                    "name": "RootCreatePostMutationErrorPayloadUnion",
+                    "namespacedName": "RootCreatePostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when creating a post"
+                },
+                {
+                    "name": "RootCreatePostTagTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootCreatePostTagTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when creating a post tag term"
+                },
+                {
+                    "name": "RootCreateUserMutationErrorPayloadUnion",
+                    "namespacedName": "RootCreateUserMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when creating a user"
+                },
+                {
+                    "name": "RootDeleteCommentMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteCommentMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting meta on a comment"
+                },
+                {
+                    "name": "RootDeleteCommentMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteCommentMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting a comment"
+                },
+                {
+                    "name": "RootDeleteCustomPostMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteCustomPostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting a custom post"
+                },
+                {
+                    "name": "RootDeleteGenericCategoryTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteGenericCategoryTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting meta on a category term"
+                },
+                {
+                    "name": "RootDeleteGenericCategoryTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteGenericCategoryTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting a category term"
+                },
+                {
+                    "name": "RootDeleteGenericCustomPostMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteGenericCustomPostMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting meta on a custom post"
+                },
+                {
+                    "name": "RootDeleteGenericTagTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteGenericTagTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting meta on a tag term"
+                },
+                {
+                    "name": "RootDeleteGenericTagTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteGenericTagTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting a tag term"
+                },
+                {
+                    "name": "RootDeleteMediaItemMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteMediaItemMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting an attachment"
+                },
+                {
+                    "name": "RootDeleteMenuMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteMenuMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting a menu"
+                },
+                {
+                    "name": "RootDeletePageMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeletePageMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting a page"
+                },
+                {
+                    "name": "RootDeletePostCategoryTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeletePostCategoryTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting meta on a post's category term"
+                },
+                {
+                    "name": "RootDeletePostCategoryTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeletePostCategoryTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting a post category term"
+                },
+                {
+                    "name": "RootDeletePostMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeletePostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting a post"
+                },
+                {
+                    "name": "RootDeletePostTagTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeletePostTagTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting meta on a post's tag term"
+                },
+                {
+                    "name": "RootDeletePostTagTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeletePostTagTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting a post tag term"
+                },
+                {
+                    "name": "RootDeleteUserMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteUserMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting meta on a user"
+                },
+                {
+                    "name": "RootDeleteUserMutationErrorPayloadUnion",
+                    "namespacedName": "RootDeleteUserMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when deleting a user"
+                },
+                {
+                    "name": "RootLoginUserMutationErrorPayloadUnion",
+                    "namespacedName": "RootLoginUserMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when logging a user in"
+                },
+                {
+                    "name": "RootLogoutUserMutationErrorPayloadUnion",
+                    "namespacedName": "RootLogoutUserMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when logging a user out"
+                },
+                {
+                    "name": "RootRemoveFeaturedImageFromCustomPostMutationErrorPayloadUnion",
+                    "namespacedName": "RootRemoveFeaturedImageFromCustomPostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when removing a featured image from a custom post"
+                },
+                {
+                    "name": "RootReplyCommentMutationErrorPayloadUnion",
+                    "namespacedName": "RootReplyCommentMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when replying to a comment"
+                },
+                {
+                    "name": "RootSetCategoriesOnCustomPostMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetCategoriesOnCustomPostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting categories on a custom post"
+                },
+                {
+                    "name": "RootSetCategoriesOnPostMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetCategoriesOnPostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting categories on a post"
+                },
+                {
+                    "name": "RootSetCommentMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetCommentMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting meta on a comment"
+                },
+                {
+                    "name": "RootSetFeaturedImageOnCustomPostMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetFeaturedImageOnCustomPostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting a featured image to a custom post"
+                },
+                {
+                    "name": "RootSetGenericCategoryTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetGenericCategoryTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting meta on a category term"
+                },
+                {
+                    "name": "RootSetGenericCustomPostMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetGenericCustomPostMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting meta on a custom post"
+                },
+                {
+                    "name": "RootSetGenericTagTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetGenericTagTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting meta on a tag term"
+                },
+                {
+                    "name": "RootSetPostCategoryTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetPostCategoryTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting meta on a post's category term"
+                },
+                {
+                    "name": "RootSetPostTagTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetPostTagTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting meta on a post's tag term"
+                },
+                {
+                    "name": "RootSetTagsOnCustomPostMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetTagsOnCustomPostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting tags on a custom post"
+                },
+                {
+                    "name": "RootSetTagsOnPostMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetTagsOnPostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting tags on a post"
+                },
+                {
+                    "name": "RootSetUserMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootSetUserMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when setting meta on a user"
+                },
+                {
+                    "name": "RootUpdateCommentMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateCommentMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating meta on a comment"
+                },
+                {
+                    "name": "RootUpdateCommentMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateCommentMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating a comment"
+                },
+                {
+                    "name": "RootUpdateCustomPostMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateCustomPostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating a custom post"
+                },
+                {
+                    "name": "RootUpdateGenericCategoryTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateGenericCategoryTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating meta on a category term"
+                },
+                {
+                    "name": "RootUpdateGenericCategoryTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateGenericCategoryTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating a category term"
+                },
+                {
+                    "name": "RootUpdateGenericCustomPostMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateGenericCustomPostMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating meta on a custom post"
+                },
+                {
+                    "name": "RootUpdateGenericTagTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateGenericTagTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating meta on a tag term"
+                },
+                {
+                    "name": "RootUpdateGenericTagTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateGenericTagTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating a tag term"
+                },
+                {
+                    "name": "RootUpdateMediaItemMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateMediaItemMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating the metadata for an attachment"
+                },
+                {
+                    "name": "RootUpdateMenuMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateMenuMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating a menu"
+                },
+                {
+                    "name": "RootUpdatePageMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdatePageMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating a page"
+                },
+                {
+                    "name": "RootUpdatePostCategoryTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdatePostCategoryTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating meta on a post's category term"
+                },
+                {
+                    "name": "RootUpdatePostCategoryTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdatePostCategoryTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating a post category term"
+                },
+                {
+                    "name": "RootUpdatePostMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdatePostMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating a post"
+                },
+                {
+                    "name": "RootUpdatePostTagTermMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdatePostTagTermMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating meta on a post's tag term"
+                },
+                {
+                    "name": "RootUpdatePostTagTermMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdatePostTagTermMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating a post tag term"
+                },
+                {
+                    "name": "RootUpdateUserMetaMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateUserMetaMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating meta on a user"
+                },
+                {
+                    "name": "RootUpdateUserMutationErrorPayloadUnion",
+                    "namespacedName": "RootUpdateUserMutationErrorPayloadUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'Error Payload' types when updating a user"
+                },
+                {
+                    "name": "TagUnion",
+                    "namespacedName": "TagUnion",
+                    "fields": null,
+                    "kind": "UNION",
+                    "description": "Union of 'tag' type resolvers"
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-exclude.gql
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-exclude.gql
@@ -1,0 +1,3 @@
+{
+  optionNames(filterBy: { exclude: "blog" })
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-exclude.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-exclude.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "optionNames": [
+      "date_format",
+      "home",
+      "posts_per_page",
+      "siteurl",
+      "stylesheet",
+      "template"
+    ]
+  }
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-include-multiple.gql
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-include-multiple.gql
@@ -1,0 +1,3 @@
+{
+  optionNames(filterBy: { include: ["template", "date"] })
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-include-multiple.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-include-multiple.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "optionNames": [
+      "date_format",
+      "template"
+    ]
+  }
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-include.gql
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-include.gql
@@ -1,0 +1,3 @@
+{
+  optionNames(filterBy: { include: "blog" })
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-include.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names-filter-by-include.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "optionNames": [
+      "blogdescription",
+      "blogname"
+    ]
+  }
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names.gql
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names.gql
@@ -1,0 +1,3 @@
+{
+  optionNames
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-option-names-filter-by/option-names.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "optionNames": [
+      "blogdescription",
+      "blogname",
+      "date_format",
+      "home",
+      "posts_per_page",
+      "siteurl",
+      "stylesheet",
+      "template"
+    ]
+  }
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-options/options.gql
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-options/options.gql
@@ -1,0 +1,4 @@
+{
+  optionNames
+  blogname: options(names: ["blogname"])
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-options/options.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-options/options.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "optionNames": [
+      "blogdescription",
+      "blogname",
+      "home",
+      "siteurl"
+    ],
+    "blogname": {
+      "blogname": "Gato GraphQL"
+    }
+  }
+}

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-options/options:1.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-options/options:1.json
@@ -1,0 +1,30 @@
+{
+  "errors": [
+    {
+      "message": "There is no option with name 'blogname'",
+      "locations": [
+        {
+          "line": 3,
+          "column": 21
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(names: [\"blogname\"])",
+          "blogname: options(names: [\"blogname\"])",
+          "query { ... }"
+        ],
+        "type": "QueryRoot",
+        "field": "blogname: options(names: [\"blogname\"])",
+        "code": "PoPCMSSchema/Settings@e1"
+      }
+    }
+  ],
+  "data": {
+    "optionNames": [
+      "home",
+      "siteurl"
+    ],
+    "blogname": null
+  }
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -8,6 +8,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Added
 
+- Fields to query the site's options (i.e. the settings) in bulk: `optionNames` returns the list of the allowed option names stored in the DB (with a `filterBy` input to include/exclude the names containing some string), and `options` returns a JSON object with the option name and value for the provided (allowed) option names (#3364)
 - Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type; `createUser` and `updateUser` (and their nested and bulk versions) also accept a `meta` input to set the user's custom meta; the "payload types for mutations" schema configuration also applies to them (#3362)
 - Mutations to delete posts, pages and custom posts: `deletePost`, `deletePage` and `deleteCustomPost` (and their bulk versions), and the nested `delete` field on the `Post`, `Page` and `GenericCustomPost` types (#3358)
 - Mutations to delete media items: `deleteMediaItem` and `deleteMediaItems`, and the nested `delete` field on the `Media` type (#3358)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/schema-settings/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/modules/schema-settings/en.md
@@ -1,6 +1,6 @@
 # Settings
 
-Retrieve the settings from the site (stored in table `wp_options`), by querying fields `optionValue`, `optionValues` and `optionObjectValue`.
+Retrieve the settings from the site (stored in table `wp_options`), by querying fields `optionValue`, `optionValues`, `optionObjectValue`, `optionNames` and `options`.
 
 For security reasons, which options can be queried must be explicitly configured.
 
@@ -17,6 +17,45 @@ For instance, this query retrieves the site's URL:
 ```graphql
 {
   homeURL: optionValue(name: "home")
+}
+```
+
+## Listing the allowed option names
+
+Field `optionNames: [String!]!` returns the list of the allowed option names that are stored in the DB (any option that cannot be accessed is omitted from the list):
+
+```graphql
+{
+  optionNames
+}
+```
+
+It can receive an `IncludeExcludeFilterInput` argument `filterBy` to filter the returned names by those containing (`include`) or not containing (`exclude`) some string. For instance, this query returns all the allowed option names that contain `"blog"` in their name (such as `"blogname"` and `"blogdescription"`):
+
+```graphql
+{
+  optionNames(filterBy: { include: "blog" })
+}
+```
+
+## Retrieving multiple options at once
+
+Field `options(names: [String!]!): JSONObject` returns a JSON object, with the option name as key and the option value as value, for the provided (allowed) option names:
+
+```graphql
+{
+  options(names: ["blogname", "blogdescription"])
+}
+```
+
+If any of the provided names cannot be accessed, an error is returned.
+
+Both fields can be combined, feeding the result from `optionNames` as input to `options` (via the `$__optionNames` dynamic variable provided by the "Field to Input" module):
+
+```graphql
+{
+  optionNames
+  options(names: $__optionNames)
 }
 ```
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
@@ -78,6 +78,22 @@ mutation {
 }
 ```
 
+### Querying the site's options
+
+The Settings module gains two new fields to query the site's options (i.e. the settings, stored in table `wp_options`) in bulk ([#3364](https://github.com/GatoGraphQL/GatoGraphQL/pull/3364)):
+
+- `optionNames: [String!]!` returns the list of the allowed option names stored in the DB. It accepts a `filterBy` input to include or exclude the names containing some string.
+- `options(names: [String!]!): JSONObject` returns a JSON object, with the option name as key and the option value as value, for the provided (allowed) option names.
+
+As with the existing `optionValue` field, only the options explicitly configured as accessible can be queried; any option that cannot be accessed is omitted from `optionNames`, and providing it to `options` returns an error.
+
+```graphql
+{
+  optionNames(filterBy: { include: "blog" })
+  options(names: $__optionNames)
+}
+```
+
 ## Improvements
 
 - Updated WooCommerce docs with mutations ([#3356](https://github.com/GatoGraphQL/GatoGraphQL/pull/3356))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -248,6 +248,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 == Changelog ==
 
 = 19.1.0 =
+* Added - Fields to query the site's options (i.e. the settings) in bulk: `optionNames` returns the list of the allowed option names stored in the DB (with a `filterBy` input to include/exclude the names containing some string), and `options` returns a JSON object with the option name and value for the provided (allowed) option names (#3364)
 * Added - Mutations to create, update and delete users: `createUser`, `updateUser` and `deleteUser` (and their bulk versions `createUsers`, `updateUsers` and `deleteUsers`), and the nested `update` and `delete` fields on the `User` type; `createUser` and `updateUser` (and their nested and bulk versions) also accept a `meta` input to set the user's custom meta; the "payload types for mutations" schema configuration also applies to them (#3362)
 * Added - Mutations to delete posts, pages and custom posts: `deletePost`, `deletePage` and `deleteCustomPost` (and their bulk versions), and the nested `delete` field on the `Post`, `Page` and `GenericCustomPost` types (#3358)
 * Added - Mutations to delete media items: `deleteMediaItem` and `deleteMediaItems`, and the nested `delete` field on the `Media` type (#3358)


### PR DESCRIPTION
Adds two `Root` fields to the Settings module, to query the site's options (stored in `wp_options`) in bulk, complementing the existing per-name `optionValue`/`optionValues`/`optionObjectValue` fields.

## New fields

- **`optionNames: [String!]!`** — returns the list of the allowed option names stored in the DB. Any option that cannot be accessed (per the Settings allow/deny configuration) is omitted from the list. Accepts an `IncludeExcludeFilterInput` `filterBy` argument to include or exclude the names containing a substring:

  ```graphql
  { optionNames(filterBy: { include: "blog" }) }   # e.g. ["blogdescription", "blogname"]
  ```

- **`options(names: [String!]!): JSONObject`** — returns a JSON object mapping each provided (allowed) option name to its value. Providing a name that cannot be accessed returns an error (`E1` for one, `E2` for several).

  ```graphql
  { options(names: ["blogname", "blogdescription"]) }
  ```

Both honor the existing Settings allow/deny configuration (global setting and per-endpoint schema config), exactly like `optionValue`.

## Implementation

- `SettingsTypeAPIInterface::getOptionNames()` (WordPress impl queries `wp_options`); the resolver filters the names through the existing allow/deny check, then applies the `filterBy` substring include/exclude.
- New `E2` feedback item for the multi-name error case.

## Tests

- Settings-dependent behavior of `options`/`optionNames` (response changes with the configured entries).
- `filterBy` variations (`include`/`exclude`, single and multiple substrings).

## Schema goldens

Regenerates the schema-printing integration goldens (introspection, type field lists) for the two new fields. Note these goldens also absorb pre-existing schema drift: the `CannotDeleteYourselfErrorPayload` and `EmailAlreadyExistsErrorPayload` types (added with the user mutations) were present in the schema but had not been regenerated into these goldens.