### PR TITLE
Print the collapsible settings descriptions with <details>/<summary>

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -19,6 +19,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Improvements
 
+- The collapsible "Show details" descriptions in the plugin settings are now printed using the native HTML `<details>`/`<summary>` elements, instead of a JavaScript-driven show/hide link (#3368)
 - Updated WooCommerce docs with mutations (#3356)
 
 ### Fixed

--- a/layers/GatoGraphQLForWP/plugins/gatographql/assets/css/collapse.css
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/assets/css/collapse.css
@@ -1,23 +1,33 @@
-/**
- * Collapsible source: https://www.w3schools.com/howto/howto_js_collapsible.asp
- */
-
-/* Style the button that is used to open and close the collapsible content */
-.collapsible {
-    /* color: olivedrab; */
+.gato-collapsible > summary {
     color: darkcyan;
-    /* text-decoration: none; */
+    cursor: pointer;
+    width: fit-content;
 }
 
-/* Add a background color to the button if it is clicked on (add the .active class with JS), and when you move the mouse over it (hover) */
+.gato-collapsible[open] > summary {
+    margin-bottom: 0.5em;
+}
+
+.gato-collapsible-content {
+    color: darkcyan;
+    overflow: hidden;
+}
+
+/**
+ * Deprecated: kept for backwards compatibility with extensions still printing
+ * the JS-driven collapsible markup.
+ * Collapsible source: https://www.w3schools.com/howto/howto_js_collapsible.asp
+ */
+.collapsible {
+    color: darkcyan;
+}
+
 .collapsible.active {
     display: none;
     overflow: hidden;
 }
 
-/* Style the collapsible content. Note: hidden by default */
 .collapsible-content {
-    /* color: olivedrab; */
     color: darkcyan;
     display: none;
     overflow: hidden;

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.1/en.md
@@ -115,6 +115,7 @@ The `customPosts` query can now be filtered by the parent custom post, using the
 
 ## Improvements
 
+- The collapsible "Show details" descriptions in the plugin settings are now printed using the native HTML `<details>`/`<summary>` elements, instead of a JavaScript-driven show/hide link ([#3368](https://github.com/GatoGraphQL/GatoGraphQL/pull/3368))
 - Updated WooCommerce docs with mutations ([#3356](https://github.com/GatoGraphQL/GatoGraphQL/pull/3356))
 
 ## Fixes

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-de_DE.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-de_DE.po
@@ -8603,7 +8603,7 @@ msgstr ""
 "Diese URL ist veraltet oder ungültig. Bitte <a href=\"%s\">klicken Sie hier, "
 "um die Seite neu zu laden</a>, und versuchen Sie es erneut"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Details anzeigen"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-el.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-el.po
@@ -8488,7 +8488,7 @@ msgstr ""
 "href=\"%s\">κάντε κλικ εδώ για να φορτώσετε ξανά τη σελίδα</a> και δοκιμάστε "
 "ξανά"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Εμφάνιση λεπτομερειών"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-es_ES.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-es_ES.po
@@ -8521,7 +8521,7 @@ msgstr ""
 "Esta URL ha caducado o no es válida. Por favor, <a href=\"%s\">haz clic aquí "
 "para recargar la página</a> e inténtalo de nuevo"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Mostrar detalles"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-fr_FR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-fr_FR.po
@@ -8712,7 +8712,7 @@ msgstr ""
 "Cette URL est obsolète ou invalide. Veuillez <a href=\"%s\">cliquer ici pour "
 "recharger la page</a>, et réessayer"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Afficher les détails"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-id_ID.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-id_ID.po
@@ -8206,7 +8206,7 @@ msgstr ""
 "URL ini sudah kedaluwarsa atau tidak valid. Silakan <a href=\"%s\">klik di "
 "sini untuk memuat ulang halaman</a>, dan coba lagi"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Tampilkan detail"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-it_IT.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-it_IT.po
@@ -8509,7 +8509,7 @@ msgstr ""
 "Questo URL è obsoleto o non valido. <a href=\"%s\">Clicca qui per ricaricare "
 "la pagina</a> e riprova"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Mostra dettagli"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ja.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ja.po
@@ -8228,7 +8228,7 @@ msgstr ""
 "このURLは古いか無効です。<a href=\"%s\">こちらをクリックしてページを再読み込"
 "み</a>してから、もう一度お試しください"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "詳細を表示"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ko_KR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ko_KR.po
@@ -7937,7 +7937,7 @@ msgstr ""
 "이 URL은 만료되었거나 유효하지 않습니다. <a href=\"%s\">여기를 클릭하여 페이"
 "지를 새로고침</a>한 후 다시 시도해 주세요"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "세부 정보 표시"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-nl_NL.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-nl_NL.po
@@ -8518,7 +8518,7 @@ msgstr ""
 "Deze URL is verouderd of niet geldig. <a href=\"%s\">Klik hier om de pagina "
 "te herladen</a> en probeer het opnieuw"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Details weergeven"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pl_PL.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pl_PL.po
@@ -8245,7 +8245,7 @@ msgstr ""
 "Ten adres URL jest nieaktualny lub nieprawidłowy. Proszę <a "
 "href=\"%s\">kliknąć tutaj, aby odświeżyć stronę</a> i spróbować ponownie"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Pokaż szczegóły"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pt_BR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pt_BR.po
@@ -8416,7 +8416,7 @@ msgstr ""
 "Esta URL está desatualizada ou não é válida. Por favor, <a "
 "href=\"%s\">clique aqui para recarregar a página</a> e tente novamente"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Mostrar detalhes"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ru_RU.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ru_RU.po
@@ -8430,7 +8430,7 @@ msgstr ""
 "Этот URL устарел или недействителен. Пожалуйста, <a href=\"%s\">нажмите "
 "здесь, чтобы перезагрузить страницу</a>, и повторите попытку"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Показать подробности"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-sv_SE.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-sv_SE.po
@@ -8263,7 +8263,7 @@ msgstr ""
 "Den här URL:en är föråldrad eller ogiltig. Vänligen <a href=\"%s\">klicka "
 "här för att ladda om sidan</a>, och försök igen"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Visa detaljer"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-th.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-th.po
@@ -7882,7 +7882,7 @@ msgid ""
 msgstr ""
 "URL นี้อาจล้าสมัยหรือไม่ถูกต้อง โปรด<a href=\"%s\">คลิกที่นี่เพื่อโหลดหน้าใหม่</a> แล้วลองอีกครั้ง"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "แสดงรายละเอียด"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-tr_TR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-tr_TR.po
@@ -8169,7 +8169,7 @@ msgstr ""
 "Bu URL eski veya geçersiz. Lütfen <a href=\"%s\">sayfayı yeniden yüklemek "
 "için buraya tıklayın</a> ve tekrar deneyin"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Ayrıntıları göster"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-vi.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-vi.po
@@ -8276,7 +8276,7 @@ msgstr ""
 "URL này đã hết hạn hoặc không hợp lệ. Vui lòng <a href=\"%s\">nhấp vào đây "
 "để tải lại trang</a>, và thử lại"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "Hiển thị chi tiết"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-zh_CN.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-zh_CN.po
@@ -7726,7 +7726,7 @@ msgid ""
 "reload the page</a>, and try again"
 msgstr "此URL已过期或无效。请<a href=\"%s\">点击此处重新加载页面</a>，然后重试"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr "显示详情"
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql.pot
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql.pot
@@ -7138,7 +7138,7 @@ msgstr ""
 msgid "This URL is either stale or not valid. Please <a href=\"%s\">click here to reload the page</a>, and try again"
 msgstr ""
 
-#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:15
+#: GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php:17
 msgid "Show details"
 msgstr ""
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -256,6 +256,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 * Added - Mutations to delete menus: `deleteMenu` and `deleteMenus`, and the nested `delete` field on the `Menu` type (#3358)
 * Added - Mutations to update and moderate comments: `updateComment` and `updateComments`, and the nested `update` field on the `Comment` type. The comment is moderated via the `status` input, which can approve it, hold it for moderation, mark it as spam, or send it to the trash (#3358)
 * Added - Mutations to delete comments: `deleteComment` and `deleteComments`, and the nested `delete` field on the `Comment` type (#3358)
+* Improved - The collapsible "Show details" descriptions in the plugin settings are now printed using the native HTML `<details>`/`<summary>` elements, instead of a JavaScript-driven show/hide link (#3368)
 * Improved - Updated WooCommerce docs with mutations (#3356)
 * Fixed - The `defaultValue` of input values (field and directive arguments, and input object fields) in the introspection query is now encoded using the GraphQL language, as required by the GraphQL spec, and not as JSON. Enum default values were previously quoted as strings (eg: `["approve"]` instead of `[approve]`), so GraphQL clients (such as GraphiQL) discarded the default value and, for non-nullable arguments, wrongly reported that the argument is required (#3367)
 * Fixed - Corrected the `parentID` and `parentIDs` filter input descriptions (on the custom posts and pages filters), which had the singular/plural wording swapped (#3366)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/ContentPrinters/CollapsibleContentPrinterTrait.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace GatoGraphQL\GatoGraphQL\ContentPrinters;
 
+use function preg_replace;
+
 trait CollapsibleContentPrinterTrait
 {
     protected function getCollapsible(
@@ -11,9 +13,14 @@ trait CollapsibleContentPrinterTrait
         ?string $showDetailsLabel = null,
     ): string {
         return sprintf(
-            '<a href="#" type="button" class="collapsible">%s</a><span class="collapsible-content">%s</span>',
+            '<details class="gato-collapsible"><summary>%s</summary><div class="gato-collapsible-content">%s</div></details>',
             $showDetailsLabel ?? \__('Show details', 'gatographql'),
-            $content
+            $this->trimCollapsibleContentLeadingLineBreaks($content)
         );
+    }
+
+    private function trimCollapsibleContentLeadingLineBreaks(string $content): string
+    {
+        return preg_replace('/^(\s*<br\s*\/?>)+/i', '', $content) ?? $content;
     }
 }


### PR DESCRIPTION
The "Show details" collapsibles in the plugin settings were a jQuery-driven `<a class="collapsible">` link toggling the `display` of an adjacent `<span class="collapsible-content">`.

`CollapsibleContentPrinterTrait::getCollapsible()` now prints the native HTML disclosure widget instead:

```html
<details class="gato-collapsible"><summary>Show details</summary><div class="gato-collapsible-content">…</div></details>
```

Since every collapsible description in the settings goes through that one printer, all ~50 call sites switch over with no changes of their own, and the widget now works without JavaScript.

### Notes

- Many descriptions were authored for the inline collapsible and start with a `<br/>` to break onto their own line. Inside `<details>` that renders as a dangling empty line, so the printer trims leading line breaks — this avoids touching (and re-translating) the description strings themselves.
- The old `.collapsible` / `.collapsible-content` CSS and `collapse.js` are kept, and still enqueued, for backwards compatibility with extensions printing the old markup directly. They are no longer used by the plugin itself.
- The `.pot`/`.po` diff is pure line-reference drift; no msgid changed, and `composer i18n-check` passes.

### Verification

- Rendered the Settings page on the dev server: 48 `<details class="gato-collapsible">` elements, 0 occurrences of the old markup, no leading `<br/>` inside the content, `collapse.css` still enqueued.
- `phpcs --standard=PSR12` on the changed file: 0 errors.
- PHPStan: no new errors.