### PR TITLE
Document the `@underDynamicVariable` meta directive

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -10,6 +10,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - Helper directives `@start` and `@end` to indicate which directives are affected by a meta directive, as an alternative to argument `affectDirectivesUnderPos`: the affected directives are wrapped between `@start` and `@end` (placed right after the meta directive), removing the need to calculate their relative positions, which is error prone in large queries. Both methods produce the same result, and can be combined within the same query (but not on the same meta directive) (#3369)
 
+### Improvements
+
+- Updated "Field Value Iteration and Manipulation" docs with the `@underDynamicVariable` meta directive (#3371)
+
 ## 19.1.0 - 27/07/2026
 
 ### Added

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
@@ -58,3 +58,7 @@ The benefit grows with the size of the query, as the relative positions must oth
 As shown above, `@start` and `@end` can be omitted when the meta directive affects a single directive (as with `@unless` and `@default`).
 
 Both methods can be combined within the same query, but not on the same meta directive. The query is validated while parsing it, returning an error whenever `@start` has no matching `@end` (or the other way around), the block contains no directives, `@start` is not placed right after a meta directive, or a meta directive affects a directive placed outside of its `@start`/`@end` block.
+
+## Improvements
+
+- Updated "Field Value Iteration and Manipulation" docs with the `@underDynamicVariable` meta directive ([#3371](https://github.com/GatoGraphQL/GatoGraphQL/pull/3371))

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/field-value-iteration-and-manipulation/docs/modules/field-value-iteration-and-manipulation/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/field-value-iteration-and-manipulation/docs/modules/field-value-iteration-and-manipulation/en.md
@@ -6,7 +6,8 @@ Addition of meta directives to the GraphQL schema, for iterating and manipulatin
 2. `@underJSONObjectProperty`
 3. `@underEachArrayItem`
 4. `@underEachJSONObjectProperty`
-5. `@objectClone`
+5. `@underDynamicVariable`
+6. `@objectClone`
 
 <!-- ## Description
 
@@ -18,7 +19,8 @@ This module introduces these meta-directives into the GraphQL schema:
 2. `@underJSONObjectProperty`
 3. `@underEachArrayItem`
 4. `@underEachJSONObjectProperty`
-5. `@objectClone` -->
+5. `@underDynamicVariable`
+6. `@objectClone` -->
 
 ## `@underArrayItem`
 
@@ -415,6 +417,118 @@ This query:
   }
 }
 ``` -->
+
+## `@underDynamicVariable`
+
+The meta-directives above all execute their nested directives on the value of the field. `@underDynamicVariable` executes them on the value of a dynamic variable instead, restoring the value of the field afterwards.
+
+This is needed whenever some value that is not the field's value must be iterated: a property extracted from a JSON object, the result of a function, or the item from an outer iteration.
+
+Without it, the value must be moved into the field (via `@applyField(setResultInResponse: true)`), iterated, and then moved back by hand:
+
+```graphql
+{
+  posts {
+    blockFlattenedDataItems
+      @underEachArrayItem(passValueOnwardsAs: "block") @start
+        @applyField(
+          name: "_objectProperty"
+          arguments: { object: $block, by: { key: "innerBlocks" } }
+          passOnwardsAs: "innerBlocks"
+        )
+        # Move the dynamic variable's value into the field...
+        @applyField(
+          name: "_echo"
+          arguments: { value: $innerBlocks }
+          setResultInResponse: true
+        )
+        @underEachArrayItem(passValueOnwardsAs: "innerBlock") @start
+          @exportFrom(
+            scopedDynamicVariable: $innerBlock
+            as: "innerBlocks"
+            type: DICTIONARY
+          )
+        @end # <!-- @underEachArrayItem -->
+        # ...and restore it afterwards
+        @applyField(
+          name: "_echo"
+          arguments: { value: $block }
+          setResultInResponse: true
+        )
+      @end # <!-- @underEachArrayItem -->
+  }
+}
+```
+
+`@underDynamicVariable` replaces both steps, and the value of the field is restored automatically:
+
+```graphql
+{
+  posts {
+    blockFlattenedDataItems
+      @underEachArrayItem(passValueOnwardsAs: "block") @start
+        @applyField(
+          name: "_objectProperty"
+          arguments: { object: $block, by: { key: "innerBlocks" } }
+          passOnwardsAs: "innerBlocks"
+        )
+        @underDynamicVariable(scopedDynamicVariable: $innerBlocks) @start
+          @underEachArrayItem(passValueOnwardsAs: "innerBlock") @start
+            @exportFrom(
+              scopedDynamicVariable: $innerBlock
+              as: "innerBlocks"
+              type: DICTIONARY
+            )
+          @end # <!-- @underEachArrayItem -->
+        @end # <!-- @underDynamicVariable -->
+      @end # <!-- @underEachArrayItem -->
+  }
+}
+```
+
+The dynamic variable can be produced by any directive that exports one, such as `@applyField(passOnwardsAs: "...")`, `@passOnwards(as: "...")`, or the `passValueOnwardsAs` / `passKeyOnwardsAs` / `passIndexOnwardsAs` arguments of the meta-directives above.
+
+### The block provides a read-only view
+
+The nested directives receive the value of the dynamic variable, but any modification they perform on it is discarded: when the block ends, the field recovers the value it had before.
+
+In the query below, `@strUpperCase` is applied on the value of `$list`, and `@strTitleCase` on the (restored) value of the field:
+
+```graphql
+{
+  _echo(value: ["original", "values"])
+    @applyField(
+      name: "_echo"
+      arguments: { value: ["hello", "world"] }
+      passOnwardsAs: "list"
+    )
+    @underDynamicVariable(scopedDynamicVariable: $list) @start
+      @underEachArrayItem @strUpperCase
+    @end # <!-- @underDynamicVariable -->
+    @underEachArrayItem @strTitleCase
+}
+```
+
+...producing:
+
+```json
+{
+  "data": {
+    "_echo": [
+      "Original",
+      "Values"
+    ]
+  }
+}
+```
+
+To keep a value computed inside the block, export it via `@exportFrom` (as in the examples above), which is unaffected by the restoration.
+
+### Handling of `null` and of errors
+
+If the dynamic variable's value is `null`, the block is still executed, with the field temporarily holding `null`. (Use `@if` to skip the block instead.)
+
+If any nested directive produces an error, the error is added to the response, and the field still recovers its original value. The failure is contained within the block: any directive composed after the block is still executed, on the restored value.
 
 ## `@objectClone`
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/extensions/field-value-iteration-and-manipulation/docs/modules/field-value-iteration-and-manipulation/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/extensions/field-value-iteration-and-manipulation/docs/modules/field-value-iteration-and-manipulation/en.md
@@ -448,14 +448,14 @@ Without it, the value must be moved into the field (via `@applyField(setResultIn
             as: "innerBlocks"
             type: DICTIONARY
           )
-        @end # <!-- @underEachArrayItem -->
+        @end
         # ...and restore it afterwards
         @applyField(
           name: "_echo"
           arguments: { value: $block }
           setResultInResponse: true
         )
-      @end # <!-- @underEachArrayItem -->
+      @end
   }
 }
 ```
@@ -479,9 +479,9 @@ Without it, the value must be moved into the field (via `@applyField(setResultIn
               as: "innerBlocks"
               type: DICTIONARY
             )
-          @end # <!-- @underEachArrayItem -->
-        @end # <!-- @underDynamicVariable -->
-      @end # <!-- @underEachArrayItem -->
+          @end
+        @end
+      @end
   }
 }
 ```
@@ -504,7 +504,7 @@ In the query below, `@strUpperCase` is applied on the value of `$list`, and `@st
     )
     @underDynamicVariable(scopedDynamicVariable: $list) @start
       @underEachArrayItem @strUpperCase
-    @end # <!-- @underDynamicVariable -->
+    @end
     @underEachArrayItem @strTitleCase
 }
 ```

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -249,6 +249,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 = 19.2.0 =
 * Added - Helper directives `@start` and `@end` to indicate which directives are affected by a meta directive, as an alternative to argument `affectDirectivesUnderPos`: the affected directives are wrapped between `@start` and `@end` (placed right after the meta directive), removing the need to calculate their relative positions, which is error prone in large queries. Both methods produce the same result, and can be combined within the same query (but not on the same meta directive) (#3369)
+* Improved - Updated "Field Value Iteration and Manipulation" docs with the `@underDynamicVariable` meta directive (#3371)
 
 = 19.1.0 =
 * Added - Filter custom posts by their parent: the `customPosts` query gains the `parentID`, `parentIDs` and `excludeParentIDs` filter inputs (as already available on the `pages` query), mapping to WordPress' `post_parent`, `post_parent__in` and `post_parent__not_in` query args (#3366)


### PR DESCRIPTION
Documents the new `@underDynamicVariable` meta directive in the **Field Value Iteration and Manipulation** extension docs.

The directive executes the composed directives on the value of a dynamic variable instead of on the value of the field, and restores the value of the field once the block ends. It replaces the idiom of moving the value into the field via `@applyField(name: "_echo", setResultInResponse: true)`, iterating it, and then restoring the original value by hand:

```graphql
@underDynamicVariable(scopedDynamicVariable: $innerBlocks) @start
  @underEachArrayItem(passValueOnwardsAs: "innerBlock") @start
    @exportFrom(
      scopedDynamicVariable: $innerBlock
      as: "innerBlocks"
      type: DICTIONARY
    )
  @end # <!-- @underEachArrayItem -->
@end # <!-- @underDynamicVariable -->
```

The new section covers the before/after comparison, that the block is a read-only view (modifications made inside it are discarded when the field's value is restored, so values computed inside must be exported via `@exportFrom`), and the handling of a `null` value and of errors.