### PR TITLE
Do not format a non-date value as a date when serializing

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -14,6 +14,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - Updated "Field Value Iteration and Manipulation" docs with the `@underDynamicVariable` meta directive (#3371)
 
+### Fixed
+
+- Serializing the value of a field of type `Date` or `DateTime` no longer produces an uncaught PHP error when that value is not a date. This happens whenever a meta directive overrides the value of the field while keeping its type (eg: via `@underDynamicVariable`, or `@applyField` with `setResultInResponse: true`), and made the request fail with a 500 response instead of returning a GraphQL error. Such a value is now serialized as any other scalar would be (#3372)
+
 ## 19.1.0 - 27/07/2026
 
 ### Added

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
@@ -62,3 +62,26 @@ Both methods can be combined within the same query, but not on the same meta dir
 ## Improvements
 
 - Updated "Field Value Iteration and Manipulation" docs with the `@underDynamicVariable` meta directive ([#3371](https://github.com/GatoGraphQL/GatoGraphQL/pull/3371))
+
+## Fixed
+
+- Serializing the value of a field of type `Date` or `DateTime` no longer produces an uncaught PHP error when that value is not a date ([#3372](https://github.com/GatoGraphQL/GatoGraphQL/pull/3372)).
+
+  A meta directive can override the value of a field while keeping its type, as in:
+
+  ```graphql
+  {
+    post(by: { id: 1 }) {
+      date
+        @underDynamicVariable(scopedDynamicVariable: $someList) @start
+          @underEachArrayItem(passValueOnwardsAs: "item") @start
+            @exportFrom(scopedDynamicVariable: $item, as: "items", type: DICTIONARY)
+          @end
+        @end
+    }
+  }
+  ```
+
+  Field `date` is of type `DateTime`, but the value being processed is not a date. Serializing it formatted the value as a date regardless, producing a PHP error which made the whole request fail with a 500 response, instead of returning a GraphQL error.
+
+  Such a value is now serialized as any other scalar would be, and only an actual date is formatted as a date.

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -250,6 +250,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 = 19.2.0 =
 * Added - Helper directives `@start` and `@end` to indicate which directives are affected by a meta directive, as an alternative to argument `affectDirectivesUnderPos`: the affected directives are wrapped between `@start` and `@end` (placed right after the meta directive), removing the need to calculate their relative positions, which is error prone in large queries. Both methods produce the same result, and can be combined within the same query (but not on the same meta directive) (#3369)
 * Improved - Updated "Field Value Iteration and Manipulation" docs with the `@underDynamicVariable` meta directive (#3371)
+* Fixed - Serializing the value of a field of type `Date` or `DateTime` no longer produces an uncaught PHP error when that value is not a date. This happens whenever a meta directive overrides the value of the field while keeping its type (eg: via `@underDynamicVariable`, or `@applyField` with `setResultInResponse: true`), and made the request fail with a 500 response instead of returning a GraphQL error. Such a value is now serialized as any other scalar would be (#3372)
 
 = 19.1.0 =
 * Added - Filter custom posts by their parent: the `customPosts` query gains the `parentID`, `parentIDs` and `excludeParentIDs` filter inputs (as already available on the `pages` query), mapping to WordPress' `post_parent`, `post_parent__in` and `post_parent__not_in` query args (#3366)

--- a/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractDateTimeScalarTypeResolver.php
+++ b/layers/Schema/packages/schema-commons/src/TypeResolvers/ScalarType/AbstractDateTimeScalarTypeResolver.php
@@ -105,7 +105,17 @@ abstract class AbstractDateTimeScalarTypeResolver extends AbstractScalarTypeReso
      */
     public function serialize(string|int|float|bool|object $scalarValue): string|int|float|bool|array|stdClass
     {
-        /** @var DateTimeInterface $scalarValue */
+        /**
+         * The value is not necessarily a DateTime: a meta directive can
+         * override the value of the field while keeping its type, as in
+         * `@underDynamicVariable` or `@applyField(setResultInResponse: true)`.
+         *
+         * Then serialize it as any other scalar would, instead of calling
+         * `->format(...)` on it (which produces an uncaught PHP Error).
+         */
+        if (!($scalarValue instanceof DateTimeInterface)) {
+            return parent::serialize($scalarValue);
+        }
         return $scalarValue->format($this->getDateTimeFormat());
     }
 

--- a/layers/Schema/packages/schema-commons/tests/TypeResolvers/ScalarType/DateTimeScalarTypeResolverSerializationTest.php
+++ b/layers/Schema/packages/schema-commons/tests/TypeResolvers/ScalarType/DateTimeScalarTypeResolverSerializationTest.php
@@ -6,7 +6,6 @@ namespace PoPSchema\SchemaCommons\TypeResolvers\ScalarType;
 
 use DateTime;
 use DateTimeImmutable;
-use DateTimeInterface;
 use PoP\ComponentModel\AbstractTestCase;
 use stdClass;
 

--- a/layers/Schema/packages/schema-commons/tests/TypeResolvers/ScalarType/DateTimeScalarTypeResolverSerializationTest.php
+++ b/layers/Schema/packages/schema-commons/tests/TypeResolvers/ScalarType/DateTimeScalarTypeResolverSerializationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPSchema\SchemaCommons\TypeResolvers\ScalarType;
+
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use PoP\ComponentModel\AbstractTestCase;
+use stdClass;
+
+/**
+ * The value to serialize is not necessarily a DateTime: a meta directive
+ * can override the value of the field while keeping its type (as done by
+ * `@underDynamicVariable` or `@applyField(setResultInResponse: true)`).
+ *
+ * Then serializing must not assume the value implements DateTimeInterface.
+ */
+class DateTimeScalarTypeResolverSerializationTest extends AbstractTestCase
+{
+    private function getDateTimeScalarTypeResolver(): DateTimeScalarTypeResolver
+    {
+        /** @var DateTimeScalarTypeResolver */
+        return $this->getService(DateTimeScalarTypeResolver::class);
+    }
+
+    private function getDateScalarTypeResolver(): DateScalarTypeResolver
+    {
+        /** @var DateScalarTypeResolver */
+        return $this->getService(DateScalarTypeResolver::class);
+    }
+
+    public function testSerializeDateTimeValue(): void
+    {
+        $dateTime = new DateTime('2018-10-20T20:03:48+00:00');
+
+        $this->assertSame(
+            '2018-10-20T20:03:48+00:00',
+            $this->getDateTimeScalarTypeResolver()->serialize($dateTime)
+        );
+        $this->assertSame(
+            '2018-10-20',
+            $this->getDateScalarTypeResolver()->serialize($dateTime)
+        );
+    }
+
+    public function testSerializeDateTimeImmutableValue(): void
+    {
+        $this->assertSame(
+            '2018-10-20T20:03:48+00:00',
+            $this->getDateTimeScalarTypeResolver()->serialize(
+                new DateTimeImmutable('2018-10-20T20:03:48+00:00')
+            )
+        );
+    }
+
+    public function testSerializeStringValue(): void
+    {
+        $this->assertSame(
+            'not a date',
+            $this->getDateTimeScalarTypeResolver()->serialize('not a date')
+        );
+    }
+
+    public function testSerializeEmptyStringValue(): void
+    {
+        $this->assertSame(
+            '',
+            $this->getDateTimeScalarTypeResolver()->serialize('')
+        );
+    }
+
+    public function testSerializeIntValue(): void
+    {
+        $this->assertSame(
+            10,
+            $this->getDateTimeScalarTypeResolver()->serialize(10)
+        );
+    }
+
+    public function testSerializeFloatValue(): void
+    {
+        $this->assertSame(
+            1.5,
+            $this->getDateTimeScalarTypeResolver()->serialize(1.5)
+        );
+    }
+
+    public function testSerializeBoolValue(): void
+    {
+        $this->assertSame(
+            true,
+            $this->getDateTimeScalarTypeResolver()->serialize(true)
+        );
+        $this->assertSame(
+            false,
+            $this->getDateTimeScalarTypeResolver()->serialize(false)
+        );
+    }
+
+    public function testSerializeStdClassValue(): void
+    {
+        $stdClass = new stdClass();
+        $stdClass->greeting = 'hello';
+        $stdClass->target = 'world';
+
+        $serializedValue = $this->getDateTimeScalarTypeResolver()->serialize($stdClass);
+
+        $this->assertEquals($stdClass, $serializedValue);
+    }
+
+    public function testSerializeStdClassValueContainingADateTime(): void
+    {
+        $stdClass = new stdClass();
+        $stdClass->when = new DateTime('2018-10-20T20:03:48+00:00');
+
+        $expectedValue = new stdClass();
+        $expectedValue->when = '2018-10-20T20:03:48+00:00';
+
+        $this->assertEquals(
+            $expectedValue,
+            $this->getDateTimeScalarTypeResolver()->serialize($stdClass)
+        );
+    }
+
+    /**
+     * The `Date` scalar formats a DateTime differently than `DateTime`
+     * does, but both must leave a non-DateTime value untouched.
+     */
+    public function testSerializeNonDateTimeValueOnEveryDateTimeScalar(): void
+    {
+        foreach ([$this->getDateTimeScalarTypeResolver(), $this->getDateScalarTypeResolver()] as $scalarTypeResolver) {
+            $this->assertSame(
+                'not a date',
+                $scalarTypeResolver->serialize('not a date')
+            );
+        }
+    }
+
+    public function testIsAlreadyCoercedValue(): void
+    {
+        $dateTimeScalarTypeResolver = $this->getDateTimeScalarTypeResolver();
+
+        $this->assertTrue($dateTimeScalarTypeResolver->isAlreadyCoercedValue(new DateTime()));
+        $this->assertTrue($dateTimeScalarTypeResolver->isAlreadyCoercedValue(new DateTimeImmutable()));
+        $this->assertFalse($dateTimeScalarTypeResolver->isAlreadyCoercedValue(new stdClass()));
+    }
+}


### PR DESCRIPTION
`AbstractDateTimeScalarTypeResolver::serialize()` assumed its input implements `DateTimeInterface`:

```php
/** @var DateTimeInterface $scalarValue */
return $scalarValue->format($this->getDateTimeFormat());
```

That `@var` is an assertion for PHPStan, not a check. When the value is not a date, `->format()` raises an uncaught PHP `Error` and the whole request fails with a 500 response: no `errors` array, no partial `data`, nothing the client can handle.

The assumption is violated whenever a meta directive overrides the value of a field while keeping its type, which is what those directives are for. Two ways to reach it:

```graphql
{
  post(by: { id: 1 }) {
    date @applyField(name: "_echo", arguments: { value: "not a date" }, setResultInResponse: true)
  }
}
```

```graphql
query One {
  post(by: { id: 1 }) {
    date
      @underDynamicVariable(scopedDynamicVariable: $someList) @start
        @underEachArrayItem(passValueOnwardsAs: "item") @start
          @exportFrom(scopedDynamicVariable: $item, as: "items", type: DICTIONARY)
        @end
      @end
  }
}
```

This is the only scalar in the codebase that overrides `serialize()`, and so the only one that can fatal: `String`, `Int`, `JSONObject`, `URL`, `Email` and the rest all inherit the near-identity `AbstractScalarTypeResolver::serialize()`. Notably, this same class already has the check it needs, 8 lines below, in `isAlreadyCoercedValue()`.

## Fix

Guard, and delegate to the parent for anything that is not a date:

```php
if (!($scalarValue instanceof DateTimeInterface)) {
    return parent::serialize($scalarValue);
}
return $scalarValue->format($this->getDateTimeFormat());
```

Delegating rather than returning the value raw keeps it type-correct (the declared return type excludes plain `object`; the parent narrows it via `ObjectSerializationManager` / recursive `stdClass` handling), makes `DateTime` behave like every sibling scalar, and turns a genuinely unserializable object into the explicit "write a serializer for this class" error instead of a `TypeError`.

## Tests

`DateTimeScalarTypeResolverSerializationTest` covers `serialize()` directly across value types: `DateTime`, `DateTimeImmutable`, string, empty string, int, float, bool, `stdClass`, an `stdClass` nesting a `DateTime`, both the `Date` and `DateTime` scalars, and `isAlreadyCoercedValue()`. 8 of its 11 tests error without the fix, all 11 pass with it.

`composer unit-test`: OK, 480 tests, 1783 assertions. PHPStan and PSR-12 clean on the touched files.