### PR TITLE
Seed options holding quotes, and read them back through the schema

### DIFF
--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/settings.gql
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/settings.gql
@@ -7,6 +7,9 @@
   nonExistingObject: optionObjectValue(name: "nonExisting")
   existingObjects: optionObjectValues(name: "list_of_objects")
   nonExistingObjects: optionObjectValues(name: "nonExisting")
+  valueWithQuotes: optionValue(name: "value_with_quotes")
+  arrayWithQuotes: optionValues(name: "list_of_values_with_quotes")
+  objectWithQuotes: optionObjectValue(name: "object_with_quotes")
   isGutenbergEditorEnabled
   isGutenbergEditorEnabledForPost: useGutenbergEditorWithCustomPostType(customPostType: "post")
   isGutenbergEditorEnabledForDummyCPT: useGutenbergEditorWithCustomPostType(customPostType: "dummy-cpt")

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/settings.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/settings.json
@@ -168,6 +168,15 @@
             }
         ],
         "nonExistingObjects": null,
+        "valueWithQuotes": "It's a \"quoted\" value",
+        "arrayWithQuotes": [
+            "It's the first",
+            "She said \"the second\""
+        ],
+        "objectWithQuotes": {
+            "label": "It's an object",
+            "quote": "She said \"hello\""
+        },
         "isGutenbergEditorEnabled": true,
         "isGutenbergEditorEnabledForPost": true,
         "isGutenbergEditorEnabledForDummyCPT": true

--- a/webservers/_shared/setup/add-options.sh
+++ b/webservers/_shared/setup/add-options.sh
@@ -3,3 +3,10 @@ echo Adding options for Gato GraphQL Integration tests
 
 wp option add downstream_domains [\"$(wp option get siteurl)\"] --format=json
 wp option add list_of_objects '[{"id":"nfpllg","category":"","desc":"","properties":[],"_created":1750156925,"_user_id":1,"_version":"2.0-beta"},{"id":"fufxfs","category":"","desc":"","properties":[],"_created":1750156913,"_user_id":1,"_version":"2.0-beta"}]' --format=json
+
+# Options are somebody else's content, and content holds quotes: what is read
+# out of them travels through a JSON response, and what is printed about them
+# travels through a shell. A value with none in it proves neither.
+wp option add value_with_quotes 'It'\''s a "quoted" value'
+wp option add list_of_values_with_quotes '["It'\''s the first","She said \"the second\""]' --format=json
+wp option add object_with_quotes '{"label":"It'\''s an object","quote":"She said \"hello\""}' --format=json


### PR DESCRIPTION
The options seeded for the integration tests (`downstream_domains`, `list_of_objects`) hold no punctuation, so nothing the suite asserts says what becomes of a quote between `wp_options` and the JSON response.

Three more are seeded — a string, a list and an object, each carrying a single and a double quote — and `fixture-schema/settings.gql` reads all three through `optionValue`, `optionValues` and `optionObjectValue`. A quote swallowed, or escaped twice, is now a failing test.

```
wp option add value_with_quotes 'It'\''s a "quoted" value'
wp option add list_of_values_with_quotes '["It'\''s the first","She said \"the second\""]' --format=json
wp option add object_with_quotes '{"label":"It'\''s an object","quote":"She said \"hello\""}' --format=json
```

Verified against the dev webserver: `vendor/bin/phpunit …/SchemaQueryExecutionFixtureWebserverRequestTest.php --filter settings` → OK (1 test, 5 assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)