### PR TITLE
Make npm install and lint-js work in the components package

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/packages/components/package-lock.json
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/packages/components/package-lock.json
@@ -18,7 +18,7 @@
                 "@wordpress/data": "^9.28.0",
                 "@wordpress/edit-post": "^7.35.0",
                 "@wordpress/scripts": "^27.9.0",
-                "prettier": "npm:wp-prettier@2.0.5",
+                "prettier": "npm:wp-prettier@^3.0.3",
                 "raw-loader": "^4.0.2",
                 "react-select": "^3.0.8"
             }
@@ -112,6 +112,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
             "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.7",
@@ -2089,37 +2090,6 @@
             "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==",
             "dev": true
         },
-        "node_modules/@emotion/babel-plugin/node_modules/babel-plugin-macros": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "cosmiconfig": "^7.0.0",
-                "resolve": "^1.19.0"
-            },
-            "engines": {
-                "node": ">=10",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/@emotion/babel-plugin/node_modules/cosmiconfig": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-            "dev": true,
-            "dependencies": {
-                "@types/parse-json": "^4.0.0",
-                "import-fresh": "^3.2.1",
-                "parse-json": "^5.0.0",
-                "path-type": "^4.0.0",
-                "yaml": "^1.10.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@emotion/babel-plugin/node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -3450,6 +3420,23 @@
                 "url": "https://opencollective.com/unts"
             }
         },
+        "node_modules/@playwright/test": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+            "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "playwright": "1.62.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
             "version": "0.5.15",
             "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.15.tgz",
@@ -3518,6 +3505,7 @@
             "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.3.tgz",
             "integrity": "sha512-M2DXse3Wi8HwjI1d2vQWOLJ3lHogvqTsJYvl4ofXRXgMFQzJ7kmlZvlt5i8x5S5VwgZu0ghru4HkLqOoFfU2JQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@preact/signals-core": "^1.6.0"
             },
@@ -4234,6 +4222,7 @@
             "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -4477,6 +4466,7 @@
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
             "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -4689,6 +4679,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
             "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -4816,6 +4807,7 @@
             "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.27.tgz",
             "integrity": "sha512-wK/oi5gcHi72VMTbOaQ70VcDxSQ1uX8S2tukBK9ARuGXrYM/+u4ou73roc7trXDNmCxCoerE8zruQqX/wuHszA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/anymatch": "*",
                 "@types/node": "*",
@@ -4940,6 +4932,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
             "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "6.21.0",
                 "@typescript-eslint/types": "6.21.0",
@@ -6875,22 +6868,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/@wordpress/scripts/node_modules/prettier": {
-            "name": "wp-prettier",
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
-            "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
-            "dev": true,
-            "bin": {
-                "prettier": "bin/prettier.cjs"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
-            }
-        },
         "node_modules/@wordpress/scripts/node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7131,6 +7108,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
             "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -7204,6 +7182,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -7878,6 +7857,35 @@
                 "source-map": "^0.5.7"
             }
         },
+        "node_modules/babel-plugin-emotion/node_modules/babel-plugin-macros": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+            "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.7.2",
+                "cosmiconfig": "^6.0.0",
+                "resolve": "^1.12.0"
+            }
+        },
+        "node_modules/babel-plugin-emotion/node_modules/cosmiconfig": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+            "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/parse-json": "^4.0.0",
+                "import-fresh": "^3.1.0",
+                "parse-json": "^5.0.0",
+                "path-type": "^4.0.0",
+                "yaml": "^1.7.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/babel-plugin-istanbul": {
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -7910,30 +7918,36 @@
             }
         },
         "node_modules/babel-plugin-macros": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-            "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.7.2",
-                "cosmiconfig": "^6.0.0",
-                "resolve": "^1.12.0"
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
+            },
+            "engines": {
+                "node": ">=10",
+                "npm": ">=6"
             }
         },
         "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-            "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+            "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/parse-json": "^4.0.0",
-                "import-fresh": "^3.1.0",
+                "import-fresh": "^3.2.1",
                 "parse-json": "^5.0.0",
                 "path-type": "^4.0.0",
-                "yaml": "^1.7.2"
+                "yaml": "^1.10.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
@@ -8265,6 +8279,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001629",
                 "electron-to-chromium": "^1.4.796",
@@ -10004,7 +10019,8 @@
             "version": "0.0.1155343",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1155343.tgz",
             "integrity": "sha512-oD9vGBV2wTc7fAzAM6KC0chSgs234V8+qDEeK+mcbRj2UvcuA7lgBztGi/opj/iahcXD3BSj8Ymvib628yy9FA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/diff": {
             "version": "4.0.2",
@@ -10584,6 +10600,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -10639,6 +10656,7 @@
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
             "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
             },
@@ -14082,6 +14100,7 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -17281,6 +17300,7 @@
             "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-6.4.0.tgz",
             "integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.6",
                 "ajv-errors": "^1.0.1",
@@ -18106,6 +18126,53 @@
                 "node": ">=8"
             }
         },
+        "node_modules/playwright": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+            "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.62.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+            "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/plur": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
@@ -18149,6 +18216,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.1",
@@ -18711,6 +18779,7 @@
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
             "integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -18773,6 +18842,7 @@
             "resolved": "https://registry.npmjs.org/preact/-/preact-10.22.1.tgz",
             "integrity": "sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==",
             "dev": true,
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/preact"
@@ -18789,15 +18859,20 @@
         },
         "node_modules/prettier": {
             "name": "wp-prettier",
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-            "integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
+            "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "bin": {
-                "prettier": "bin-prettier.js"
+                "prettier": "bin/prettier.cjs"
             },
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/prettier-linter-helpers": {
@@ -19285,6 +19360,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -19322,6 +19398,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -19367,6 +19444,7 @@
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
             "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -19610,6 +19688,7 @@
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
             "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.9.2"
             }
@@ -20071,6 +20150,7 @@
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
             "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -20166,6 +20246,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
             "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "json-schema-traverse": "^1.0.0",
@@ -21396,6 +21477,7 @@
             "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
             "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@csstools/selector-specificity": "^2.0.2",
                 "balanced-match": "^2.0.0",
@@ -22173,6 +22255,7 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
             "dev": true,
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -22273,6 +22356,21 @@
             "dev": true,
             "dependencies": {
                 "is-typedarray": "^1.0.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/uc.micro": {
@@ -22760,6 +22858,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.1.tgz",
             "integrity": "sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^1.0.5",
@@ -22875,6 +22974,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -23002,6 +23102,7 @@
             "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
             "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.9",
                 "@types/connect-history-api-fallback": "^1.3.5",
@@ -23576,6 +23677,7 @@
             "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.18.tgz",
             "integrity": "sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "lib0": "^0.2.86"
             },
@@ -23659,6 +23761,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
             "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.24.7",
@@ -24027,7 +24130,8 @@
             "version": "7.21.0-placeholder-for-preset-env.2",
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
             "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@babel/plugin-syntax-async-generators": {
             "version": "7.8.4",
@@ -24970,7 +25074,8 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.2.0.tgz",
             "integrity": "sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@discoveryjs/json-ext": {
             "version": "0.5.7",
@@ -25033,30 +25138,6 @@
                     "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
                     "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==",
                     "dev": true
-                },
-                "babel-plugin-macros": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-                    "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/runtime": "^7.12.5",
-                        "cosmiconfig": "^7.0.0",
-                        "resolve": "^1.19.0"
-                    }
-                },
-                "cosmiconfig": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-                    "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-                    "dev": true,
-                    "requires": {
-                        "@types/parse-json": "^4.0.0",
-                        "import-fresh": "^3.2.1",
-                        "parse-json": "^5.0.0",
-                        "path-type": "^4.0.0",
-                        "yaml": "^1.10.0"
-                    }
                 },
                 "csstype": {
                     "version": "3.1.3",
@@ -25318,7 +25399,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
             "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@emotion/utils": {
             "version": "0.11.3",
@@ -26124,6 +26206,16 @@
             "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
             "dev": true
         },
+        "@playwright/test": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+            "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "playwright": "1.62.1"
+            }
+        },
         "@pmmmwh/react-refresh-webpack-plugin": {
             "version": "0.5.15",
             "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.15.tgz",
@@ -26158,6 +26250,7 @@
             "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.3.tgz",
             "integrity": "sha512-M2DXse3Wi8HwjI1d2vQWOLJ3lHogvqTsJYvl4ofXRXgMFQzJ7kmlZvlt5i8x5S5VwgZu0ghru4HkLqOoFfU2JQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@preact/signals-core": "^1.6.0"
             }
@@ -26609,49 +26702,57 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
             "integrity": "sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@svgr/babel-plugin-remove-jsx-attribute": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-8.0.0.tgz",
             "integrity": "sha512-BcCkm/STipKvbCl6b7QFrMh/vx00vIP63k2eM66MfHJzPr6O2U0jYEViXkHJWqXqQYjdeA9cuCl5KWmlwjDvbA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@svgr/babel-plugin-remove-jsx-empty-expression": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-8.0.0.tgz",
             "integrity": "sha512-5BcGCBfBxB5+XSDSWnhTThfI9jcO5f0Ai2V24gZpG+wXF14BzwxxdDb4g6trdOux0rhibGs385BeFMSmxtS3uA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@svgr/babel-plugin-replace-jsx-attribute-value": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-8.0.0.tgz",
             "integrity": "sha512-KVQ+PtIjb1BuYT3ht8M5KbzWBhdAjjUPdlMtpuw/VjT8coTrItWX6Qafl9+ji831JaJcu6PJNKCV0bp01lBNzQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@svgr/babel-plugin-svg-dynamic-title": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-8.0.0.tgz",
             "integrity": "sha512-omNiKqwjNmOQJ2v6ge4SErBbkooV2aAWwaPFs2vUY7p7GhVkzRkJ00kILXQvRhA6miHnNpXv7MRnnSjdRjK8og==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@svgr/babel-plugin-svg-em-dimensions": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-8.0.0.tgz",
             "integrity": "sha512-mURHYnu6Iw3UBTbhGwE/vsngtCIbHE43xCRK7kCw4t01xyGqb2Pd+WXekRRoFOBIY29ZoOhUCTEweDMdrjfi9g==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@svgr/babel-plugin-transform-react-native-svg": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-8.1.0.tgz",
             "integrity": "sha512-Tx8T58CHo+7nwJ+EhUwx3LfdNSG9R2OKfaIXXs5soiy5HtgoAEkDay9LIimLOcG8dJQH1wPZp/cnAv6S9CrR1Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@svgr/babel-plugin-transform-svg-component": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-8.0.0.tgz",
             "integrity": "sha512-DFx8xa3cZXTdb/k3kfPeaixecQLgKh5NVBMwD0AQxOzcZawK4oo1Jh9LbrcACUivsCA7TLG8eeWgrDXjTMhRmw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@svgr/babel-preset": {
             "version": "8.1.0",
@@ -26674,6 +26775,7 @@
             "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
             "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@babel/core": "^7.21.3",
                 "@svgr/babel-preset": "8.1.0",
@@ -26870,6 +26972,7 @@
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
             "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
@@ -27082,6 +27185,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
             "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -27210,6 +27314,7 @@
             "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.27.tgz",
             "integrity": "sha512-wK/oi5gcHi72VMTbOaQ70VcDxSQ1uX8S2tukBK9ARuGXrYM/+u4ou73roc7trXDNmCxCoerE8zruQqX/wuHszA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/anymatch": "*",
                 "@types/node": "*",
@@ -27312,6 +27417,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
             "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@typescript-eslint/scope-manager": "6.21.0",
                 "@typescript-eslint/types": "6.21.0",
@@ -27622,19 +27728,22 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
             "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@webpack-cli/info": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
             "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@webpack-cli/serve": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
             "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@wordpress/a11y": {
             "version": "3.58.0",
@@ -27671,7 +27780,8 @@
             "version": "4.41.0",
             "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.41.0.tgz",
             "integrity": "sha512-hYxj2Uobxk86ctlfaJou9v13XqXZ30yx4ZwRNu5cH5/LWXe2MIXBTPv7dUk6wqN/qFOjsFvP9jCB0NsW6MnkrA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@wordpress/babel-preset-default": {
             "version": "7.42.0",
@@ -28520,7 +28630,8 @@
             "version": "4.43.0",
             "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.43.0.tgz",
             "integrity": "sha512-XSb7AdDC7yGTBVYeRM4oqmOygEB+/+tk7lobLIGDmlZJs+M3F/NUvQq0Vcas1pojq2fyPYTUwOlu81ga33fNwQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@wordpress/patterns": {
             "version": "1.19.0",
@@ -28594,7 +28705,8 @@
             "version": "3.15.0",
             "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.15.0.tgz",
             "integrity": "sha512-exC2rkEioTt//AnzPRyaaFv8FNYIvamPDytNol5bKQ6Qh65QSdZZE9V+GtRCrIPL7/Bq6xba03XuRVxl9TjtJg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@wordpress/primitives": {
             "version": "3.56.0",
@@ -28795,12 +28907,6 @@
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
-                "prettier": {
-                    "version": "npm:wp-prettier@3.0.3",
-                    "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
-                    "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
-                    "dev": true
-                },
                 "supports-color": {
                     "version": "7.2.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -28988,7 +29094,8 @@
             "version": "8.12.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
             "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "acorn-globals": {
             "version": "7.0.1",
@@ -29004,13 +29111,15 @@
             "version": "1.9.5",
             "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
             "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "8.3.3",
@@ -29041,6 +29150,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -29052,7 +29162,8 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
             "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ajv-formats": {
             "version": "2.1.1",
@@ -29087,7 +29198,8 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ansi-colors": {
             "version": "4.1.3",
@@ -29527,6 +29639,32 @@
                 "escape-string-regexp": "^1.0.5",
                 "find-root": "^1.1.0",
                 "source-map": "^0.5.7"
+            },
+            "dependencies": {
+                "babel-plugin-macros": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+                    "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/runtime": "^7.7.2",
+                        "cosmiconfig": "^6.0.0",
+                        "resolve": "^1.12.0"
+                    }
+                },
+                "cosmiconfig": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+                    "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/parse-json": "^4.0.0",
+                        "import-fresh": "^3.1.0",
+                        "parse-json": "^5.0.0",
+                        "path-type": "^4.0.0",
+                        "yaml": "^1.7.2"
+                    }
+                }
             }
         },
         "babel-plugin-istanbul": {
@@ -29555,27 +29693,27 @@
             }
         },
         "babel-plugin-macros": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
-            "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+            "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.7.2",
-                "cosmiconfig": "^6.0.0",
-                "resolve": "^1.12.0"
+                "@babel/runtime": "^7.12.5",
+                "cosmiconfig": "^7.0.0",
+                "resolve": "^1.19.0"
             },
             "dependencies": {
                 "cosmiconfig": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-                    "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+                    "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
                     "dev": true,
                     "requires": {
                         "@types/parse-json": "^4.0.0",
-                        "import-fresh": "^3.1.0",
+                        "import-fresh": "^3.2.1",
                         "parse-json": "^5.0.0",
                         "path-type": "^4.0.0",
-                        "yaml": "^1.7.2"
+                        "yaml": "^1.10.0"
                     }
                 }
             }
@@ -29828,6 +29966,7 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
             "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "caniuse-lite": "^1.0.30001629",
                 "electron-to-chromium": "^1.4.796",
@@ -30628,7 +30767,8 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
             "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "css-functions-list": {
             "version": "3.2.2",
@@ -30747,7 +30887,8 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.2.tgz",
             "integrity": "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "csso": {
             "version": "5.0.5",
@@ -30926,7 +31067,8 @@
             "version": "1.5.3",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
             "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "deep-equal": {
             "version": "2.2.3",
@@ -30976,7 +31118,8 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.5.0.tgz",
             "integrity": "sha512-bFywDpBUUWMs576H2dgLFLLFuQ/UWXbzHfKD98MZTfGsl7+twIzvz4ihCNrRrZ/Emz3kqJaNIAp5eBWUEWhnAw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "default-gateway": {
             "version": "6.0.3",
@@ -31087,7 +31230,8 @@
             "version": "0.0.1155343",
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1155343.tgz",
             "integrity": "sha512-oD9vGBV2wTc7fAzAM6KC0chSgs234V8+qDEeK+mcbRj2UvcuA7lgBztGi/opj/iahcXD3BSj8Ymvib628yy9FA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "diff": {
             "version": "4.0.2",
@@ -31552,6 +31696,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
             "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -31769,7 +31914,9 @@
             "version": "8.10.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
             "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
-            "dev": true
+            "dev": true,
+            "peer": true,
+            "requires": {}
         },
         "eslint-import-resolver-node": {
             "version": "0.3.9",
@@ -32028,7 +32175,8 @@
             "version": "0.15.3",
             "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.15.3.tgz",
             "integrity": "sha512-LQMW5y0DLK5Fnpya7JR1oAYL2/7Y9wDiYw6VZqlKqcRGSgjbVKNqxraphk7ra1U3Bb5EK444xMgUlQPbMg2M1g==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-plugin-prettier": {
             "version": "5.1.3",
@@ -32092,7 +32240,8 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
             "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "eslint-scope": {
             "version": "5.1.1",
@@ -33378,7 +33527,8 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
             "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ieee754": {
             "version": "1.2.1",
@@ -34042,6 +34192,7 @@
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -34704,7 +34855,8 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
             "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "jest-regex-util": {
             "version": "29.6.3",
@@ -35611,7 +35763,8 @@
                             "version": "8.13.0",
                             "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
                             "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-                            "dev": true
+                            "dev": true,
+                            "requires": {}
                         }
                     }
                 },
@@ -35647,7 +35800,8 @@
                     "version": "7.5.10",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
                     "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {}
                 }
             }
         },
@@ -36452,6 +36606,7 @@
             "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-6.4.0.tgz",
             "integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "ajv": "^6.12.6",
                 "ajv-errors": "^1.0.1",
@@ -37057,6 +37212,31 @@
                 "find-up": "^4.0.0"
             }
         },
+        "playwright": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+            "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+            "dev": true,
+            "requires": {
+                "fsevents": "2.3.2",
+                "playwright-core": "1.62.1"
+            },
+            "dependencies": {
+                "fsevents": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+                    "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "playwright-core": {
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+            "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+            "dev": true
+        },
         "plur": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
@@ -37077,6 +37257,7 @@
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
             "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.1",
@@ -37119,25 +37300,29 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.2.tgz",
             "integrity": "sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-discard-duplicates": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.3.tgz",
             "integrity": "sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-discard-empty": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.3.tgz",
             "integrity": "sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-discard-overridden": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.2.tgz",
             "integrity": "sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-loader": {
             "version": "6.2.1",
@@ -37243,7 +37428,8 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
             "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.5",
@@ -37278,7 +37464,8 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.2.tgz",
             "integrity": "sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-normalize-display-values": {
             "version": "6.0.2",
@@ -37367,7 +37554,8 @@
             "version": "1.49.0",
             "resolved": "https://registry.npmjs.org/postcss-prefixwrap/-/postcss-prefixwrap-1.49.0.tgz",
             "integrity": "sha512-TpUrBl78L3zJXuL32YBnPY122zlOo9qm31onXQFX+n0UdyRciBUz8Zefxt5mo963dqQbtkvg91XOgx6Vx8J7hQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-reduce-initial": {
             "version": "6.1.0",
@@ -37398,19 +37586,22 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
             "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-scss": {
             "version": "4.0.9",
             "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
             "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "postcss-selector-parser": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
             "integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -37454,7 +37645,8 @@
             "version": "10.22.1",
             "resolved": "https://registry.npmjs.org/preact/-/preact-10.22.1.tgz",
             "integrity": "sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "prelude-ls": {
             "version": "1.2.1",
@@ -37463,10 +37655,11 @@
             "dev": true
         },
         "prettier": {
-            "version": "npm:wp-prettier@2.0.5",
-            "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.0.5.tgz",
-            "integrity": "sha512-5GCgdeevIXwR3cW4Qj5XWC5MO1iSCz8+IPn0mMw6awAt/PBiey8yyO7MhePRsaMqghJAhg6Q3QLYWSnUHWkG6A==",
-            "dev": true
+            "version": "npm:wp-prettier@3.0.3",
+            "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
+            "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
+            "dev": true,
+            "peer": true
         },
         "prettier-linter-helpers": {
             "version": "1.0.0",
@@ -37694,7 +37887,8 @@
                     "version": "8.5.0",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
                     "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {}
                 }
             }
         },
@@ -37818,6 +38012,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0"
             }
@@ -37837,13 +38032,15 @@
             "version": "5.6.1",
             "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
             "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "react-dom": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -37878,7 +38075,8 @@
             "version": "0.14.2",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
             "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "react-remove-scroll": {
             "version": "2.5.4",
@@ -38049,6 +38247,7 @@
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
             "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@babel/runtime": "^7.9.2"
             }
@@ -38402,6 +38601,7 @@
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
             "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",
                 "immutable": "^4.0.0",
@@ -38453,6 +38653,7 @@
                     "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
                     "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
                     "dev": true,
+                    "peer": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
                         "json-schema-traverse": "^1.0.0",
@@ -39439,6 +39640,7 @@
             "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
             "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@csstools/selector-specificity": "^2.0.2",
                 "balanced-match": "^2.0.0",
@@ -39551,7 +39753,8 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
             "integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "stylelint-config-recommended-scss": {
             "version": "5.0.2",
@@ -39965,7 +40168,8 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
             "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "tsconfig-paths": {
             "version": "3.15.0",
@@ -40038,7 +40242,8 @@
             "version": "0.21.3",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
             "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "type-is": {
             "version": "1.6.18",
@@ -40110,6 +40315,13 @@
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
+        },
+        "typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "peer": true
         },
         "uc.micro": {
             "version": "1.0.6",
@@ -40293,7 +40505,8 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.2.tgz",
             "integrity": "sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "use-sidecar": {
             "version": "1.1.2",
@@ -40309,7 +40522,8 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
             "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -40455,6 +40669,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.1.tgz",
             "integrity": "sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^1.0.5",
@@ -40531,7 +40746,8 @@
                     "version": "7.5.10",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
                     "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-                    "dev": true
+                    "dev": true,
+                    "requires": {}
                 }
             }
         },
@@ -40540,6 +40756,7 @@
             "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
             "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
                 "@webpack-cli/configtest": "^2.1.1",
@@ -40617,6 +40834,7 @@
             "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
             "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "@types/bonjour": "^3.5.9",
                 "@types/connect-history-api-fallback": "^1.3.5",
@@ -40899,7 +41117,8 @@
             "version": "8.18.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
             "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "xdg-basedir": {
             "version": "4.0.0",
@@ -41003,6 +41222,7 @@
             "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.18.tgz",
             "integrity": "sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==",
             "dev": true,
+            "peer": true,
             "requires": {
                 "lib0": "^0.2.86"
             }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/packages/components/package.json
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/packages/components/package.json
@@ -30,8 +30,15 @@
         "@wordpress/data": "^9.28.0",
         "@wordpress/edit-post": "^7.35.0",
         "@wordpress/scripts": "^27.9.0",
-        "prettier": "npm:wp-prettier@2.0.5",
+        "prettier": "npm:wp-prettier@^3.0.3",
         "raw-loader": "^4.0.2",
         "react-select": "^3.0.8"
+    },
+    "overrides": {
+        "typescript": "^5.4.5",
+        "react-select": {
+            "react": "^18.0.0",
+            "react-dom": "^18.0.0"
+        }
     }
 }


### PR DESCRIPTION
`packages/components` could neither be installed without a flag nor linted at all. Three separate causes, each measured.

### 1. `lint-js` died with `TypeError: prettier.resolveConfig is not a function`

`eslint-plugin-prettier@5.1.3` (shipped by `@wordpress/scripts@27.9`) reaches prettier through a dynamic import:

```js
prettier = await import('prettier');
… await prettier.resolveConfig(…)   // worker.js:40
```

The package pinned `prettier` down to `npm:wp-prettier@2.0.5`. On that CJS build the named exports are not detected, so the import namespace has the API under `.default`:

| | named `resolveConfig` via `import()` |
| --- | --- |
| wp-prettier **2.0.5** | `undefined` ← the TypeError |
| wp-prettier **3.0.3** | `function` |

`@wordpress/scripts@27.9` already depends on `prettier: npm:wp-prettier@3.0.3`, so the pin was dragging it backwards. It now follows what `@wordpress/scripts` ships.

Note this had to stay an explicit pin: simply dropping it lets npm hoist **stock** `prettier@3.9.6` instead of the WordPress fork, which would change the formatting rules.

### 2. Installing required `--legacy-peer-deps`

`react-select@3.2.0` declares `peerDependencies: { react: "^16.8.0 || ^17.0.0" }` while the package is on React 18. An `overrides` entry lets a plain `npm install` resolve.

### 3. …which then surfaced a third failure

Once peers actually resolve, npm pulls `typescript` in (through `ts-api-utils`, whose peer range is an open-ended `>=4.2.0`) and picks the newest major. `ts-api-utils@1.3.0` cannot read it, and ESLint failed with `Failed to load plugin '@typescript-eslint': Cannot read properties of undefined (reading 'Intrinsic')`. Pinned to the major that library expects. TypeScript is only an optional peer of `@typescript-eslint` — packages that lint fine today simply have none installed.

### Verification

Both from a wiped `node_modules`:

| | before | after |
| --- | --- | --- |
| `npm install` | `ERESOLVE`, needs `--legacy-peer-deps` | succeeds, no flags |
| resolved `prettier` | wp-prettier@2.0.5 | wp-prettier@**3.0.3** (also from `eslint-plugin-prettier`'s own resolution) |
| `typescript` | latest major | 5.9.3 |
| `wp-scripts lint-js src` | `TypeError`, nothing linted | runs — 701 findings |

Rebuilt a consumer block: the bundle is byte-identical, so nothing shipped changes.

### Scope

Tooling only. No source file is touched, and the 701 findings ESLint can now see are the formatting backlog from the years it was unable to run — left for its own pass, as they are pure `prettier/prettier` reformatting. Nothing in CI runs `lint-js`, so this cannot affect the build either way.

No changelog entry: nothing here is visible to a user of the plugin.