### PR TITLE
Document why `--legacy-peer-deps` must stay in `build-js.sh`

### DIFF
--- a/dev-helpers/scripts/build-js.sh
+++ b/dev-helpers/scripts/build-js.sh
@@ -28,7 +28,7 @@ BASE_DIR="$PWD/$1"
 # Pass the command to execute:
 # - BUILD_PROD: run `npm build` for all blocks
 # - COMPILE_DEV: run `npm start` for all blocks in a new tab
-# - INSTALL_DEPS: run `npm install --legacy-peers` for all blocks
+# - INSTALL_DEPS: run `npm install --legacy-peer-deps` for all blocks
 COMMAND="$2"
 ########################################################################
 
@@ -72,6 +72,15 @@ runCommand(){
                 ttab 'npm start'
             elif [ $COMMAND = "INSTALL_DEPS" ]
             then
+                # Do not remove `--legacy-peer-deps`. Without it, npm resolves
+                # the peer dependencies of the `@wordpress/scripts` toolchain,
+                # which installs `typescript` at its latest major (via the
+                # open-ended peer range of `ts-api-utils`) and Playwright.
+                # `ts-api-utils` cannot read that version of TypeScript, so
+                # `npm run lint-js` then fails to load the `@typescript-eslint`
+                # plugin in every package that does not pin `typescript` under
+                # `overrides` in its `package.json` — which is most of them. It
+                # also adds ~45 MB of unused Playwright to each package.
                 npm install --legacy-peer-deps
             fi
             cd ..


### PR DESCRIPTION
`dev-helpers/scripts/build-js.sh` installs every block's dependencies with `npm install --legacy-peer-deps`. That flag reads as leftover cruft — the peer-dependency conflict it was originally added for (react-select v3 declaring React 16/17 against the toolchain's React 18) was fixed at the source in #3383, by adding a `react-select` override to the two `packages/components` manifests.

It is not cruft, and removing it now would break the build tooling. This adds a comment saying so, so the next person to look at it doesn't have to re-run the experiment.

## Why it must stay

`--legacy-peer-deps` skips installing peer dependencies altogether. Without it, npm resolves the peers of the `@wordpress/scripts` toolchain, and two of them are hazards:

- **`typescript`** — reached through `ts-api-utils`, whose peer range is open-ended (`>=4.2.0`), so npm installs the latest major. `ts-api-utils@1.3.0` cannot read it, and ESLint then dies loading the plugin:

  ```
  Failed to load plugin '@typescript-eslint' declared in '--config » plugin:@wordpress/recommended':
  Cannot read properties of undefined (reading 'Intrinsic')
  ```

  Only the two `packages/components` manifests pin `typescript` under `overrides` (added in #3383). **56 of the 58 packages do not**, so `npm run lint-js` would break in all of them.

- **Playwright** — `@playwright/test`, `playwright` and `playwright-core` get installed into every package, though nothing here uses them.

## Measured

A/B install of `layers/GatoGraphQLForWP/plugins/access-control-visitor-ip/blocks/access-control-rule-visitor-ip` (a package with no `typescript` override), from a clean `node_modules`:

| | with `--legacy-peer-deps` | without |
| --- | --- | --- |
| packages installed | 1978 | 1983 |
| `node_modules` size | 527 MB | 572 MB |
| `typescript` | not installed | 7.0.2 |
| `npm run lint-js` | works (29 findings) | fails to load `@typescript-eslint` |

The five extra packages are exactly `@playwright/test`, `playwright`, `playwright-core`, `typescript` and `@typescript-eslint`'s TS dependency. Across all 58 packages the Playwright copies alone would add roughly 2.6 GB.

Removing the flag properly would mean adding a `typescript` override to all 58 manifests, in exchange for a slower, much larger install and no lint benefit.

## Also

Fixes a typo in the header comment: `--legacy-peers` → `--legacy-peer-deps`.

Comment-only change; `bash -n` passes.