### PR TITLE
Stop autoloading the options that are only read in the wp-admin

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -10,6 +10,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 - Documentation for the FluentCart integration (#3379)
 
+### Improvements
+
+- The plugin's cached AI model data, its log counts and its internal transients are no longer loaded on every request, only where they are read (#3387)
+
 ## 19.2.1 - 20/08/2026
 
 ### Improvements

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.3/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.3/en.md
@@ -1,5 +1,15 @@
 # Release Notes: 19.3
 
+## Improvements
+
+### Fewer options loaded on every request
+
+WordPress loads the options marked as "autoload" on every single request, front-end ones included. Three of the plugin's own were marked that way and had no business being: the cached list of models retrieved from the AI services, the log entry counts, and the internal flags kept between one request and the next ([#3387](https://github.com/GatoGraphQL/GatoGraphQL/pull/3387)).
+
+None of them is read outside the wp-admin, the WP-CLI commands, or a translation being run, and the AI model data in particular can run to hundreds of kilobytes on a site with several AI services configured. They are now read where they are used instead.
+
+Nothing needs doing on an existing site: each option stops being autoloaded the next time it is written.
+
 ## Added
 
 ### FluentCart extension

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -249,6 +249,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 = 19.3.0 =
 * Added - Documentation for the FluentCart integration (#3379)
+* Improved - The plugin's cached AI model data, its log counts and its internal transients are no longer loaded on every request, only where they are read (#3387)
 
 = 19.2.1 =
 * Improved - Tested up to WordPress 7.1 (#aa2cdc8d)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Settings/JSONDataOptionSettingsManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Settings/JSONDataOptionSettingsManager.php
@@ -69,7 +69,7 @@ class JSONDataOptionSettingsManager implements JSONDataOptionSettingsManagerInte
             $jsonData,
             $nameData
         );
-        update_option($option, $jsonData);
+        update_option($option, $jsonData, false);
     }
 
     /**
@@ -97,6 +97,6 @@ class JSONDataOptionSettingsManager implements JSONDataOptionSettingsManagerInte
             return;
         }
 
-        update_option($option, $jsonData);
+        update_option($option, $jsonData, false);
     }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Settings/LogEntryCounterSettingsManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Settings/LogEntryCounterSettingsManager.php
@@ -92,7 +92,7 @@ class LogEntryCounterSettingsManager implements LogEntryCounterSettingsManagerIn
             $logCounts,
             array_change_key_case($severityLogCounts, CASE_LOWER)
         );
-        update_option($option, $logCounts);
+        update_option($option, $logCounts, false);
     }
 
     /**
@@ -120,6 +120,6 @@ class LogEntryCounterSettingsManager implements LogEntryCounterSettingsManagerIn
             return;
         }
 
-        update_option($option, $logCounts);
+        update_option($option, $logCounts, false);
     }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Settings/TransientSettingsManager.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Settings/TransientSettingsManager.php
@@ -59,7 +59,7 @@ class TransientSettingsManager implements TransientSettingsManagerInterface
             $transients,
             $nameTransients
         );
-        update_option($option, $transients);
+        update_option($option, $transients, false);
     }
 
     /**
@@ -87,6 +87,6 @@ class TransientSettingsManager implements TransientSettingsManagerInterface
             return;
         }
 
-        update_option($option, $transients);
+        update_option($option, $transients, false);
     }
 }


### PR DESCRIPTION
WordPress loads every option marked as autoload on every single request, front-end ones included. Three of the plugin's own were marked that way, and none of them is read outside the wp-admin, the WP-CLI commands, or a translation being run.

| Option | Written by | Read by |
| --- | --- | --- |
| `gatographql-json-data` | the AI services' model retrieval | the AI settings form, model resolution at translation time |
| `gatographql-log-counts` | `Logger::logMessage()`, when something is logged | the Logs screen, the menu badge, the WP-CLI commands |
| `gatographql-transients` | license activation, plugin/theme status change | `AbstractMainPlugin`, behind an `is_admin()` guard |

`gatographql-json-data` is the one that costs the most: it holds the model lists retrieved from each AI service, and on a site with several of them configured it runs to hundreds of kilobytes loaded on every page view for nothing.

The three managers now pass `false` as `update_option()`'s `$autoload`. `update_option()` re-evaluates the autoload column whenever the value passed differs from the one stored, so an existing site stops autoloading each option on its next write — no migration, and nothing to do on upgrade.

### What keeps autoloading, and why

- `gatographql-modules` and `gatographql-timestamps` — both decide whether the cached service container is still valid, so they are read before anything else on every request.
- `gatographql-endpoint-configuration`, `-schema-configuration`, `-schema-type-configuration`, `-server-configuration`, `-plugin-configuration`, `-plugin-integration-configuration`, `-api-keys` — read through `UserSettingsManager` while the schema is built.
- `gatographql-commercial-extension-activated-license-entries` — read at bootstrap to gate which extensions load at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uwntMfH1F2npDJ1oZor3x