### PR TITLE
Stop autoloading the stored plugin and extension versions

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -13,6 +13,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Improvements
 
 - The plugin's cached AI model data, its log counts and its internal transients are no longer loaded on every request, only where they are read (#3387)
+- The stored plugin and extension versions are no longer loaded on every request, only in the wp-admin where they are read (#3388)
 
 ## 19.2.1 - 20/08/2026
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.3/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.3/en.md
@@ -8,6 +8,8 @@ WordPress loads the options marked as "autoload" on every single request, front-
 
 None of them is read outside the wp-admin, the WP-CLI commands, or a translation being run, and the AI model data in particular can run to hundreds of kilobytes on a site with several AI services configured. They are now read where they are used instead.
 
+The same goes for the record of which version of the plugin and of each extension is installed, which is only consulted in the wp-admin to notice that one of them has just been activated or updated ([#3388](https://github.com/GatoGraphQL/GatoGraphQL/pull/3388)).
+
 Nothing needs doing on an existing site: each option stops being autoloaded the next time it is written.
 
 ## Added

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -250,6 +250,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 = 19.3.0 =
 * Added - Documentation for the FluentCart integration (#3379)
 * Improved - The plugin's cached AI model data, its log counts and its internal transients are no longer loaded on every request, only where they are read (#3387)
+* Improved - The stored plugin and extension versions are no longer loaded on every request, only in the wp-admin where they are read (#3388)
 
 = 19.2.1 =
 * Improved - Tested up to WordPress 7.1 (#aa2cdc8d)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractMainPlugin.php
@@ -337,7 +337,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
         $option = $optionNamespacer->namespaceOption(PluginOptions::PLUGIN_VERSIONS);
         $storedPluginVersions = get_option($option, []);
         unset($storedPluginVersions[$pluginBaseName]);
-        update_option($option, $storedPluginVersions);
+        update_option($option, $storedPluginVersions, false);
     }
 
 
@@ -694,7 +694,7 @@ abstract class AbstractMainPlugin extends AbstractPlugin implements MainPluginIn
                          *
                          * @see https://github.com/GatoGraphQL/GatoGraphQL/issues/2631
                          */
-                        update_option($option, $storedPluginVersions);
+                        update_option($option, $storedPluginVersions, false);
 
                         if ($isMainPluginJustActivated) {
                             $this->pluginJustActivated();

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractPlugin.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/PluginSkeleton/AbstractPlugin.php
@@ -428,7 +428,7 @@ abstract class AbstractPlugin implements PluginInterface
         $option = $optionNamespacer->namespaceOption(PluginOptions::PLUGIN_VERSIONS);
         $pluginVersions = get_option($option, []);
         unset($pluginVersions[$this->pluginBaseName]);
-        \update_option($option, $pluginVersions);
+        \update_option($option, $pluginVersions, false);
     }
 
     /**


### PR DESCRIPTION
Follow-up to #3387, from the same audit.

`gatographql-plugin-versions` maps each installed plugin and extension to the version last seen, so that an activation or an update can be noticed and acted on. On a site with the bundle installed it is around 4KB, and it was being loaded on every single request.

It is read in exactly one place — the `PluginAppHooks::INITIALIZE_APP` closure in `AbstractMainPlugin` — and that closure returns early on `!is_admin()`:

```php
add_action(
    PluginAppHooks::INITIALIZE_APP,
    function (string $pluginAppGraphQLServerName): void {
        if (
            $pluginAppGraphQLServerName === PluginAppGraphQLServerNames::INTERNAL
            || !is_admin()
            || $this->initializationException !== null
        ) {
            return;
        }
        ...
        $storedPluginVersions = get_option($option, []);
```

The other two touches are the deactivation paths in `AbstractMainPlugin::removePluginVersion()` and `AbstractPlugin::removePluginVersion()`, which are wp-admin as well.

All three writes now pass `false` as `update_option()`'s `$autoload`, so an existing site takes the option off the autoload set on its next write.

### Looked at and left alone

`gatographql-plugin-management` (~3.4KB) is also a candidate on size, but its settings are reached through `UserSettingsManager` from module resolvers rather than from a single guarded place, so whether anything consults one while the container or the schema is built needs tracing before it can be moved. Left as it is for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uwntMfH1F2npDJ1oZor3x