### PR TITLE
Harden protected meta key and allow/deny matching

### DIFF
--- a/layers/CMSSchema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
+++ b/layers/CMSSchema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
@@ -82,7 +82,7 @@ class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
 
     protected function normalizeMetaKeyForProtection(string $key): string
     {
-        return strtolower(remove_accents(rtrim($key)));
+        return strtolower(remove_accents(trim($key)));
     }
 
     /**

--- a/layers/CMSSchema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
+++ b/layers/CMSSchema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
@@ -10,6 +10,7 @@ use WP_User;
 use function current_user_can;
 use function get_user_meta;
 use function is_protected_meta;
+use function remove_accents;
 
 /**
  * Methods to interact with the Type, to be implemented by the underlying CMS
@@ -18,6 +19,9 @@ class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
 {
     public function isMetaKeyProtected(string $key): bool
     {
+        if ($this->isMetaKeyRoleRelated($key)) {
+            return !current_user_can('promote_users');
+        }
         if (current_user_can('manage_options')) {
             return false;
         }
@@ -32,10 +36,35 @@ class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
 
     protected function isMetaKeyAbsolutelyProtected(string $key): bool
     {
-        $normalizedKey = $this->normalizeMetaKeyForProtection($key);
-        if ($normalizedKey === 'session_tokens' || $normalizedKey === '_application_passwords') {
+        return $this->matchesProtectedMetaKey($key, $this->isNormalizedMetaKeyAbsolutelyProtected(...));
+    }
+
+    protected function isMetaKeyRoleRelated(string $key): bool
+    {
+        return $this->matchesProtectedMetaKey($key, $this->isNormalizedMetaKeyRoleRelated(...));
+    }
+
+    /**
+     * @param callable(string):bool $isNormalizedMetaKeyProtected
+     */
+    protected function matchesProtectedMetaKey(string $key, callable $isNormalizedMetaKeyProtected): bool
+    {
+        if ($isNormalizedMetaKeyProtected($this->normalizeMetaKeyForProtection($key))) {
             return true;
         }
+        if (preg_match('/[^\x20-\x7E]/', $key) !== 1) {
+            return false;
+        }
+        foreach ($this->getDatabaseResolvedMetaKeys($key) as $matchedMetaKey) {
+            if ($isNormalizedMetaKeyProtected($this->normalizeMetaKeyForProtection($matchedMetaKey))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function isNormalizedMetaKeyRoleRelated(string $normalizedKey): bool
+    {
         global $wpdb;
         $basePrefix = strtolower($wpdb->base_prefix);
         return preg_match(
@@ -44,9 +73,31 @@ class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
         ) === 1;
     }
 
+    protected function isNormalizedMetaKeyAbsolutelyProtected(string $normalizedKey): bool
+    {
+        return $normalizedKey === 'session_tokens'
+            || $normalizedKey === '_application_passwords'
+            || $this->isNormalizedMetaKeyRoleRelated($normalizedKey);
+    }
+
     protected function normalizeMetaKeyForProtection(string $key): string
     {
-        return strtolower(rtrim($key));
+        return strtolower(remove_accents(rtrim($key)));
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getDatabaseResolvedMetaKeys(string $key): array
+    {
+        global $wpdb;
+        /** @var string[] */
+        return $wpdb->get_col(
+            $wpdb->prepare(
+                "SELECT DISTINCT meta_key FROM {$wpdb->usermeta} WHERE meta_key = %s",
+                $key
+            )
+        );
     }
 
     public function isMetaKeyProtectedFromReading(string $key): bool

--- a/layers/CMSSchema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
+++ b/layers/CMSSchema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
@@ -32,15 +32,21 @@ class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
 
     protected function isMetaKeyAbsolutelyProtected(string $key): bool
     {
-        if ($key === 'session_tokens' || $key === '_application_passwords') {
+        $normalizedKey = $this->normalizeMetaKeyForProtection($key);
+        if ($normalizedKey === 'session_tokens' || $normalizedKey === '_application_passwords') {
             return true;
         }
         global $wpdb;
-        $basePrefix = $wpdb->base_prefix;
+        $basePrefix = strtolower($wpdb->base_prefix);
         return preg_match(
             '/^' . preg_quote($basePrefix, '/') . '(?:\d+_)?(?:capabilities|user_level)$/',
-            $key
+            $normalizedKey
         ) === 1;
+    }
+
+    protected function normalizeMetaKeyForProtection(string $key): string
+    {
+        return strtolower(rtrim($key));
     }
 
     public function isMetaKeyProtectedFromReading(string $key): bool

--- a/layers/GatoGraphQLForWP/phpunit-packages/wpfaker-schema/tests/Unit/WPFakerFixtureQueryExecutionGraphQLServerTestTrait.php
+++ b/layers/GatoGraphQLForWP/phpunit-packages/wpfaker-schema/tests/Unit/WPFakerFixtureQueryExecutionGraphQLServerTestTrait.php
@@ -17,6 +17,7 @@ use function Brain\faker;
 use function Brain\fakerReset;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\stubEscapeFunctions;
+use function Brain\Monkey\Functions\when;
 use function Brain\Monkey\setUp;
 use function Brain\Monkey\tearDown;
 
@@ -124,6 +125,9 @@ trait WPFakerFixtureQueryExecutionGraphQLServerTestTrait
     {
         // Stub `esc_sql`
         stubEscapeFunctions();
+
+        // There is no logged-in user in these tests
+        when('current_user_can')->justReturn(false);
 
         // Use default date format by WordPress
         expect('get_option')

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -9,6 +9,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Security
 
 - Fixed a privilege escalation vulnerability where a logged-in user could still modify protected user meta keys (such as their own role/capabilities) through the user meta mutations by varying the letter case or adding trailing whitespace to the key name, bypassing the protection added in 19.2.2 (#3392)
+- The allow/deny lists for settings and meta keys are no longer bypassable by varying the letter case or adding trailing whitespace in the name, which allowed reading the value of a denylisted option, and writing and filtering by a denylisted meta key (#3392)
 
 ## 19.2.2 - 02/09/2026
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -8,8 +8,9 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ### Security
 
-- Fixed a privilege escalation vulnerability where a logged-in user could still modify protected user meta keys (such as their own role/capabilities) through the user meta mutations by varying the letter case or adding trailing whitespace to the key name, bypassing the protection added in 19.2.2 (#3392)
-- The allow/deny lists for settings and meta keys are no longer bypassable by varying the letter case or adding trailing whitespace in the name, which allowed reading the value of a denylisted option, and writing and filtering by a denylisted meta key (#3392)
+- Fixed a privilege escalation vulnerability where a logged-in user could still modify protected user meta keys (such as their own role/capabilities) through the user meta mutations by varying the letter case, accenting a letter, or adding trailing whitespace to the key name, bypassing the protection added in 19.2.2 (#3392)
+- The allow/deny lists for settings and meta keys are no longer bypassable by varying the letter case, accenting a letter, or adding trailing whitespace in the name, which allowed reading the value of a denylisted option, and writing and filtering by a denylisted meta key (#3392)
+- Writing the roles/capabilities user meta keys now requires the "promote users" capability, instead of any administrator-level capability (#3392)
 
 ## 19.2.2 - 02/09/2026
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `gatographql` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 19.2.3 - 07/09/2026
+
+### Security
+
+- Fixed a privilege escalation vulnerability where a logged-in user could still modify protected user meta keys (such as their own role/capabilities) through the user meta mutations by varying the letter case or adding trailing whitespace to the key name, bypassing the protection added in 19.2.2 (#3392)
+
 ## 19.2.2 - 02/09/2026
 
 ### Security

--- a/layers/GatoGraphQLForWP/plugins/gatographql/config/Overrides/services.yaml
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/config/Overrides/services.yaml
@@ -18,3 +18,6 @@ services:
     # Inject "executing-graphql" into the state
     GraphQLByPoP\GraphQLEndpointForWP\State\GraphQLEndpointHandlerAppStateProvider:
         class: \GatoGraphQL\GatoGraphQL\Overrides\State\GraphQLEndpointHandlerAppStateProvider
+
+    PoPSchema\SchemaCommons\Services\AllowOrDenySettingsServiceInterface:
+        class: \GatoGraphQL\GatoGraphQL\Overrides\Services\AllowOrDenySettingsService

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
@@ -10,6 +10,8 @@ Previously, because editing one's own account authorized writing any meta key on
 
 The same protection is applied to the custom post, comment and taxonomy meta mutations, which now reject WordPress protected meta keys (those flagged by `is_protected_meta`, such as keys prefixed with `_`) ([#3389](https://github.com/GatoGraphQL/GatoGraphQL/pull/3389)).
 
+In 19.2.3 this protection was hardened to also reject variants of the protected keys that differ only in letter case or trailing whitespace (such as `WP_capabilities` or `wp_capabilities `). WordPress resolves the meta key against the database column case-insensitively and ignoring trailing whitespace, so such a variant still targeted the protected row; the check now normalizes the key the same way before rejecting it ([#3392](https://github.com/GatoGraphQL/GatoGraphQL/pull/3392)).
+
 Protected **user** meta keys are also no longer **readable** by non-administrators. Previously any user, including anonymous visitors, could read them through fields `metaValue`, `metaValues`, `meta` and `metaKeys` — including application-password hashes stored under `_application_passwords`, session tokens, and the roles/capabilities keys — because the meta allow/deny list defaulted to permissive. Now administrators can read any user meta key, while every other user cannot read the protected ones (they are also omitted from the `metaKeys` list). Meta on other entities (posts, comments, taxonomies) is unaffected — for instance a product's `_price` remains readable — so this does not change public content reads.
 
 ### Reading site options is restricted to administrators

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
@@ -4,23 +4,27 @@
 
 ### Protected user meta keys can no longer be modified through mutations
 
+(`v19.2.2`)
+
 Writing a protected user meta key (the role/capabilities key, the user level, session tokens and application passwords) through the user meta mutations `addUserMeta`, `updateUserMeta`, `setUserMeta` and `deleteUserMeta` (and their bulk variants) is now rejected ([#3389](https://github.com/GatoGraphQL/GatoGraphQL/pull/3389)).
 
 Previously, because editing one's own account authorized writing any meta key on it, a logged-in user could set their own capabilities key and escalate to a higher role. Assigning roles remains available through the `updateUser` mutation's `roles` input, which is gated by the `promote_users` capability.
 
 The same protection is applied to the custom post, comment and taxonomy meta mutations, which now reject WordPress protected meta keys (those flagged by `is_protected_meta`, such as keys prefixed with `_`) ([#3389](https://github.com/GatoGraphQL/GatoGraphQL/pull/3389)).
 
-In 19.2.3 this protection was hardened to also reject variants of the protected keys that differ only in letter case or trailing whitespace (such as `WP_capabilities` or `wp_capabilities `). WordPress resolves the meta key against the database column case-insensitively and ignoring trailing whitespace, so such a variant still targeted the protected row; the check now normalizes the key the same way before rejecting it ([#3392](https://github.com/GatoGraphQL/GatoGraphQL/pull/3392)).
+In `v19.2.3` this protection was hardened to also reject variants of the protected keys that differ only in letter case or trailing whitespace (such as `WP_capabilities` or `wp_capabilities `). WordPress resolves the meta key against the database column case-insensitively and ignoring trailing whitespace, so such a variant still targeted the protected row; the check now normalizes the key the same way before rejecting it ([#3392](https://github.com/GatoGraphQL/GatoGraphQL/pull/3392)).
 
 Protected **user** meta keys are also no longer **readable** by non-administrators. Previously any user, including anonymous visitors, could read them through fields `metaValue`, `metaValues`, `meta` and `metaKeys` — including application-password hashes stored under `_application_passwords`, session tokens, and the roles/capabilities keys — because the meta allow/deny list defaulted to permissive. Now administrators can read any user meta key, while every other user cannot read the protected ones (they are also omitted from the `metaKeys` list). Meta on other entities (posts, comments, taxonomies) is unaffected — for instance a product's `_price` remains readable — so this does not change public content reads.
 
 ### Reading site options is restricted to administrators
 
+(`v19.2.2`)
+
 The fields to read site options (`optionValue`, `optionValues`, `optionNames`, `optionObjectValue` and `optionObjectValues`) previously allowed any user, including anonymous visitors, to read the value of any option in the database, because the "Settings" allow/deny list defaulted to an empty denylist. This could expose sensitive options such as API keys stored by other plugins ([#3389](https://github.com/GatoGraphQL/GatoGraphQL/pull/3389)).
 
 Now, administrators can read any option, while every other user can only read the options explicitly added to the settings allowlist, whose default is empty. To expose specific options publicly, add them under Settings.
 
-In 19.2.3 the allow/deny list matching itself was hardened. Entries were compared against the requested name exactly, so on a site configured with a *denylist*, a name differing only in letter case or trailing whitespace did not match the entry and passed the check, while the database resolved it to the very same option or meta key. This allowed reading the value of a denylisted option, and writing and filtering by a denylisted meta key. Names are now compared ignoring letter case and trailing whitespace, for both the settings and the meta allow/deny lists ([#3392](https://github.com/GatoGraphQL/GatoGraphQL/pull/3392)).
+In `v19.2.3` the allow/deny list matching itself was hardened. Entries were compared against the requested name exactly, so on a site configured with a *denylist*, a name differing only in letter case or trailing whitespace did not match the entry and passed the check, while the database resolved it to the very same option or meta key. This allowed reading the value of a denylisted option, and writing and filtering by a denylisted meta key. Names are now compared ignoring letter case and trailing whitespace, for both the settings and the meta allow/deny lists ([#3392](https://github.com/GatoGraphQL/GatoGraphQL/pull/3392)).
 
 ## Added
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
@@ -20,6 +20,8 @@ The fields to read site options (`optionValue`, `optionValues`, `optionNames`, `
 
 Now, administrators can read any option, while every other user can only read the options explicitly added to the settings allowlist, whose default is empty. To expose specific options publicly, add them under Settings.
 
+In 19.2.3 the allow/deny list matching itself was hardened. Entries were compared against the requested name exactly, so on a site configured with a *denylist*, a name differing only in letter case or trailing whitespace did not match the entry and passed the check, while the database resolved it to the very same option or meta key. This allowed reading the value of a denylisted option, and writing and filtering by a denylisted meta key. Names are now compared ignoring letter case and trailing whitespace, for both the settings and the meta allow/deny lists ([#3392](https://github.com/GatoGraphQL/GatoGraphQL/pull/3392)).
+
 ## Added
 
 ### Composing directives with `@start` and `@end`

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -247,6 +247,9 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 == Changelog ==
 
+= 19.2.3 =
+* Security - Fixed a privilege escalation vulnerability where a logged-in user could still modify protected user meta keys (such as their own role/capabilities) through the user meta mutations by varying the letter case or adding trailing whitespace to the key name, bypassing the protection added in 19.2.2 (#3392)
+
 = 19.2.2 =
 * Security - Fixed a privilege escalation vulnerability where a logged-in user could modify protected user meta keys (such as their own role/capabilities) through the user meta mutations to gain higher privileges (#3389)
 * Security - Protected meta keys (WordPress internal keys, such as those prefixed with <code>_</code>) can no longer be written through the custom post, comment and taxonomy meta mutations either (#3389)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -249,6 +249,7 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 = 19.2.3 =
 * Security - Fixed a privilege escalation vulnerability where a logged-in user could still modify protected user meta keys (such as their own role/capabilities) through the user meta mutations by varying the letter case or adding trailing whitespace to the key name, bypassing the protection added in 19.2.2 (#3392)
+* Security - The allow/deny lists for settings and meta keys are no longer bypassable by varying the letter case or adding trailing whitespace in the name, which allowed reading the value of a denylisted option, and writing and filtering by a denylisted meta key (#3392)
 
 = 19.2.2 =
 * Security - Fixed a privilege escalation vulnerability where a logged-in user could modify protected user meta keys (such as their own role/capabilities) through the user meta mutations to gain higher privileges (#3389)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -248,8 +248,9 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 == Changelog ==
 
 = 19.2.3 =
-* Security - Fixed a privilege escalation vulnerability where a logged-in user could still modify protected user meta keys (such as their own role/capabilities) through the user meta mutations by varying the letter case or adding trailing whitespace to the key name, bypassing the protection added in 19.2.2 (#3392)
-* Security - The allow/deny lists for settings and meta keys are no longer bypassable by varying the letter case or adding trailing whitespace in the name, which allowed reading the value of a denylisted option, and writing and filtering by a denylisted meta key (#3392)
+* Security - Fixed a privilege escalation vulnerability where a logged-in user could still modify protected user meta keys (such as their own role/capabilities) through the user meta mutations by varying the letter case, accenting a letter, or adding trailing whitespace to the key name, bypassing the protection added in 19.2.2 (#3392)
+* Security - The allow/deny lists for settings and meta keys are no longer bypassable by varying the letter case, accenting a letter, or adding trailing whitespace in the name, which allowed reading the value of a denylisted option, and writing and filtering by a denylisted meta key (#3392)
+* Security - Writing the roles/capabilities user meta keys now requires the "promote users" capability, instead of any administrator-level capability (#3392)
 
 = 19.2.2 =
 * Security - Fixed a privilege escalation vulnerability where a logged-in user could modify protected user meta keys (such as their own role/capabilities) through the user meta mutations to gain higher privileges (#3389)

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Overrides/Services/AllowOrDenySettingsService.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Overrides/Services/AllowOrDenySettingsService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GatoGraphQL\GatoGraphQL\Overrides\Services;
+
+use PoPSchema\SchemaCommons\Services\AllowOrDenySettingsService as UpstreamAllowOrDenySettingsService;
+
+use function remove_accents;
+
+/**
+ * The `option_name` and `meta_key` columns use a Unicode collation which,
+ * on top of ignoring letter case and trailing whitespace, treats a letter
+ * and its accented variants as the same character. An entry on a denylist
+ * would then not match a name such as "plugin_api_kéy", which the database
+ * nevertheless resolves to the denylisted "plugin_api_key".
+ */
+class AllowOrDenySettingsService extends UpstreamAllowOrDenySettingsService
+{
+    protected function normalizeEntryName(string $name): string
+    {
+        return parent::normalizeEntryName(remove_accents($name));
+    }
+}

--- a/layers/Schema/packages/schema-commons/src/Services/AllowOrDenySettingsService.php
+++ b/layers/Schema/packages/schema-commons/src/Services/AllowOrDenySettingsService.php
@@ -19,8 +19,9 @@ class AllowOrDenySettingsService implements AllowOrDenySettingsServiceInterface
         if ($entries === []) {
             return $behavior === Behaviors::DENY;
         }
+        $normalizedName = $this->normalizeEntryName($name);
         $matchResults = array_filter(array_map(
-            function (string $termOrRegex) use ($name): bool {
+            function (string $termOrRegex) use ($name, $normalizedName): bool {
                 // Remove whitespaces at either end of the string
                 $termOrRegex = trim($termOrRegex);
 
@@ -29,10 +30,11 @@ class AllowOrDenySettingsService implements AllowOrDenySettingsServiceInterface
                     (str_starts_with($termOrRegex, '/') && str_ends_with($termOrRegex, '/'))
                     || (str_starts_with($termOrRegex, '#') && str_ends_with($termOrRegex, '#'))
                 ) {
-                    return preg_match($termOrRegex, $name) === 1;
+                    return preg_match($termOrRegex . 'i', $name) === 1
+                        || preg_match($termOrRegex . 'i', $normalizedName) === 1;
                 }
                 // Check it's a full match
-                return $termOrRegex === $name;
+                return $this->normalizeEntryName($termOrRegex) === $normalizedName;
             },
             $entries
         ));
@@ -43,5 +45,10 @@ class AllowOrDenySettingsService implements AllowOrDenySettingsServiceInterface
             return false;
         }
         return true;
+    }
+
+    protected function normalizeEntryName(string $name): string
+    {
+        return strtolower(rtrim($name));
     }
 }

--- a/layers/Schema/packages/schema-commons/src/Services/AllowOrDenySettingsService.php
+++ b/layers/Schema/packages/schema-commons/src/Services/AllowOrDenySettingsService.php
@@ -49,6 +49,6 @@ class AllowOrDenySettingsService implements AllowOrDenySettingsServiceInterface
 
     protected function normalizeEntryName(string $name): string
     {
-        return strtolower(rtrim($name));
+        return strtolower(trim($name));
     }
 }

--- a/layers/Schema/packages/schema-commons/tests/Services/AllowOrDenySettingsServiceTest.php
+++ b/layers/Schema/packages/schema-commons/tests/Services/AllowOrDenySettingsServiceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPSchema\SchemaCommons\Services;
+
+use PoPSchema\SchemaCommons\Constants\Behaviors;
+use PHPUnit\Framework\TestCase;
+
+class AllowOrDenySettingsServiceTest extends TestCase
+{
+    private function getService(): AllowOrDenySettingsService
+    {
+        return new AllowOrDenySettingsService();
+    }
+
+    public function testEmptyEntriesAllowUnderDenyBehavior(): void
+    {
+        $service = $this->getService();
+        $this->assertTrue($service->isEntryAllowed('anything', [], Behaviors::DENY));
+        $this->assertFalse($service->isEntryAllowed('anything', [], Behaviors::ALLOW));
+    }
+
+    /**
+     * @dataProvider provideProtectedNameVariants
+     */
+    public function testDenylistCannotBeBypassedByNameVariant(string $name): void
+    {
+        $service = $this->getService();
+        $this->assertFalse(
+            $service->isEntryAllowed($name, ['plugin_api_key'], Behaviors::DENY)
+        );
+    }
+
+    /**
+     * @dataProvider provideProtectedNameVariants
+     */
+    public function testDenylistRegexCannotBeBypassedByNameVariant(string $name): void
+    {
+        $service = $this->getService();
+        $this->assertFalse(
+            $service->isEntryAllowed($name, ['/^plugin_api_key$/'], Behaviors::DENY)
+        );
+    }
+
+    /**
+     * @dataProvider provideProtectedNameVariants
+     */
+    public function testDenylistUppercaseRegexCannotBeBypassedByNameVariant(string $name): void
+    {
+        $service = $this->getService();
+        $this->assertFalse(
+            $service->isEntryAllowed($name, ['/^PLUGIN_API_KEY$/'], Behaviors::DENY)
+        );
+    }
+
+    public function testDenylistRegexStillAllowsUnrelatedNames(): void
+    {
+        $service = $this->getService();
+        $this->assertTrue(
+            $service->isEntryAllowed('blogname', ['/^plugin_api_key$/'], Behaviors::DENY)
+        );
+    }
+
+    /**
+     * @return array<string,array{0:string}>
+     */
+    public static function provideProtectedNameVariants(): array
+    {
+        return [
+            'exact' => ['plugin_api_key'],
+            'uppercase' => ['PLUGIN_API_KEY'],
+            'mixed case' => ['Plugin_Api_Key'],
+            'trailing space' => ['plugin_api_key '],
+            'uppercase and trailing space' => ['PLUGIN_API_KEY '],
+        ];
+    }
+
+    public function testDenylistStillAllowsUnrelatedNames(): void
+    {
+        $service = $this->getService();
+        $this->assertTrue(
+            $service->isEntryAllowed('blogname', ['plugin_api_key'], Behaviors::DENY)
+        );
+        $this->assertTrue(
+            $service->isEntryAllowed('plugin_api_key_suffix', ['plugin_api_key'], Behaviors::DENY)
+        );
+    }
+
+    /**
+     * @dataProvider provideProtectedNameVariants
+     */
+    public function testAllowlistAcceptsNameVariantsOfTheSameEntry(string $name): void
+    {
+        $service = $this->getService();
+        $this->assertTrue(
+            $service->isEntryAllowed($name, ['plugin_api_key'], Behaviors::ALLOW)
+        );
+    }
+
+    public function testAllowlistStillRejectsUnlistedNames(): void
+    {
+        $service = $this->getService();
+        $this->assertFalse(
+            $service->isEntryAllowed('plugin_api_key', ['blogname'], Behaviors::ALLOW)
+        );
+    }
+}

--- a/layers/Schema/packages/schema-commons/tests/Services/AllowOrDenySettingsServiceTest.php
+++ b/layers/Schema/packages/schema-commons/tests/Services/AllowOrDenySettingsServiceTest.php
@@ -73,6 +73,8 @@ class AllowOrDenySettingsServiceTest extends TestCase
             'mixed case' => ['Plugin_Api_Key'],
             'trailing space' => ['plugin_api_key '],
             'uppercase and trailing space' => ['PLUGIN_API_KEY '],
+            'leading space' => [' plugin_api_key'],
+            'surrounding space' => ['  plugin_api_key  '],
         ];
     }
 


### PR DESCRIPTION
Hardens the protected meta key and allow/deny matching introduced in 19.2.2.

The `meta_key` and `option_name` columns are compared by the database under a collation that treats certain differences in spelling as equal. The PHP-side checks added in 19.2.2 compared names exactly, so the two could disagree about whether a given name referred to a protected key or to a configured entry. The checks now follow the database's own matching instead.

## Changes

- **`UserMetaTypeAPI`** normalizes a meta key before matching it against the protected keys, and where normalization is not sufficient it resolves the key through the database rather than attempting to reproduce the collation in PHP. The extra lookup is gated so it does not run on the common path.
- **`AllowOrDenySettingsService`** matches allow/deny entries under the same normalization, for both literal and regex entries. Allowlists are unaffected in substance, since a variant spelling resolves to the same underlying row. Part of this is WordPress-specific and is applied through the plugin's existing `config/Overrides/` convention.
- **Role writes** to the capabilities keys now require `promote_users`, aligning the meta path with the gate already used by `AbstractCreateOrUpdateUserMutationResolver`.

## Also here

`current_user_can` is stubbed in the WPFaker unit tests. Since the admin bypass was added in 19.2.2 they errored with *"current_user_can is not defined nor mocked"*, which aborted the run before any test executed.

## Tests

- `AllowOrDenySettingsServiceTest` — 24 cases across literal and regex entries under both behaviours.
- The `user-meta-protected-keys` fixture gains coverage for the variant spellings across the non-admin role classes.
- Unit suites green (504 upstream); the settings and meta integration classes pass.

## Not included

Defaulting the meta allow/deny lists to an allowlist rather than an empty denylist is a breaking change and is being handled separately for 20.0 — unlike settings, `AbstractMetaTypeAPI::validateIsMetaKeyAllowed()` has no admin bypass, so that flip would also stop administrators reading user meta. It is hardening rather than an open hole, as protected keys have an independent barrier regardless of how the list is configured.

Further detail is deliberately withheld until the release has shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTxkUBvy2xAixEpEAoYzZk
