### PR TITLE
Restrict protected meta keys to administrators, and resolve look-alike key names

### DIFF
--- a/layers/CMSSchema/packages/commentmeta-wp/src/TypeAPIs/CommentMetaTypeAPI.php
+++ b/layers/CMSSchema/packages/commentmeta-wp/src/TypeAPIs/CommentMetaTypeAPI.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoPCMSSchema\CommentMetaWP\TypeAPIs;
 
 use PoPCMSSchema\CommentMeta\TypeAPIs\AbstractCommentMetaTypeAPI;
+use PoPCMSSchema\MetaQueryWP\TypeAPIs\ProtectedMetaKeyResolverTrait;
 use WP_Comment;
 
 use function current_user_can;
@@ -13,15 +14,36 @@ use function is_protected_meta;
 
 class CommentMetaTypeAPI extends AbstractCommentMetaTypeAPI
 {
+    use ProtectedMetaKeyResolverTrait;
+
     public function isMetaKeyProtected(string $key): bool
     {
         if (current_user_can('manage_options')) {
             return false;
         }
-        if (!is_protected_meta($key, 'comment')) {
+        if (!$this->isMetaKeyProtectedByCMS($key)) {
             return false;
         }
         return !$this->isMetaKeyExplicitlyAllowed($key);
+    }
+
+    protected function isMetaKeyProtectedByCMS(string $key): bool
+    {
+        return $this->matchesProtectedMetaKey(
+            $key,
+            fn (string $candidateKey): bool => is_protected_meta($candidateKey, 'comment')
+        );
+    }
+
+    protected function getMetaDatabaseTableName(): string
+    {
+        global $wpdb;
+        return $wpdb->commentmeta;
+    }
+
+    public function isMetaKeyProtectedFromReading(string $key): bool
+    {
+        return $this->isMetaKeyProtected($key);
     }
 
     /**

--- a/layers/CMSSchema/packages/custompostmeta-wp/src/TypeAPIs/CustomPostMetaTypeAPI.php
+++ b/layers/CMSSchema/packages/custompostmeta-wp/src/TypeAPIs/CustomPostMetaTypeAPI.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PoPCMSSchema\CustomPostMetaWP\TypeAPIs;
 
 use PoPCMSSchema\CustomPostMeta\TypeAPIs\AbstractCustomPostMetaTypeAPI;
+use PoPCMSSchema\MetaQueryWP\TypeAPIs\ProtectedMetaKeyResolverTrait;
 use WP_Post;
 
 use function current_user_can;
@@ -13,15 +14,36 @@ use function is_protected_meta;
 
 class CustomPostMetaTypeAPI extends AbstractCustomPostMetaTypeAPI
 {
+    use ProtectedMetaKeyResolverTrait;
+
     public function isMetaKeyProtected(string $key): bool
     {
         if (current_user_can('manage_options')) {
             return false;
         }
-        if (!is_protected_meta($key, 'post')) {
+        if (!$this->isMetaKeyProtectedByCMS($key)) {
             return false;
         }
         return !$this->isMetaKeyExplicitlyAllowed($key);
+    }
+
+    protected function isMetaKeyProtectedByCMS(string $key): bool
+    {
+        return $this->matchesProtectedMetaKey(
+            $key,
+            fn (string $candidateKey): bool => is_protected_meta($candidateKey, 'post')
+        );
+    }
+
+    protected function getMetaDatabaseTableName(): string
+    {
+        global $wpdb;
+        return $wpdb->postmeta;
+    }
+
+    public function isMetaKeyProtectedFromReading(string $key): bool
+    {
+        return $this->isMetaKeyProtected($key);
     }
 
     /**

--- a/layers/CMSSchema/packages/metaquery-wp/src/TypeAPIs/ProtectedMetaKeyResolverTrait.php
+++ b/layers/CMSSchema/packages/metaquery-wp/src/TypeAPIs/ProtectedMetaKeyResolverTrait.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\MetaQueryWP\TypeAPIs;
+
+use function remove_accents;
+
+trait ProtectedMetaKeyResolverTrait
+{
+    /**
+     * @param callable(string):bool $isMetaKeyProtected
+     */
+    protected function matchesProtectedMetaKey(string $key, callable $isMetaKeyProtected): bool
+    {
+        foreach ($this->getMetaKeyProtectionCandidates($key) as $candidateKey) {
+            if ($isMetaKeyProtected($candidateKey)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The meta key columns are stored under a case, accent and
+     * trailing-space insensitive collation, and some characters
+     * (such as the zero-width ones) carry no weight at all. Hence
+     * the database can resolve a key to a stored entry which the
+     * PHP comparison, being exact, would not match.
+     *
+     * @return string[]
+     */
+    protected function getMetaKeyProtectionCandidates(string $key): array
+    {
+        $candidateKeys = [$key];
+        $trimmedKey = trim($key);
+        if ($trimmedKey !== $key) {
+            $candidateKeys[] = $trimmedKey;
+        }
+        if (preg_match('/[^\x20-\x7E]/', $key) !== 1) {
+            return $candidateKeys;
+        }
+        foreach ($this->getDatabaseResolvedMetaKeys($key) as $databaseResolvedMetaKey) {
+            $candidateKeys[] = $databaseResolvedMetaKey;
+        }
+        return $candidateKeys;
+    }
+
+    protected function normalizeMetaKeyForProtection(string $key): string
+    {
+        return strtolower(remove_accents(trim($key)));
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getDatabaseResolvedMetaKeys(string $key): array
+    {
+        global $wpdb;
+        $metaTableName = $this->getMetaDatabaseTableName();
+        /** @var string[] */
+        return $wpdb->get_col(
+            $wpdb->prepare(
+                "SELECT DISTINCT meta_key FROM {$metaTableName} WHERE meta_key = %s",
+                $key
+            )
+        );
+    }
+
+    abstract protected function getMetaDatabaseTableName(): string;
+}

--- a/layers/CMSSchema/packages/metaquery-wp/tests/TypeAPIs/ProtectedMetaKeyResolverTraitTest.php
+++ b/layers/CMSSchema/packages/metaquery-wp/tests/TypeAPIs/ProtectedMetaKeyResolverTraitTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\MetaQueryWP\TypeAPIs;
+
+use PHPUnit\Framework\TestCase;
+
+class ProtectedMetaKeyResolverTraitTest extends TestCase
+{
+    private const ZERO_WIDTH_NON_JOINER = "\u{200C}";
+    private const ZERO_WIDTH_SPACE = "\u{200B}";
+    private const ZERO_WIDTH_NO_BREAK_SPACE = "\u{FEFF}";
+    private const FULLWIDTH_LOW_LINE = "\u{FF3F}";
+
+    /**
+     * @param array<string,string[]> $databaseResolvedMetaKeys
+     */
+    private function getResolver(array $databaseResolvedMetaKeys = []): StubProtectedMetaKeyResolver
+    {
+        return new StubProtectedMetaKeyResolver($databaseResolvedMetaKeys);
+    }
+
+    public function testProtectedKeyIsMatched(): void
+    {
+        $this->assertTrue($this->getResolver()->isProtected('_secret'));
+    }
+
+    public function testNonProtectedKeyIsNotMatched(): void
+    {
+        $this->assertFalse($this->getResolver()->isProtected('secret'));
+    }
+
+    /**
+     * @dataProvider provideZeroWeightPrefixedKeys
+     */
+    public function testKeyResolvedByTheDatabaseToAProtectedKeyIsMatched(string $key): void
+    {
+        $resolver = $this->getResolver([$key => ['_secret']]);
+        $this->assertTrue($resolver->isProtected($key));
+    }
+
+    /**
+     * @dataProvider provideZeroWeightPrefixedKeys
+     */
+    public function testKeyResolvedByTheDatabaseToNothingIsNotMatched(string $key): void
+    {
+        $this->assertFalse($this->getResolver()->isProtected($key));
+    }
+
+    /**
+     * @return array<string,array{0:string}>
+     */
+    public static function provideZeroWeightPrefixedKeys(): array
+    {
+        return [
+            'zero-width non-joiner' => [self::ZERO_WIDTH_NON_JOINER . '_secret'],
+            'zero-width space' => [self::ZERO_WIDTH_SPACE . '_secret'],
+            'zero-width no-break space' => [self::ZERO_WIDTH_NO_BREAK_SPACE . '_secret'],
+            'fullwidth low line' => [self::FULLWIDTH_LOW_LINE . 'secret'],
+        ];
+    }
+
+    public function testKeyResolvedByTheDatabaseToADifferentUnprotectedKeyIsNotMatched(): void
+    {
+        $key = self::ZERO_WIDTH_NON_JOINER . 'secret';
+        $resolver = $this->getResolver([$key => ['secret']]);
+        $this->assertFalse($resolver->isProtected($key));
+    }
+
+    public function testSurroundingWhitespaceDoesNotHideAProtectedKey(): void
+    {
+        $resolver = $this->getResolver();
+        $this->assertTrue($resolver->isProtected(' _secret'));
+        $this->assertTrue($resolver->isProtected('_secret '));
+        $this->assertTrue($resolver->isProtected('  _secret  '));
+    }
+
+    public function testAnASCIIKeyIsNotResolvedAgainstTheDatabase(): void
+    {
+        $this->assertSame(['_secret'], $this->getResolver()->getCandidates('_secret'));
+    }
+
+    public function testAnASCIIKeyWithWhitespaceOnlyAddsItsTrimmedForm(): void
+    {
+        $this->assertSame([' _secret ', '_secret'], $this->getResolver()->getCandidates(' _secret '));
+    }
+
+    public function testANonASCIIKeyAddsTheKeysTheDatabaseResolvesItTo(): void
+    {
+        $key = self::ZERO_WIDTH_NON_JOINER . '_secret';
+        $resolver = $this->getResolver([$key => ['_secret', '_Secret']]);
+        $this->assertSame([$key, '_secret', '_Secret'], $resolver->getCandidates($key));
+    }
+}

--- a/layers/CMSSchema/packages/metaquery-wp/tests/TypeAPIs/StubProtectedMetaKeyResolver.php
+++ b/layers/CMSSchema/packages/metaquery-wp/tests/TypeAPIs/StubProtectedMetaKeyResolver.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\MetaQueryWP\TypeAPIs;
+
+class StubProtectedMetaKeyResolver
+{
+    use ProtectedMetaKeyResolverTrait;
+
+    /**
+     * @param array<string,string[]> $databaseResolvedMetaKeys
+     */
+    public function __construct(
+        private readonly array $databaseResolvedMetaKeys = [],
+    ) {
+    }
+
+    public function isProtected(string $key): bool
+    {
+        return $this->matchesProtectedMetaKey(
+            $key,
+            fn (string $candidateKey): bool => str_starts_with($candidateKey, '_')
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCandidates(string $key): array
+    {
+        return $this->getMetaKeyProtectionCandidates($key);
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getDatabaseResolvedMetaKeys(string $key): array
+    {
+        return $this->databaseResolvedMetaKeys[$key] ?? [];
+    }
+
+    protected function getMetaDatabaseTableName(): string
+    {
+        return 'wp_postmeta';
+    }
+}

--- a/layers/CMSSchema/packages/taxonomymeta-wp/src/TypeAPIs/TaxonomyMetaTypeAPI.php
+++ b/layers/CMSSchema/packages/taxonomymeta-wp/src/TypeAPIs/TaxonomyMetaTypeAPI.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\TaxonomyMetaWP\TypeAPIs;
 
+use PoPCMSSchema\MetaQueryWP\TypeAPIs\ProtectedMetaKeyResolverTrait;
 use PoPCMSSchema\TaxonomyMeta\TypeAPIs\AbstractTaxonomyMetaTypeAPI;
 use WP_Term;
 
@@ -13,15 +14,36 @@ use function is_protected_meta;
 
 class TaxonomyMetaTypeAPI extends AbstractTaxonomyMetaTypeAPI
 {
+    use ProtectedMetaKeyResolverTrait;
+
     public function isMetaKeyProtected(string $key): bool
     {
         if (current_user_can('manage_options')) {
             return false;
         }
-        if (!is_protected_meta($key, 'term')) {
+        if (!$this->isMetaKeyProtectedByCMS($key)) {
             return false;
         }
         return !$this->isMetaKeyExplicitlyAllowed($key);
+    }
+
+    protected function isMetaKeyProtectedByCMS(string $key): bool
+    {
+        return $this->matchesProtectedMetaKey(
+            $key,
+            fn (string $candidateKey): bool => is_protected_meta($candidateKey, 'term')
+        );
+    }
+
+    protected function getMetaDatabaseTableName(): string
+    {
+        global $wpdb;
+        return $wpdb->termmeta;
+    }
+
+    public function isMetaKeyProtectedFromReading(string $key): bool
+    {
+        return $this->isMetaKeyProtected($key);
     }
 
     /**

--- a/layers/CMSSchema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
+++ b/layers/CMSSchema/packages/usermeta-wp/src/TypeAPIs/UserMetaTypeAPI.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace PoPCMSSchema\UserMetaWP\TypeAPIs;
 
+use PoPCMSSchema\MetaQueryWP\TypeAPIs\ProtectedMetaKeyResolverTrait;
 use PoPCMSSchema\UserMeta\TypeAPIs\AbstractUserMetaTypeAPI;
 use WP_User;
 
 use function current_user_can;
 use function get_user_meta;
 use function is_protected_meta;
-use function remove_accents;
 
 /**
  * Methods to interact with the Type, to be implemented by the underlying CMS
  */
 class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
 {
+    use ProtectedMetaKeyResolverTrait;
+
     public function isMetaKeyProtected(string $key): bool
     {
         if ($this->isMetaKeyRoleRelated($key)) {
@@ -28,39 +30,38 @@ class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
         if ($this->isMetaKeyAbsolutelyProtected($key)) {
             return true;
         }
-        if (is_protected_meta($key, 'user')) {
+        if ($this->isMetaKeyProtectedByCMS($key)) {
             return !$this->isMetaKeyExplicitlyAllowed($key);
         }
         return false;
     }
 
+    protected function isMetaKeyProtectedByCMS(string $key): bool
+    {
+        return $this->matchesProtectedMetaKey(
+            $key,
+            fn (string $candidateKey): bool => is_protected_meta($candidateKey, 'user')
+        );
+    }
+
     protected function isMetaKeyAbsolutelyProtected(string $key): bool
     {
-        return $this->matchesProtectedMetaKey($key, $this->isNormalizedMetaKeyAbsolutelyProtected(...));
+        return $this->matchesProtectedMetaKey(
+            $key,
+            fn (string $candidateKey): bool => $this->isNormalizedMetaKeyAbsolutelyProtected(
+                $this->normalizeMetaKeyForProtection($candidateKey)
+            )
+        );
     }
 
     protected function isMetaKeyRoleRelated(string $key): bool
     {
-        return $this->matchesProtectedMetaKey($key, $this->isNormalizedMetaKeyRoleRelated(...));
-    }
-
-    /**
-     * @param callable(string):bool $isNormalizedMetaKeyProtected
-     */
-    protected function matchesProtectedMetaKey(string $key, callable $isNormalizedMetaKeyProtected): bool
-    {
-        if ($isNormalizedMetaKeyProtected($this->normalizeMetaKeyForProtection($key))) {
-            return true;
-        }
-        if (preg_match('/[^\x20-\x7E]/', $key) !== 1) {
-            return false;
-        }
-        foreach ($this->getDatabaseResolvedMetaKeys($key) as $matchedMetaKey) {
-            if ($isNormalizedMetaKeyProtected($this->normalizeMetaKeyForProtection($matchedMetaKey))) {
-                return true;
-            }
-        }
-        return false;
+        return $this->matchesProtectedMetaKey(
+            $key,
+            fn (string $candidateKey): bool => $this->isNormalizedMetaKeyRoleRelated(
+                $this->normalizeMetaKeyForProtection($candidateKey)
+            )
+        );
     }
 
     protected function isNormalizedMetaKeyRoleRelated(string $normalizedKey): bool
@@ -80,24 +81,10 @@ class UserMetaTypeAPI extends AbstractUserMetaTypeAPI
             || $this->isNormalizedMetaKeyRoleRelated($normalizedKey);
     }
 
-    protected function normalizeMetaKeyForProtection(string $key): string
-    {
-        return strtolower(remove_accents(trim($key)));
-    }
-
-    /**
-     * @return string[]
-     */
-    protected function getDatabaseResolvedMetaKeys(string $key): array
+    protected function getMetaDatabaseTableName(): string
     {
         global $wpdb;
-        /** @var string[] */
-        return $wpdb->get_col(
-            $wpdb->prepare(
-                "SELECT DISTINCT meta_key FROM {$wpdb->usermeta} WHERE meta_key = %s",
-                $key
-            )
-        );
+        return $wpdb->usermeta;
     }
 
     public function isMetaKeyProtectedFromReading(string $key): bool

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/custom-posts.gql
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/custom-posts.gql
@@ -73,9 +73,9 @@ query {
       metaValue2: metaValue(key: "_wp_page_template")
       meta(keys: ["_thumbnail_id", "_wp_page_template"])
       metaKeys
-      includingMetaKeys: metaKeys(filter: { include: ["_thumbnail_id", "_edit_last"] })
+      includingMetaKeys: metaKeys(filter: { include: ["some_random_int", "some_page_meta", "_thumbnail_id", "_edit_last"] })
       excludingMetaKeys: metaKeys(filter: { exclude: ["_thumbnail_id", "_edit_last"] })
-      includingAndExcludingMetaKeys: metaKeys(filter: { include: ["_thumbnail_id", "_edit_last", "_wp_page_template"], exclude: ["_edit_last", "_wp_page_template"] })
+      includingAndExcludingMetaKeys: metaKeys(filter: { include: ["some_random_int", "some_page_meta", "_thumbnail_id", "_edit_last", "_wp_page_template"], exclude: ["some_random_int", "_edit_last", "_wp_page_template"] })
       # These ones produce the value of data being inserted to DB, so can't save fixed value for testing
       # modifiedDate
       # modifiedDateStr(format: "m-d")

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/custom-posts.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/custom-posts.json
@@ -1,612 +1,724 @@
 {
-    "data": {
-        "urlToCustomPostIDFields": {
-            "existingPostWithTrailingSlash": 1,
-            "existingPostWithoutTrailingSlash": 1,
-            "existingPageWithTrailingSlash": 2,
-            "existingPageWithoutTrailingSlash": 2,
-            "existingDummyCPTWithTrailingSlash": 1613,
-            "existingDummyCPTWithoutTrailingSlash": 1613,
-            "attachmentPageWithTrailingSlash": 1362,
-            "attachmentPageWithoutTrailingSlash": 1362,
-            "nonExistingPost": null,
-            "nonExistingPage": null,
-            "differentDomain": null,
-            "externalDomain": null,
-            "categoryPageWithTrailingSlash": null,
-            "categoryPageWithoutTrailingSlash": null,
-            "userURLWithTrailingSlash": null,
-            "userURLWithoutTrailingSlash": null
-        },
-        "customPosts": [
-            {
-                "__typename": "Post",
-                "areCommentsOpen": true,
-                "author": {
-                    "id": 2,
-                    "name": "Blogger Davenport"
-                },
-                "commentCount": 0,
-                "comments": [],
-                "content": "\n<p class=\"wp-block-paragraph\">Welcome to WordPress. This is your first post. Edit or delete it, then start writing!<\/p>\n",
-                "customPostType": "post",
-                "date": "2020-04-17T13:06:58+00:00",
-                "dateStr": "April 17, 2020",
-                "excerpt": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!",
-                "featuredImage": null,
-                "hasComments": false,
-                "hasFeaturedImage": false,
-                "id": 1,
-                "isStatus": false,
-                "menuOrder": 0,
-                "metaValue": null,
-                "metaValue2": null,
-                "meta": {},
-                "metaKeys": [],
-                "includingMetaKeys": [],
-                "excludingMetaKeys": [],
-                "includingAndExcludingMetaKeys": [],
-                "rawContent": "<!-- wp:paragraph -->\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!<\/p>\n<!-- \/wp:paragraph -->",
-                "slug": "hello-world",
-                "status": "publish",
-                "title": "Hello world!",
-                "url": "https:\/\/gatographql.lndo.site\/hello-world\/",
-                "urlPath": "\/hello-world\/",
-                "slugPath": "hello-world"
-            },
-            {
-                "__typename": "Page",
-                "areCommentsOpen": false,
-                "author": {
-                    "id": 2,
-                    "name": "Blogger Davenport"
-                },
-                "commentCount": 0,
-                "comments": [],
-                "content": "\n<p class=\"wp-block-paragraph\">This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:<\/p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)<\/p><\/blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">&#8230;or something like this:<\/p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.<\/p><\/blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">As a new WordPress user, you should go to <a href=\"https:\/\/gatographql.lndo.site\/wp-admin\/\">your dashboard<\/a> to delete this page and create new pages for your content. Have fun!<\/p>\n",
-                "customPostType": "page",
-                "date": "2020-04-17T13:06:58+00:00",
-                "dateStr": "April 17, 2020",
-                "excerpt": "This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger&hellip; <a class=\"more-link\" href=\"https:\/\/gatographql.lndo.site\/all-blocks-with-entity-references\/\">Continue reading <span class=\"screen-reader-text\">All blocks with entity references<\/span><\/a>",
-                "featuredImage": null,
-                "hasComments": false,
-                "hasFeaturedImage": false,
-                "id": 2,
-                "isStatus": false,
-                "menuOrder": 0,
-                "metaValue": null,
-                "metaValue2": "default",
-                "meta": {
-                    "_wp_page_template": [
-                        "default"
-                    ]
-                },
-                "metaKeys": [
-                    "_wp_page_template"
-                ],
-                "includingMetaKeys": [],
-                "excludingMetaKeys": [
-                    "_wp_page_template"
-                ],
-                "includingAndExcludingMetaKeys": [],
-                "rawContent": "<!-- wp:paragraph -->\n<p>This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>Hi there! I'm a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin' caught in the rain.)<\/p><\/blockquote>\n<!-- \/wp:quote -->\n\n<!-- wp:paragraph -->\n<p>...or something like this:<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.<\/p><\/blockquote>\n<!-- \/wp:quote -->\n\n<!-- wp:paragraph -->\n<p>As a new WordPress user, you should go to <a href=\"https:\/\/gatographql.lndo.site\/wp-admin\/\">your dashboard<\/a> to delete this page and create new pages for your content. Have fun!<\/p>\n<!-- \/wp:paragraph -->",
-                "slug": "sample-page",
-                "status": "publish",
-                "title": "Sample Page",
-                "url": "https:\/\/gatographql.lndo.site\/sample-page\/",
-                "urlPath": "\/sample-page\/",
-                "slugPath": "sample-page"
-            },
-            {
-                "__typename": "Post",
-                "areCommentsOpen": true,
-                "author": {
-                    "id": 3,
-                    "name": "Subscriber Bennett"
-                },
-                "commentCount": 1,
-                "comments": [
-                    {
-                        "id": 2
-                    }
-                ],
-                "content": "\n<p class=\"wp-block-paragraph\">This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets.<br><br><\/p>\n\n\n\n<h2 class=\"wp-block-heading\">Image Block (Standard)<\/h2>\n\n\n\n<figure class=\"wp-block-image\"><img decoding=\"async\" src=\"https:\/\/d.pr\/i\/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"\/><\/figure>\n",
-                "customPostType": "post",
-                "date": "2020-12-12T03:56:13+00:00",
-                "dateStr": "December 12, 2020",
-                "excerpt": "This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets. Image Block (Standard)",
-                "featuredImage": {
-                    "id": 1361,
-                    "src": "https:\/\/gatographql.lndo.site\/wp-content\/uploads\/GatoGraphQL-logo.webp"
-                },
-                "hasComments": true,
-                "hasFeaturedImage": true,
-                "id": 1113,
-                "isStatus": false,
-                "menuOrder": 0,
-                "metaValue": "1361",
-                "metaValue2": "default",
-                "meta": {
-                    "_thumbnail_id": [
-                        "1361"
-                    ],
-                    "_wp_page_template": [
-                        "default"
-                    ]
-                },
-                "metaKeys": [
-                    "_thumbnail_id",
-                    "_wp_page_template"
-                ],
-                "includingMetaKeys": [
-                    "_thumbnail_id"
-                ],
-                "excludingMetaKeys": [
-                    "_wp_page_template"
-                ],
-                "includingAndExcludingMetaKeys": [
-                    "_thumbnail_id"
-                ],
-                "rawContent": "<!-- wp:paragraph -->\n<p>This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets.<br><br><\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:heading -->\n<h2>Image Block (Standard)<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:image {\"id\":1755} -->\n<figure class=\"wp-block-image\"><img src=\"https:\/\/d.pr\/i\/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"\/><\/figure>\n<!-- \/wp:image -->",
-                "slug": "released-v0-6-check-it-out",
-                "status": "publish",
-                "title": "Released v0.6, check it out",
-                "url": "https:\/\/gatographql.lndo.site\/released-v0-6-check-it-out\/",
-                "urlPath": "\/released-v0-6-check-it-out\/",
-                "slugPath": "released-v0-6-check-it-out"
-            }
-        ],
-        "customPostsByAuthorIDs": [
-            {
-                "__typename": "Post",
-                "id": 1128,
-                "title": "HTTP caching improves performance"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1619,
-                "title": "Error debitis nulla vel est"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1630,
-                "title": "Corrupti voluptatem asperiores nam exercitationem corrupti"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1631,
-                "title": "Voluptatibus inventore quaerat quas explicabo possimus debitis"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1682,
-                "title": "Dummy CPT with several levels of children"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1684,
-                "title": "Dummy CPT with parent and children"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1688,
-                "title": "Dummy CPT with parent only"
-            },
-            {
-                "__typename": "Page",
-                "id": 1701,
-                "title": "Page with several levels of children"
-            },
-            {
-                "__typename": "Page",
-                "id": 1703,
-                "title": "Page with parent and children"
-            },
-            {
-                "__typename": "Page",
-                "id": 1705,
-                "title": "Page with parent only"
-            }
-        ],
-        "customPostsByAuthorSlug": [
-            {
-                "__typename": "Post",
-                "id": 1,
-                "title": "Hello world!"
-            },
-            {
-                "__typename": "Page",
-                "id": 2,
-                "title": "Sample Page"
-            },
-            {
-                "__typename": "Post",
-                "id": 1121,
-                "title": "Customize the schema for each client"
-            },
-            {
-                "__typename": "Post",
-                "id": 1123,
-                "title": "GraphQL or REST? Why not both?"
-            },
-            {
-                "__typename": "Post",
-                "id": 1125,
-                "title": "Public or Private API mode, for extra security"
-            },
-            {
-                "__typename": "Post",
-                "id": 1200,
-                "title": "PHP-only blocks"
-            },
-            {
-                "__typename": "Post",
-                "id": 1210,
-                "title": "PHP-only blocks (combinations)"
-            },
-            {
-                "__typename": "Post",
-                "id": 1212,
-                "title": "All blocks with entity references"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1620,
-                "title": "Dignissimos sed dolore aut"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1634,
-                "title": "Recusandae vel deleniti est expedita dolores quasi"
-            }
-        ],
-        "customPostsByCustomPostTypes": [
-            {
-                "__typename": "Page",
-                "id": 2,
-                "title": "Sample Page"
-            },
-            {
-                "__typename": "Page",
-                "id": 1666,
-                "title": "Another Page"
-            },
-            {
-                "__typename": "Page",
-                "id": 1701,
-                "title": "Page with several levels of children"
-            },
-            {
-                "__typename": "Page",
-                "id": 1703,
-                "title": "Page with parent and children"
-            },
-            {
-                "__typename": "Page",
-                "id": 1705,
-                "title": "Page with parent only"
-            }
-        ],
-        "customPostsByDateQuery": [
-            {
-                "__typename": "Post",
-                "id": 1,
-                "title": "Hello world!"
-            },
-            {
-                "__typename": "Page",
-                "id": 2,
-                "title": "Sample Page"
-            }
-        ],
-        "customPostsByExcludeAuthorIDs": [
-            {
-                "__typename": "Post",
-                "id": 1,
-                "title": "Hello world!"
-            },
-            {
-                "__typename": "Page",
-                "id": 2,
-                "title": "Sample Page"
-            },
-            {
-                "__typename": "Post",
-                "id": 1113,
-                "title": "Released v0.6, check it out"
-            },
-            {
-                "__typename": "Post",
-                "id": 1119,
-                "title": "Nested mutations are a must have"
-            },
-            {
-                "__typename": "Post",
-                "id": 1121,
-                "title": "Customize the schema for each client"
-            },
-            {
-                "__typename": "Post",
-                "id": 1123,
-                "title": "GraphQL or REST? Why not both?"
-            },
-            {
-                "__typename": "Post",
-                "id": 1125,
-                "title": "Public or Private API mode, for extra security"
-            },
-            {
-                "__typename": "Post",
-                "id": 1128,
-                "title": "HTTP caching improves performance"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1132,
-                "title": "Synced pattern with nested blocks"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1136,
-                "title": "Global synced pattern"
-            }
-        ],
-        "customPostsByExcludeIDs": [
-            {
-                "__typename": "Page",
-                "id": 2,
-                "title": "Sample Page"
-            },
-            {
-                "__typename": "Post",
-                "id": 1113,
-                "title": "Released v0.6, check it out"
-            },
-            {
-                "__typename": "Post",
-                "id": 1116,
-                "title": "Working on flat chain syntax next"
-            },
-            {
-                "__typename": "Post",
-                "id": 1119,
-                "title": "Nested mutations are a must have"
-            },
-            {
-                "__typename": "Post",
-                "id": 1121,
-                "title": "Customize the schema for each client"
-            },
-            {
-                "__typename": "Post",
-                "id": 1123,
-                "title": "GraphQL or REST? Why not both?"
-            },
-            {
-                "__typename": "Post",
-                "id": 1125,
-                "title": "Public or Private API mode, for extra security"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1132,
-                "title": "Synced pattern with nested blocks"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1136,
-                "title": "Global synced pattern"
-            },
-            {
-                "__typename": "Post",
-                "id": 1140,
-                "title": "Welcome to a single post full of blocks!"
-            }
-        ],
-        "customPostsByExcludeParentIDs": [
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1682,
-                "title": "Dummy CPT with several levels of children"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1688,
-                "title": "Dummy CPT with parent only"
-            }
-        ],
-        "customPostsByHasPassword": [],
-        "emptyCustomPostsByIds": [],
-        "customPostsByIds": [
-            {
-                "__typename": "Post",
-                "id": 1,
-                "title": "Hello world!"
-            },
-            {
-                "__typename": "Post",
-                "id": 1128,
-                "title": "HTTP caching improves performance"
-            }
-        ],
-        "customPostsByMetaQuery": [
-            {
-                "__typename": "Post",
-                "id": 1113,
-                "title": "Released v0.6, check it out"
-            },
-            {
-                "__typename": "Post",
-                "id": 1116,
-                "title": "Working on flat chain syntax next"
-            },
-            {
-                "__typename": "Post",
-                "id": 1125,
-                "title": "Public or Private API mode, for extra security"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1613,
-                "title": "Dolor facilis repellat pariatur veniam at"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1616,
-                "title": "Asperiores voluptatem facilis doloremque nemo nesciunt"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1622,
-                "title": "Dolore ex et deleniti mollitia"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1627,
-                "title": "Quis voluptatum tempore veniam est sit"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1634,
-                "title": "Recusandae vel deleniti est expedita dolores quasi"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1636,
-                "title": "Ab blanditiis doloremque cupiditate inventore magni ducimus"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1639,
-                "title": "Quaerat repudiandae voluptatem voluptas aut ab molestiae"
-            }
-        ],
-        "customPostsByParentID": [
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1684,
-                "title": "Dummy CPT with parent and children"
-            }
-        ],
-        "customPostsByParentIDs": [
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1684,
-                "title": "Dummy CPT with parent and children"
-            },
-            {
-                "__typename": "Page",
-                "id": 1703,
-                "title": "Page with parent and children"
-            }
-        ],
-        "customPostsByPassword": [],
-        "customPostsBySearch": [
-            {
-                "__typename": "Post",
-                "id": 1,
-                "title": "Hello world!"
-            },
-            {
-                "__typename": "Post",
-                "id": 1140,
-                "title": "Welcome to a single post full of blocks!"
-            },
-            {
-                "__typename": "Post",
-                "id": 1142,
-                "title": "Post with internal links, also in meta (entries starting with internal_link_)"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1660,
-                "title": "Dummy CPT with non server-side-registered block"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1680,
-                "title": "Dummy CPT with server-side-registered block"
-            }
-        ],
-        "customPostsByStatus": [
-            {
-                "__typename": "Page",
-                "id": 3,
-                "title": "Privacy Policy"
-            }
-        ],
-        "customPostsBySlugs": [
-            {
-                "id": 1,
-                "title": "Hello world!",
-                "slug": "hello-world"
-            },
-            {
-                "id": 1113,
-                "title": "Released v0.6, check it out",
-                "slug": "released-v0-6-check-it-out"
-            }
-        ],
-        "customPostsSortedASC": [
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1636,
-                "title": "Ab blanditiis doloremque cupiditate inventore magni ducimus"
-            },
-            {
-                "__typename": "Post",
-                "id": 1212,
-                "title": "All blocks with entity references"
-            },
-            {
-                "__typename": "Page",
-                "id": 1666,
-                "title": "Another Page"
-            }
-        ],
-        "customPostsSortedDESC": [
-            {
-                "__typename": "Post",
-                "id": 1116,
-                "title": "Working on flat chain syntax next"
-            },
-            {
-                "__typename": "Post",
-                "id": 1140,
-                "title": "Welcome to a single post full of blocks!"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1631,
-                "title": "Voluptatibus inventore quaerat quas explicabo possimus debitis"
-            }
-        ],
-        "customPostsWithSlugPath": [
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1682,
-                "title": "Dummy CPT with several levels of children",
-                "slugPath": "dummy-cpt-with-children"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1684,
-                "title": "Dummy CPT with parent and children",
-                "slugPath": "dummy-cpt-with-children\/dummy-cpt-with-parent-and-children"
-            },
-            {
-                "__typename": "GenericCustomPost",
-                "id": 1688,
-                "title": "Dummy CPT with parent only",
-                "slugPath": "dummy-cpt-with-children\/dummy-cpt-with-parent-and-children\/dummy-cpt-with-parent-only"
-            }
-        ],
-        "singleCustomPost": {
-            "__typename": "GenericCustomPost",
-            "id": 1619,
-            "title": "Error debitis nulla vel est",
-            "content": "<hr>\n<hr>\n<h1>Laudantium distinctio blanditiis et et voluptas. Nobis maxime et ab ut laboriosam provident<\/h1>\n<ul>\n<li>Nisi dolorem<\/li>\n<li>Dolorum<\/li>\n<\/ul>\n<p><!--more--><br \/>\n<img decoding=\"async\" class=\"alignleft\" alt=\"Illum neque aliquam fuga dolor ea voluptas\" src=\"https:\/\/gatographql.lndo.site\/wp-content\/uploads\/c08092fd-0c80-38d0-a678-61e938599f7d.jpg\"><\/p>\n",
-            "customPostType": "dummy-cpt"
+  "errors": [
+    {
+      "message": "There is no key with name '_thumbnail_id'",
+      "locations": [
+        {
+          "line": 72,
+          "column": 17
         }
+      ],
+      "extensions": {
+        "path": [
+          "(key: \"_thumbnail_id\")",
+          "metaValue(key: \"_thumbnail_id\")",
+          "...on CustomPost { ... }",
+          "customPosts(filter: {ids: [1, 2, 1113]}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
+        ],
+        "type": "Post",
+        "field": "metaValue(key: \"_thumbnail_id\")",
+        "code": "PoPCMSSchema/Meta@e1"
+      }
+    },
+    {
+      "message": "There is no key with name '_wp_page_template'",
+      "locations": [
+        {
+          "line": 73,
+          "column": 29
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(key: \"_wp_page_template\")",
+          "metaValue2: metaValue(key: \"_wp_page_template\")",
+          "...on CustomPost { ... }",
+          "customPosts(filter: {ids: [1, 2, 1113]}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
+        ],
+        "type": "Post",
+        "field": "metaValue2: metaValue(key: \"_wp_page_template\")",
+        "code": "PoPCMSSchema/Meta@e1"
+      }
+    },
+    {
+      "message": "There are no keys with names '_thumbnail_id', '_wp_page_template'",
+      "locations": [
+        {
+          "line": 74,
+          "column": 12
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+          "meta(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+          "...on CustomPost { ... }",
+          "customPosts(filter: {ids: [1, 2, 1113]}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
+        ],
+        "type": "Post",
+        "field": "meta(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+        "code": "PoPCMSSchema/Meta@e2"
+      }
+    },
+    {
+      "message": "There is no key with name '_thumbnail_id'",
+      "locations": [
+        {
+          "line": 72,
+          "column": 17
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(key: \"_thumbnail_id\")",
+          "metaValue(key: \"_thumbnail_id\")",
+          "...on CustomPost { ... }",
+          "customPosts(filter: {ids: [1, 2, 1113]}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
+        ],
+        "type": "Page",
+        "field": "metaValue(key: \"_thumbnail_id\")",
+        "code": "PoPCMSSchema/Meta@e1"
+      }
+    },
+    {
+      "message": "There is no key with name '_wp_page_template'",
+      "locations": [
+        {
+          "line": 73,
+          "column": 29
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(key: \"_wp_page_template\")",
+          "metaValue2: metaValue(key: \"_wp_page_template\")",
+          "...on CustomPost { ... }",
+          "customPosts(filter: {ids: [1, 2, 1113]}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
+        ],
+        "type": "Page",
+        "field": "metaValue2: metaValue(key: \"_wp_page_template\")",
+        "code": "PoPCMSSchema/Meta@e1"
+      }
+    },
+    {
+      "message": "There are no keys with names '_thumbnail_id', '_wp_page_template'",
+      "locations": [
+        {
+          "line": 74,
+          "column": 12
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+          "meta(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+          "...on CustomPost { ... }",
+          "customPosts(filter: {ids: [1, 2, 1113]}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
+        ],
+        "type": "Page",
+        "field": "meta(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+        "code": "PoPCMSSchema/Meta@e2"
+      }
     }
+  ],
+  "data": {
+    "urlToCustomPostIDFields": {
+      "existingPostWithTrailingSlash": 1,
+      "existingPostWithoutTrailingSlash": 1,
+      "existingPageWithTrailingSlash": 2,
+      "existingPageWithoutTrailingSlash": 2,
+      "existingDummyCPTWithTrailingSlash": 1613,
+      "existingDummyCPTWithoutTrailingSlash": 1613,
+      "attachmentPageWithTrailingSlash": 1362,
+      "attachmentPageWithoutTrailingSlash": 1362,
+      "nonExistingPost": null,
+      "nonExistingPage": null,
+      "differentDomain": null,
+      "externalDomain": null,
+      "categoryPageWithTrailingSlash": null,
+      "categoryPageWithoutTrailingSlash": null,
+      "userURLWithTrailingSlash": null,
+      "userURLWithoutTrailingSlash": null
+    },
+    "customPosts": [
+      {
+        "__typename": "Post",
+        "areCommentsOpen": true,
+        "author": {
+          "id": 2,
+          "name": "Blogger Davenport"
+        },
+        "commentCount": 0,
+        "comments": [],
+        "content": "\n<p class=\"wp-block-paragraph\">Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
+        "customPostType": "post",
+        "date": "2020-04-17T13:06:58+00:00",
+        "dateStr": "April 17, 2020",
+        "excerpt": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!",
+        "featuredImage": null,
+        "hasComments": false,
+        "hasFeaturedImage": false,
+        "id": 1,
+        "isStatus": false,
+        "menuOrder": 0,
+        "metaValue": null,
+        "metaValue2": null,
+        "meta": null,
+        "metaKeys": [],
+        "includingMetaKeys": [],
+        "excludingMetaKeys": [],
+        "includingAndExcludingMetaKeys": [],
+        "rawContent": "<!-- wp:paragraph -->\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n<!-- /wp:paragraph -->",
+        "slug": "hello-world",
+        "status": "publish",
+        "title": "Hello world!",
+        "url": "https://gatographql.lndo.site/hello-world/",
+        "urlPath": "/hello-world/",
+        "slugPath": "hello-world"
+      },
+      {
+        "__typename": "Page",
+        "areCommentsOpen": false,
+        "author": {
+          "id": 2,
+          "name": "Blogger Davenport"
+        },
+        "commentCount": 0,
+        "comments": [],
+        "content": "\n<p class=\"wp-block-paragraph\">This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">As a new WordPress user, you should go to <a href=\"https://gatographql.lndo.site/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
+        "customPostType": "page",
+        "date": "2020-04-17T13:06:58+00:00",
+        "dateStr": "April 17, 2020",
+        "excerpt": "This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger&hellip; <a class=\"more-link\" href=\"https://gatographql.lndo.site/all-blocks-with-entity-references/\">Continue reading <span class=\"screen-reader-text\">All blocks with entity references</span></a>",
+        "featuredImage": null,
+        "hasComments": false,
+        "hasFeaturedImage": false,
+        "id": 2,
+        "isStatus": false,
+        "menuOrder": 0,
+        "metaValue": null,
+        "metaValue2": null,
+        "meta": null,
+        "metaKeys": [
+          "some_page_meta"
+        ],
+        "includingMetaKeys": [
+          "some_page_meta"
+        ],
+        "excludingMetaKeys": [
+          "some_page_meta"
+        ],
+        "includingAndExcludingMetaKeys": [
+          "some_page_meta"
+        ],
+        "rawContent": "<!-- wp:paragraph -->\n<p>This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>Hi there! I'm a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin' caught in the rain.)</p></blockquote>\n<!-- /wp:quote -->\n\n<!-- wp:paragraph -->\n<p>...or something like this:</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n<!-- /wp:quote -->\n\n<!-- wp:paragraph -->\n<p>As a new WordPress user, you should go to <a href=\"https://gatographql.lndo.site/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n<!-- /wp:paragraph -->",
+        "slug": "sample-page",
+        "status": "publish",
+        "title": "Sample Page",
+        "url": "https://gatographql.lndo.site/sample-page/",
+        "urlPath": "/sample-page/",
+        "slugPath": "sample-page"
+      },
+      {
+        "__typename": "Post",
+        "areCommentsOpen": true,
+        "author": {
+          "id": 3,
+          "name": "Subscriber Bennett"
+        },
+        "commentCount": 1,
+        "comments": [
+          {
+            "id": 2
+          }
+        ],
+        "content": "\n<p class=\"wp-block-paragraph\">This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets.<br><br></p>\n\n\n\n<h2 class=\"wp-block-heading\">Image Block (Standard)</h2>\n\n\n\n<figure class=\"wp-block-image\"><img decoding=\"async\" src=\"https://d.pr/i/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"/></figure>\n",
+        "customPostType": "post",
+        "date": "2020-12-12T03:56:13+00:00",
+        "dateStr": "December 12, 2020",
+        "excerpt": "This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets. Image Block (Standard)",
+        "featuredImage": {
+          "id": 1361,
+          "src": "https://gatographql.lndo.site/wp-content/uploads/GatoGraphQL-logo.webp"
+        },
+        "hasComments": true,
+        "hasFeaturedImage": true,
+        "id": 1113,
+        "isStatus": false,
+        "menuOrder": 0,
+        "metaValue": null,
+        "metaValue2": null,
+        "meta": null,
+        "metaKeys": [],
+        "includingMetaKeys": [],
+        "excludingMetaKeys": [],
+        "includingAndExcludingMetaKeys": [],
+        "rawContent": "<!-- wp:paragraph -->\n<p>This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets.<br><br></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2>Image Block (Standard)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:image {\"id\":1755} -->\n<figure class=\"wp-block-image\"><img src=\"https://d.pr/i/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"/></figure>\n<!-- /wp:image -->",
+        "slug": "released-v0-6-check-it-out",
+        "status": "publish",
+        "title": "Released v0.6, check it out",
+        "url": "https://gatographql.lndo.site/released-v0-6-check-it-out/",
+        "urlPath": "/released-v0-6-check-it-out/",
+        "slugPath": "released-v0-6-check-it-out"
+      }
+    ],
+    "customPostsByAuthorIDs": [
+      {
+        "__typename": "Post",
+        "id": 1128,
+        "title": "HTTP caching improves performance"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1619,
+        "title": "Error debitis nulla vel est"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1630,
+        "title": "Corrupti voluptatem asperiores nam exercitationem corrupti"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1631,
+        "title": "Voluptatibus inventore quaerat quas explicabo possimus debitis"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1682,
+        "title": "Dummy CPT with several levels of children"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1684,
+        "title": "Dummy CPT with parent and children"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1688,
+        "title": "Dummy CPT with parent only"
+      },
+      {
+        "__typename": "Page",
+        "id": 1701,
+        "title": "Page with several levels of children"
+      },
+      {
+        "__typename": "Page",
+        "id": 1703,
+        "title": "Page with parent and children"
+      },
+      {
+        "__typename": "Page",
+        "id": 1705,
+        "title": "Page with parent only"
+      }
+    ],
+    "customPostsByAuthorSlug": [
+      {
+        "__typename": "Post",
+        "id": 1,
+        "title": "Hello world!"
+      },
+      {
+        "__typename": "Page",
+        "id": 2,
+        "title": "Sample Page"
+      },
+      {
+        "__typename": "Post",
+        "id": 1121,
+        "title": "Customize the schema for each client"
+      },
+      {
+        "__typename": "Post",
+        "id": 1123,
+        "title": "GraphQL or REST? Why not both?"
+      },
+      {
+        "__typename": "Post",
+        "id": 1125,
+        "title": "Public or Private API mode, for extra security"
+      },
+      {
+        "__typename": "Post",
+        "id": 1200,
+        "title": "PHP-only blocks"
+      },
+      {
+        "__typename": "Post",
+        "id": 1210,
+        "title": "PHP-only blocks (combinations)"
+      },
+      {
+        "__typename": "Post",
+        "id": 1212,
+        "title": "All blocks with entity references"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1620,
+        "title": "Dignissimos sed dolore aut"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1634,
+        "title": "Recusandae vel deleniti est expedita dolores quasi"
+      }
+    ],
+    "customPostsByCustomPostTypes": [
+      {
+        "__typename": "Page",
+        "id": 2,
+        "title": "Sample Page"
+      },
+      {
+        "__typename": "Page",
+        "id": 1666,
+        "title": "Another Page"
+      },
+      {
+        "__typename": "Page",
+        "id": 1701,
+        "title": "Page with several levels of children"
+      },
+      {
+        "__typename": "Page",
+        "id": 1703,
+        "title": "Page with parent and children"
+      },
+      {
+        "__typename": "Page",
+        "id": 1705,
+        "title": "Page with parent only"
+      }
+    ],
+    "customPostsByDateQuery": [
+      {
+        "__typename": "Post",
+        "id": 1,
+        "title": "Hello world!"
+      },
+      {
+        "__typename": "Page",
+        "id": 2,
+        "title": "Sample Page"
+      }
+    ],
+    "customPostsByExcludeAuthorIDs": [
+      {
+        "__typename": "Post",
+        "id": 1,
+        "title": "Hello world!"
+      },
+      {
+        "__typename": "Page",
+        "id": 2,
+        "title": "Sample Page"
+      },
+      {
+        "__typename": "Post",
+        "id": 1113,
+        "title": "Released v0.6, check it out"
+      },
+      {
+        "__typename": "Post",
+        "id": 1119,
+        "title": "Nested mutations are a must have"
+      },
+      {
+        "__typename": "Post",
+        "id": 1121,
+        "title": "Customize the schema for each client"
+      },
+      {
+        "__typename": "Post",
+        "id": 1123,
+        "title": "GraphQL or REST? Why not both?"
+      },
+      {
+        "__typename": "Post",
+        "id": 1125,
+        "title": "Public or Private API mode, for extra security"
+      },
+      {
+        "__typename": "Post",
+        "id": 1128,
+        "title": "HTTP caching improves performance"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1132,
+        "title": "Synced pattern with nested blocks"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1136,
+        "title": "Global synced pattern"
+      }
+    ],
+    "customPostsByExcludeIDs": [
+      {
+        "__typename": "Page",
+        "id": 2,
+        "title": "Sample Page"
+      },
+      {
+        "__typename": "Post",
+        "id": 1113,
+        "title": "Released v0.6, check it out"
+      },
+      {
+        "__typename": "Post",
+        "id": 1116,
+        "title": "Working on flat chain syntax next"
+      },
+      {
+        "__typename": "Post",
+        "id": 1119,
+        "title": "Nested mutations are a must have"
+      },
+      {
+        "__typename": "Post",
+        "id": 1121,
+        "title": "Customize the schema for each client"
+      },
+      {
+        "__typename": "Post",
+        "id": 1123,
+        "title": "GraphQL or REST? Why not both?"
+      },
+      {
+        "__typename": "Post",
+        "id": 1125,
+        "title": "Public or Private API mode, for extra security"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1132,
+        "title": "Synced pattern with nested blocks"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1136,
+        "title": "Global synced pattern"
+      },
+      {
+        "__typename": "Post",
+        "id": 1140,
+        "title": "Welcome to a single post full of blocks!"
+      }
+    ],
+    "customPostsByExcludeParentIDs": [
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1682,
+        "title": "Dummy CPT with several levels of children"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1688,
+        "title": "Dummy CPT with parent only"
+      }
+    ],
+    "customPostsByHasPassword": [],
+    "emptyCustomPostsByIds": [],
+    "customPostsByIds": [
+      {
+        "__typename": "Post",
+        "id": 1,
+        "title": "Hello world!"
+      },
+      {
+        "__typename": "Post",
+        "id": 1128,
+        "title": "HTTP caching improves performance"
+      }
+    ],
+    "customPostsByMetaQuery": [
+      {
+        "__typename": "Post",
+        "id": 1113,
+        "title": "Released v0.6, check it out"
+      },
+      {
+        "__typename": "Post",
+        "id": 1116,
+        "title": "Working on flat chain syntax next"
+      },
+      {
+        "__typename": "Post",
+        "id": 1125,
+        "title": "Public or Private API mode, for extra security"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1613,
+        "title": "Dolor facilis repellat pariatur veniam at"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1616,
+        "title": "Asperiores voluptatem facilis doloremque nemo nesciunt"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1622,
+        "title": "Dolore ex et deleniti mollitia"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1627,
+        "title": "Quis voluptatum tempore veniam est sit"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1634,
+        "title": "Recusandae vel deleniti est expedita dolores quasi"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1636,
+        "title": "Ab blanditiis doloremque cupiditate inventore magni ducimus"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1639,
+        "title": "Quaerat repudiandae voluptatem voluptas aut ab molestiae"
+      }
+    ],
+    "customPostsByParentID": [
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1684,
+        "title": "Dummy CPT with parent and children"
+      }
+    ],
+    "customPostsByParentIDs": [
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1684,
+        "title": "Dummy CPT with parent and children"
+      },
+      {
+        "__typename": "Page",
+        "id": 1703,
+        "title": "Page with parent and children"
+      }
+    ],
+    "customPostsByPassword": [],
+    "customPostsBySearch": [
+      {
+        "__typename": "Post",
+        "id": 1,
+        "title": "Hello world!"
+      },
+      {
+        "__typename": "Post",
+        "id": 1140,
+        "title": "Welcome to a single post full of blocks!"
+      },
+      {
+        "__typename": "Post",
+        "id": 1142,
+        "title": "Post with internal links, also in meta (entries starting with internal_link_)"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1660,
+        "title": "Dummy CPT with non server-side-registered block"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1680,
+        "title": "Dummy CPT with server-side-registered block"
+      }
+    ],
+    "customPostsByStatus": [
+      {
+        "__typename": "Page",
+        "id": 3,
+        "title": "Privacy Policy"
+      }
+    ],
+    "customPostsBySlugs": [
+      {
+        "id": 1,
+        "title": "Hello world!",
+        "slug": "hello-world"
+      },
+      {
+        "id": 1113,
+        "title": "Released v0.6, check it out",
+        "slug": "released-v0-6-check-it-out"
+      }
+    ],
+    "customPostsSortedASC": [
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1636,
+        "title": "Ab blanditiis doloremque cupiditate inventore magni ducimus"
+      },
+      {
+        "__typename": "Post",
+        "id": 1212,
+        "title": "All blocks with entity references"
+      },
+      {
+        "__typename": "Page",
+        "id": 1666,
+        "title": "Another Page"
+      }
+    ],
+    "customPostsSortedDESC": [
+      {
+        "__typename": "Post",
+        "id": 1116,
+        "title": "Working on flat chain syntax next"
+      },
+      {
+        "__typename": "Post",
+        "id": 1140,
+        "title": "Welcome to a single post full of blocks!"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1631,
+        "title": "Voluptatibus inventore quaerat quas explicabo possimus debitis"
+      }
+    ],
+    "customPostsWithSlugPath": [
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1682,
+        "title": "Dummy CPT with several levels of children",
+        "slugPath": "dummy-cpt-with-children"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1684,
+        "title": "Dummy CPT with parent and children",
+        "slugPath": "dummy-cpt-with-children/dummy-cpt-with-parent-and-children"
+      },
+      {
+        "__typename": "GenericCustomPost",
+        "id": 1688,
+        "title": "Dummy CPT with parent only",
+        "slugPath": "dummy-cpt-with-children/dummy-cpt-with-parent-and-children/dummy-cpt-with-parent-only"
+      }
+    ],
+    "singleCustomPost": {
+      "__typename": "GenericCustomPost",
+      "id": 1619,
+      "title": "Error debitis nulla vel est",
+      "content": "<hr>\n<hr>\n<h1>Laudantium distinctio blanditiis et et voluptas. Nobis maxime et ab ut laboriosam provident</h1>\n<ul>\n<li>Nisi dolorem</li>\n<li>Dolorum</li>\n</ul>\n<p><!--more--><br />\n<img decoding=\"async\" class=\"alignleft\" alt=\"Illum neque aliquam fuga dolor ea voluptas\" src=\"https://gatographql.lndo.site/wp-content/uploads/c08092fd-0c80-38d0-a678-61e938599f7d.jpg\"></p>\n",
+      "customPostType": "dummy-cpt"
+    }
+  }
 }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/pages.gql
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/pages.gql
@@ -32,9 +32,9 @@ query {
     metaValue2: metaValue(key: "_wp_page_template")
     meta(keys: ["_thumbnail_id", "_wp_page_template"])
     metaKeys
-    includingMetaKeys: metaKeys(filter: { include: ["_thumbnail_id", "_edit_last", "_wp_page_template"] })
+    includingMetaKeys: metaKeys(filter: { include: ["some_page_meta", "_thumbnail_id", "_edit_last", "_wp_page_template"] })
     excludingMetaKeys: metaKeys(filter: { exclude: ["_thumbnail_id", "_edit_last", "_wp_page_template"] })
-    includingAndExcludingMetaKeys: metaKeys(filter: { include: ["_thumbnail_id", "_edit_last", "_wp_page_template"], exclude: ["_edit_last", "_wp_page_template"] })
+    includingAndExcludingMetaKeys: metaKeys(filter: { include: ["some_page_meta", "_thumbnail_id", "_edit_last", "_wp_page_template"], exclude: ["_edit_last", "_wp_page_template"] })
     # These ones produce the value of data being inserted to DB, so can't save fixed value for testing
     # modifiedDate
     # modifiedDateStr(format: "m-d")

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/pages.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/pages.json
@@ -1,381 +1,443 @@
 {
-    "data": {
-        "pages": [
-            {
-                "areCommentsOpen": false,
-                "author": {
-                    "id": 2,
-                    "name": "Blogger Davenport"
-                },
-                "children": [],
-                "childCount": 0,
-                "commentCount": 0,
-                "comments": [],
-                "content": "\n<p class=\"wp-block-paragraph\">This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:<\/p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)<\/p><\/blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">&#8230;or something like this:<\/p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.<\/p><\/blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">As a new WordPress user, you should go to <a href=\"https:\/\/gatographql.lndo.site\/wp-admin\/\">your dashboard<\/a> to delete this page and create new pages for your content. Have fun!<\/p>\n",
-                "customPostType": "page",
-                "date": "2020-04-17T13:06:58+00:00",
-                "dateStr": "April 17, 2020",
-                "excerpt": "This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger&hellip; <a class=\"more-link\" href=\"https:\/\/gatographql.lndo.site\/all-blocks-with-entity-references\/\">Continue reading <span class=\"screen-reader-text\">All blocks with entity references<\/span><\/a>",
-                "featuredImage": null,
-                "hasComments": false,
-                "hasFeaturedImage": false,
-                "id": 2,
-                "isStatus": false,
-                "menuOrder": 0,
-                "metaValue": null,
-                "metaValue2": "default",
-                "meta": {
-                    "_wp_page_template": [
-                        "default"
-                    ]
-                },
-                "metaKeys": [
-                    "_wp_page_template"
-                ],
-                "includingMetaKeys": [
-                    "_wp_page_template"
-                ],
-                "excludingMetaKeys": [],
-                "includingAndExcludingMetaKeys": [],
-                "parent": null,
-                "ancestors": [],
-                "rawContent": "<!-- wp:paragraph -->\n<p>This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>Hi there! I'm a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin' caught in the rain.)<\/p><\/blockquote>\n<!-- \/wp:quote -->\n\n<!-- wp:paragraph -->\n<p>...or something like this:<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.<\/p><\/blockquote>\n<!-- \/wp:quote -->\n\n<!-- wp:paragraph -->\n<p>As a new WordPress user, you should go to <a href=\"https:\/\/gatographql.lndo.site\/wp-admin\/\">your dashboard<\/a> to delete this page and create new pages for your content. Have fun!<\/p>\n<!-- \/wp:paragraph -->",
-                "rawTitle": "Sample Page",
-                "rawExcerpt": "",
-                "slug": "sample-page",
-                "status": "publish",
-                "title": "Sample Page",
-                "url": "https:\/\/gatographql.lndo.site\/sample-page\/",
-                "urlPath": "\/sample-page\/"
-            },
-            {
-                "areCommentsOpen": false,
-                "author": {
-                    "id": 2,
-                    "name": "Blogger Davenport"
-                },
-                "children": [],
-                "childCount": 0,
-                "commentCount": 0,
-                "comments": [],
-                "content": "\n<p class=\"wp-block-paragraph\">This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:<\/p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)<\/p><\/blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">&#8230;or something like this:<\/p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.<\/p><\/blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">As a new WordPress user, you should go to <a href=\"https:\/\/gatographql.lndo.site\/wp-admin\/\">your dashboard<\/a> to delete this page and create new pages for your content. Have fun!<\/p>\n",
-                "customPostType": "page",
-                "date": "2020-08-17T13:06:58+00:00",
-                "dateStr": "August 17, 2020",
-                "excerpt": "This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger&hellip; <a class=\"more-link\" href=\"https:\/\/gatographql.lndo.site\/all-blocks-with-entity-references\/\">Continue reading <span class=\"screen-reader-text\">All blocks with entity references<\/span><\/a>",
-                "featuredImage": null,
-                "hasComments": false,
-                "hasFeaturedImage": false,
-                "id": 1666,
-                "isStatus": false,
-                "menuOrder": 0,
-                "metaValue": null,
-                "metaValue2": "default",
-                "meta": {
-                    "_wp_page_template": [
-                        "default"
-                    ]
-                },
-                "metaKeys": [
-                    "_wp_page_template"
-                ],
-                "includingMetaKeys": [
-                    "_wp_page_template"
-                ],
-                "excludingMetaKeys": [],
-                "includingAndExcludingMetaKeys": [],
-                "parent": null,
-                "ancestors": [],
-                "rawContent": "<!-- wp:paragraph -->\n<p>This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>Hi there! I'm a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin' caught in the rain.)<\/p><\/blockquote>\n<!-- \/wp:quote -->\n\n<!-- wp:paragraph -->\n<p>...or something like this:<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.<\/p><\/blockquote>\n<!-- \/wp:quote -->\n\n<!-- wp:paragraph -->\n<p>As a new WordPress user, you should go to <a href=\"https:\/\/gatographql.lndo.site\/wp-admin\/\">your dashboard<\/a> to delete this page and create new pages for your content. Have fun!<\/p>\n<!-- \/wp:paragraph -->",
-                "rawTitle": "Another Page",
-                "rawExcerpt": "",
-                "slug": "another-page",
-                "status": "publish",
-                "title": "Another Page",
-                "url": "https:\/\/gatographql.lndo.site\/another-page\/",
-                "urlPath": "\/another-page\/"
-            },
-            {
-                "areCommentsOpen": false,
-                "author": {
-                    "id": 5,
-                    "name": "Author Marquez"
-                },
-                "children": [
-                    {
-                        "id": 1703,
-                        "title": "Page with parent and children"
-                    }
-                ],
-                "childCount": 1,
-                "commentCount": 0,
-                "comments": [],
-                "content": "\n<p class=\"wp-block-paragraph\">I am the most ancestor page<\/p>\n",
-                "customPostType": "page",
-                "date": "2025-07-29T06:40:54+00:00",
-                "dateStr": "July 29, 2025",
-                "excerpt": "I am the most ancestor page",
-                "featuredImage": null,
-                "hasComments": false,
-                "hasFeaturedImage": false,
-                "id": 1701,
-                "isStatus": false,
-                "menuOrder": 0,
-                "metaValue": null,
-                "metaValue2": null,
-                "meta": {},
-                "metaKeys": [],
-                "includingMetaKeys": [],
-                "excludingMetaKeys": [],
-                "includingAndExcludingMetaKeys": [],
-                "parent": null,
-                "ancestors": [],
-                "rawContent": "<!-- wp:paragraph -->\n<p>I am the most ancestor page<\/p>\n<!-- \/wp:paragraph -->",
-                "rawTitle": "Page with several levels of children",
-                "rawExcerpt": "",
-                "slug": "page-with-several-levels-of-children",
-                "status": "publish",
-                "title": "Page with several levels of children",
-                "url": "https:\/\/gatographql.lndo.site\/page-with-several-levels-of-children\/",
-                "urlPath": "\/page-with-several-levels-of-children\/"
-            }
+  "errors": [
+    {
+      "message": "There is no key with name '_thumbnail_id'",
+      "locations": [
+        {
+          "line": 31,
+          "column": 15
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(key: \"_thumbnail_id\")",
+          "metaValue(key: \"_thumbnail_id\")",
+          "pages(pagination: {limit: 3}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
         ],
-        "pagesByAuthorIDs": [
-            {
-                "id": 1666,
-                "title": "Another Page"
-            },
-            {
-                "id": 2,
-                "title": "Sample Page"
-            }
+        "type": "Page",
+        "field": "metaValue(key: \"_thumbnail_id\")",
+        "code": "PoPCMSSchema/Meta@e1"
+      }
+    },
+    {
+      "message": "There is no key with name '_wp_page_template'",
+      "locations": [
+        {
+          "line": 32,
+          "column": 27
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(key: \"_wp_page_template\")",
+          "metaValue2: metaValue(key: \"_wp_page_template\")",
+          "pages(pagination: {limit: 3}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
         ],
-        "pagesByAuthorSlug": [
-            {
-                "id": 1666,
-                "title": "Another Page"
-            },
-            {
-                "id": 2,
-                "title": "Sample Page"
-            }
+        "type": "Page",
+        "field": "metaValue2: metaValue(key: \"_wp_page_template\")",
+        "code": "PoPCMSSchema/Meta@e1"
+      }
+    },
+    {
+      "message": "There are no keys with names '_thumbnail_id', '_wp_page_template'",
+      "locations": [
+        {
+          "line": 33,
+          "column": 10
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+          "meta(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+          "pages(pagination: {limit: 3}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
         ],
-        "pagesByDateQuery": [
-            {
-                "id": 2,
-                "title": "Sample Page"
-            }
-        ],
-        "pagesByExcludeAuthorIDs": [
-            {
-                "id": 1705,
-                "title": "Page with parent only"
-            },
-            {
-                "id": 1703,
-                "title": "Page with parent and children"
-            },
-            {
-                "id": 1701,
-                "title": "Page with several levels of children"
-            }
-        ],
-        "pagesByExcludeIDs": [
-            {
-                "id": 1705,
-                "title": "Page with parent only"
-            },
-            {
-                "id": 1703,
-                "title": "Page with parent and children"
-            },
-            {
-                "id": 1701,
-                "title": "Page with several levels of children"
-            },
-            {
-                "id": 1666,
-                "title": "Another Page"
-            }
-        ],
-        "pagesByHasPassword": [],
-        "emptyPagesByIds": [],
-        "pagesByIds": [
-            {
-                "id": 2,
-                "title": "Sample Page"
-            },
-            {
-                "id": 3,
-                "title": "Privacy Policy"
-            }
-        ],
-        "pagesByMetaQuery": [
-            {
-                "id": 1705,
-                "title": "Page with parent only"
-            },
-            {
-                "id": 1703,
-                "title": "Page with parent and children"
-            },
-            {
-                "id": 1701,
-                "title": "Page with several levels of children"
-            },
-            {
-                "id": 1666,
-                "title": "Another Page"
-            },
-            {
-                "id": 2,
-                "title": "Sample Page"
-            }
-        ],
-        "pagesByParentID": [],
-        "pagesByParentIDs": [],
-        "pagesByPassword": [],
-        "pagesBySearch": [
-            {
-                "id": 2,
-                "title": "Sample Page"
-            }
-        ],
-        "pagesByStatus": [
-            {
-                "id": 3,
-                "title": "Privacy Policy"
-            }
-        ],
-        "pagesSortedASC": [
-            {
-                "id": 1666,
-                "title": "Another Page"
-            },
-            {
-                "id": 1703,
-                "title": "Page with parent and children"
-            },
-            {
-                "id": 1705,
-                "title": "Page with parent only"
-            },
-            {
-                "id": 1701,
-                "title": "Page with several levels of children"
-            },
-            {
-                "id": 3,
-                "title": "Privacy Policy"
-            },
-            {
-                "id": 2,
-                "title": "Sample Page"
-            }
-        ],
-        "pagesSortedDESC": [
-            {
-                "id": 2,
-                "title": "Sample Page"
-            },
-            {
-                "id": 3,
-                "title": "Privacy Policy"
-            },
-            {
-                "id": 1701,
-                "title": "Page with several levels of children"
-            },
-            {
-                "id": 1705,
-                "title": "Page with parent only"
-            },
-            {
-                "id": 1703,
-                "title": "Page with parent and children"
-            },
-            {
-                "id": 1666,
-                "title": "Another Page"
-            }
-        ],
-        "pagesWithAncestors": [
-            {
-                "id": 1701,
-                "title": "Page with several levels of children",
-                "parent": null,
-                "ancestors": [],
-                "children": [
-                    {
-                        "id": 1703,
-                        "title": "Page with parent and children"
-                    }
-                ],
-                "draftChildren": [],
-                "publishedChildren": [
-                    {
-                        "id": 1703,
-                        "title": "Page with parent and children"
-                    }
-                ],
-                "childCount": 1,
-                "draftChildCount": 0,
-                "publishedChildCount": 1
-            },
-            {
-                "id": 1703,
-                "title": "Page with parent and children",
-                "parent": {
-                    "id": 1701,
-                    "title": "Page with several levels of children"
-                },
-                "ancestors": [
-                    {
-                        "id": 1701,
-                        "title": "Page with several levels of children"
-                    }
-                ],
-                "children": [
-                    {
-                        "id": 1705,
-                        "title": "Page with parent only"
-                    }
-                ],
-                "draftChildren": [],
-                "publishedChildren": [
-                    {
-                        "id": 1705,
-                        "title": "Page with parent only"
-                    }
-                ],
-                "childCount": 1,
-                "draftChildCount": 0,
-                "publishedChildCount": 1
-            },
-            {
-                "id": 1705,
-                "title": "Page with parent only",
-                "parent": {
-                    "id": 1703,
-                    "title": "Page with parent and children"
-                },
-                "ancestors": [
-                    {
-                        "id": 1703,
-                        "title": "Page with parent and children"
-                    },
-                    {
-                        "id": 1701,
-                        "title": "Page with several levels of children"
-                    }
-                ],
-                "children": [],
-                "draftChildren": [],
-                "publishedChildren": [],
-                "childCount": 0,
-                "draftChildCount": 0,
-                "publishedChildCount": 0
-            }
-        ]
+        "type": "Page",
+        "field": "meta(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+        "code": "PoPCMSSchema/Meta@e2"
+      }
     }
+  ],
+  "data": {
+    "pages": [
+      {
+        "areCommentsOpen": false,
+        "author": {
+          "id": 2,
+          "name": "Blogger Davenport"
+        },
+        "children": [],
+        "childCount": 0,
+        "commentCount": 0,
+        "comments": [],
+        "content": "\n<p class=\"wp-block-paragraph\">This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">As a new WordPress user, you should go to <a href=\"https://gatographql.lndo.site/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
+        "customPostType": "page",
+        "date": "2020-04-17T13:06:58+00:00",
+        "dateStr": "April 17, 2020",
+        "excerpt": "This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger&hellip; <a class=\"more-link\" href=\"https://gatographql.lndo.site/all-blocks-with-entity-references/\">Continue reading <span class=\"screen-reader-text\">All blocks with entity references</span></a>",
+        "featuredImage": null,
+        "hasComments": false,
+        "hasFeaturedImage": false,
+        "id": 2,
+        "isStatus": false,
+        "menuOrder": 0,
+        "metaValue": null,
+        "metaValue2": null,
+        "meta": null,
+        "metaKeys": [
+          "some_page_meta"
+        ],
+        "includingMetaKeys": [
+          "some_page_meta"
+        ],
+        "excludingMetaKeys": [
+          "some_page_meta"
+        ],
+        "includingAndExcludingMetaKeys": [
+          "some_page_meta"
+        ],
+        "parent": null,
+        "ancestors": [],
+        "rawContent": "<!-- wp:paragraph -->\n<p>This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>Hi there! I'm a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin' caught in the rain.)</p></blockquote>\n<!-- /wp:quote -->\n\n<!-- wp:paragraph -->\n<p>...or something like this:</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n<!-- /wp:quote -->\n\n<!-- wp:paragraph -->\n<p>As a new WordPress user, you should go to <a href=\"https://gatographql.lndo.site/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n<!-- /wp:paragraph -->",
+        "rawTitle": "Sample Page",
+        "rawExcerpt": "",
+        "slug": "sample-page",
+        "status": "publish",
+        "title": "Sample Page",
+        "url": "https://gatographql.lndo.site/sample-page/",
+        "urlPath": "/sample-page/"
+      },
+      {
+        "areCommentsOpen": false,
+        "author": {
+          "id": 2,
+          "name": "Blogger Davenport"
+        },
+        "children": [],
+        "childCount": 0,
+        "commentCount": 0,
+        "comments": [],
+        "content": "\n<p class=\"wp-block-paragraph\">This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>Hi there! I&#8217;m a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin&#8217; caught in the rain.)</p></blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">&#8230;or something like this:</p>\n\n\n\n<blockquote class=\"wp-block-quote is-layout-flow wp-block-quote-is-layout-flow\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n\n\n\n<p class=\"wp-block-paragraph\">As a new WordPress user, you should go to <a href=\"https://gatographql.lndo.site/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n",
+        "customPostType": "page",
+        "date": "2020-08-17T13:06:58+00:00",
+        "dateStr": "August 17, 2020",
+        "excerpt": "This is an example page. It&#8217;s different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this: Hi there! I&#8217;m a bike messenger&hellip; <a class=\"more-link\" href=\"https://gatographql.lndo.site/all-blocks-with-entity-references/\">Continue reading <span class=\"screen-reader-text\">All blocks with entity references</span></a>",
+        "featuredImage": null,
+        "hasComments": false,
+        "hasFeaturedImage": false,
+        "id": 1666,
+        "isStatus": false,
+        "menuOrder": 0,
+        "metaValue": null,
+        "metaValue2": null,
+        "meta": null,
+        "metaKeys": [
+          "some_page_meta"
+        ],
+        "includingMetaKeys": [
+          "some_page_meta"
+        ],
+        "excludingMetaKeys": [
+          "some_page_meta"
+        ],
+        "includingAndExcludingMetaKeys": [
+          "some_page_meta"
+        ],
+        "parent": null,
+        "ancestors": [],
+        "rawContent": "<!-- wp:paragraph -->\n<p>This is an example page. It's different from a blog post because it will stay in one place and will show up in your site navigation (in most themes). Most people start with an About page that introduces them to potential site visitors. It might say something like this:</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>Hi there! I'm a bike messenger by day, aspiring actor by night, and this is my website. I live in Los Angeles, have a great dog named Jack, and I like pi&#241;a coladas. (And gettin' caught in the rain.)</p></blockquote>\n<!-- /wp:quote -->\n\n<!-- wp:paragraph -->\n<p>...or something like this:</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>The XYZ Doohickey Company was founded in 1971, and has been providing quality doohickeys to the public ever since. Located in Gotham City, XYZ employs over 2,000 people and does all kinds of awesome things for the Gotham community.</p></blockquote>\n<!-- /wp:quote -->\n\n<!-- wp:paragraph -->\n<p>As a new WordPress user, you should go to <a href=\"https://gatographql.lndo.site/wp-admin/\">your dashboard</a> to delete this page and create new pages for your content. Have fun!</p>\n<!-- /wp:paragraph -->",
+        "rawTitle": "Another Page",
+        "rawExcerpt": "",
+        "slug": "another-page",
+        "status": "publish",
+        "title": "Another Page",
+        "url": "https://gatographql.lndo.site/another-page/",
+        "urlPath": "/another-page/"
+      },
+      {
+        "areCommentsOpen": false,
+        "author": {
+          "id": 5,
+          "name": "Author Marquez"
+        },
+        "children": [
+          {
+            "id": 1703,
+            "title": "Page with parent and children"
+          }
+        ],
+        "childCount": 1,
+        "commentCount": 0,
+        "comments": [],
+        "content": "\n<p class=\"wp-block-paragraph\">I am the most ancestor page</p>\n",
+        "customPostType": "page",
+        "date": "2025-07-29T06:40:54+00:00",
+        "dateStr": "July 29, 2025",
+        "excerpt": "I am the most ancestor page",
+        "featuredImage": null,
+        "hasComments": false,
+        "hasFeaturedImage": false,
+        "id": 1701,
+        "isStatus": false,
+        "menuOrder": 0,
+        "metaValue": null,
+        "metaValue2": null,
+        "meta": null,
+        "metaKeys": [],
+        "includingMetaKeys": [],
+        "excludingMetaKeys": [],
+        "includingAndExcludingMetaKeys": [],
+        "parent": null,
+        "ancestors": [],
+        "rawContent": "<!-- wp:paragraph -->\n<p>I am the most ancestor page</p>\n<!-- /wp:paragraph -->",
+        "rawTitle": "Page with several levels of children",
+        "rawExcerpt": "",
+        "slug": "page-with-several-levels-of-children",
+        "status": "publish",
+        "title": "Page with several levels of children",
+        "url": "https://gatographql.lndo.site/page-with-several-levels-of-children/",
+        "urlPath": "/page-with-several-levels-of-children/"
+      }
+    ],
+    "pagesByAuthorIDs": [
+      {
+        "id": 1666,
+        "title": "Another Page"
+      },
+      {
+        "id": 2,
+        "title": "Sample Page"
+      }
+    ],
+    "pagesByAuthorSlug": [
+      {
+        "id": 1666,
+        "title": "Another Page"
+      },
+      {
+        "id": 2,
+        "title": "Sample Page"
+      }
+    ],
+    "pagesByDateQuery": [
+      {
+        "id": 2,
+        "title": "Sample Page"
+      }
+    ],
+    "pagesByExcludeAuthorIDs": [
+      {
+        "id": 1705,
+        "title": "Page with parent only"
+      },
+      {
+        "id": 1703,
+        "title": "Page with parent and children"
+      },
+      {
+        "id": 1701,
+        "title": "Page with several levels of children"
+      }
+    ],
+    "pagesByExcludeIDs": [
+      {
+        "id": 1705,
+        "title": "Page with parent only"
+      },
+      {
+        "id": 1703,
+        "title": "Page with parent and children"
+      },
+      {
+        "id": 1701,
+        "title": "Page with several levels of children"
+      },
+      {
+        "id": 1666,
+        "title": "Another Page"
+      }
+    ],
+    "pagesByHasPassword": [],
+    "emptyPagesByIds": [],
+    "pagesByIds": [
+      {
+        "id": 2,
+        "title": "Sample Page"
+      },
+      {
+        "id": 3,
+        "title": "Privacy Policy"
+      }
+    ],
+    "pagesByMetaQuery": [
+      {
+        "id": 1705,
+        "title": "Page with parent only"
+      },
+      {
+        "id": 1703,
+        "title": "Page with parent and children"
+      },
+      {
+        "id": 1701,
+        "title": "Page with several levels of children"
+      },
+      {
+        "id": 1666,
+        "title": "Another Page"
+      },
+      {
+        "id": 2,
+        "title": "Sample Page"
+      }
+    ],
+    "pagesByParentID": [],
+    "pagesByParentIDs": [],
+    "pagesByPassword": [],
+    "pagesBySearch": [
+      {
+        "id": 2,
+        "title": "Sample Page"
+      }
+    ],
+    "pagesByStatus": [
+      {
+        "id": 3,
+        "title": "Privacy Policy"
+      }
+    ],
+    "pagesSortedASC": [
+      {
+        "id": 1666,
+        "title": "Another Page"
+      },
+      {
+        "id": 1703,
+        "title": "Page with parent and children"
+      },
+      {
+        "id": 1705,
+        "title": "Page with parent only"
+      },
+      {
+        "id": 1701,
+        "title": "Page with several levels of children"
+      },
+      {
+        "id": 3,
+        "title": "Privacy Policy"
+      },
+      {
+        "id": 2,
+        "title": "Sample Page"
+      }
+    ],
+    "pagesSortedDESC": [
+      {
+        "id": 2,
+        "title": "Sample Page"
+      },
+      {
+        "id": 3,
+        "title": "Privacy Policy"
+      },
+      {
+        "id": 1701,
+        "title": "Page with several levels of children"
+      },
+      {
+        "id": 1705,
+        "title": "Page with parent only"
+      },
+      {
+        "id": 1703,
+        "title": "Page with parent and children"
+      },
+      {
+        "id": 1666,
+        "title": "Another Page"
+      }
+    ],
+    "pagesWithAncestors": [
+      {
+        "id": 1701,
+        "title": "Page with several levels of children",
+        "parent": null,
+        "ancestors": [],
+        "children": [
+          {
+            "id": 1703,
+            "title": "Page with parent and children"
+          }
+        ],
+        "draftChildren": [],
+        "publishedChildren": [
+          {
+            "id": 1703,
+            "title": "Page with parent and children"
+          }
+        ],
+        "childCount": 1,
+        "draftChildCount": 0,
+        "publishedChildCount": 1
+      },
+      {
+        "id": 1703,
+        "title": "Page with parent and children",
+        "parent": {
+          "id": 1701,
+          "title": "Page with several levels of children"
+        },
+        "ancestors": [
+          {
+            "id": 1701,
+            "title": "Page with several levels of children"
+          }
+        ],
+        "children": [
+          {
+            "id": 1705,
+            "title": "Page with parent only"
+          }
+        ],
+        "draftChildren": [],
+        "publishedChildren": [
+          {
+            "id": 1705,
+            "title": "Page with parent only"
+          }
+        ],
+        "childCount": 1,
+        "draftChildCount": 0,
+        "publishedChildCount": 1
+      },
+      {
+        "id": 1705,
+        "title": "Page with parent only",
+        "parent": {
+          "id": 1703,
+          "title": "Page with parent and children"
+        },
+        "ancestors": [
+          {
+            "id": 1703,
+            "title": "Page with parent and children"
+          },
+          {
+            "id": 1701,
+            "title": "Page with several levels of children"
+          }
+        ],
+        "children": [],
+        "draftChildren": [],
+        "publishedChildren": [],
+        "childCount": 0,
+        "draftChildCount": 0,
+        "publishedChildCount": 0
+      }
+    ]
+  }
 }

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/posts.gql
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/posts.gql
@@ -35,9 +35,9 @@ query {
     metaValue2: metaValue(key: "_wp_page_template")
     meta(keys: ["_thumbnail_id", "_wp_page_template"])
     metaKeys
-    includingMetaKeys: metaKeys(filter: { include: ["_thumbnail_id", "_edit_last"] })
+    includingMetaKeys: metaKeys(filter: { include: ["text_field", "_thumbnail_id", "_edit_last"] })
     excludingMetaKeys: metaKeys(filter: { exclude: ["_thumbnail_id", "_edit_last"] })
-    includingAndExcludingMetaKeys: metaKeys(filter: { include: ["_thumbnail_id", "_edit_last", "_wp_page_template"], exclude: ["_edit_last", "_wp_page_template"] })
+    includingAndExcludingMetaKeys: metaKeys(filter: { include: ["text_field", "number_field", "_thumbnail_id", "_edit_last", "_wp_page_template"], exclude: ["number_field", "_edit_last", "_wp_page_template"] })
     # These ones produce the value of data being inserted to DB, so can't save fixed value for testing
     # modifiedDate
     # modifiedDateStr(format: "m-d")

--- a/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/posts.json
+++ b/layers/GatoGraphQLForWP/phpunit-packages/gatographql/tests/Integration/fixture-schema/posts.json
@@ -1,644 +1,663 @@
 {
-    "data": {
-        "posts": [
-            {
-                "areCommentsOpen": true,
-                "author": {
-                    "id": 2,
-                    "name": "Blogger Davenport"
-                },
-                "categories": [
-                    {
-                        "id": 1,
-                        "name": "Uncategorized"
-                    }
-                ],
-                "categoryCount": 1,
-                "categoryNames": [
-                    "Uncategorized"
-                ],
-                "commentCount": 0,
-                "comments": [],
-                "content": "\n<p class=\"wp-block-paragraph\">Welcome to WordPress. This is your first post. Edit or delete it, then start writing!<\/p>\n",
-                "customPostType": "post",
-                "date": "2020-04-17T13:06:58+00:00",
-                "dateStr": "April 17, 2020",
-                "wpAdminEditURL": null,
-                "excerpt": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!",
-                "featuredImage": null,
-                "hasComments": false,
-                "hasFeaturedImage": false,
-                "id": 1,
-                "isStatus": false,
-                "isSticky": false,
-                "menuOrder": 0,
-                "metaValue": null,
-                "metaValue2": null,
-                "meta": {},
-                "metaKeys": [],
-                "includingMetaKeys": [],
-                "excludingMetaKeys": [],
-                "includingAndExcludingMetaKeys": [],
-                "postFormat": "standard",
-                "rawContent": "<!-- wp:paragraph -->\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!<\/p>\n<!-- \/wp:paragraph -->",
-                "rawTitle": "Hello world!",
-                "rawExcerpt": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!",
-                "slug": "hello-world",
-                "status": "publish",
-                "tagCount": 0,
-                "tagNames": [],
-                "tags": [],
-                "title": "Hello world!",
-                "url": "https:\/\/gatographql.lndo.site\/hello-world\/",
-                "urlPath": "\/hello-world\/"
-            },
-            {
-                "areCommentsOpen": true,
-                "author": {
-                    "id": 3,
-                    "name": "Subscriber Bennett"
-                },
-                "categories": [
-                    {
-                        "id": 3,
-                        "name": "Blog"
-                    }
-                ],
-                "categoryCount": 1,
-                "categoryNames": [
-                    "Blog"
-                ],
-                "commentCount": 1,
-                "comments": [
-                    {
-                        "id": 2
-                    }
-                ],
-                "content": "\n<p class=\"wp-block-paragraph\">This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets.<br><br><\/p>\n\n\n\n<h2 class=\"wp-block-heading\">Image Block (Standard)<\/h2>\n\n\n\n<figure class=\"wp-block-image\"><img decoding=\"async\" src=\"https:\/\/d.pr\/i\/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"\/><\/figure>\n",
-                "customPostType": "post",
-                "date": "2020-12-12T03:56:13+00:00",
-                "dateStr": "December 12, 2020",
-                "wpAdminEditURL": null,
-                "excerpt": "This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets. Image Block (Standard)",
-                "featuredImage": {
-                    "id": 1361,
-                    "src": "https:\/\/gatographql.lndo.site\/wp-content\/uploads\/GatoGraphQL-logo.webp"
-                },
-                "hasComments": true,
-                "hasFeaturedImage": true,
-                "id": 1113,
-                "isStatus": false,
-                "isSticky": false,
-                "menuOrder": 0,
-                "metaValue": "1361",
-                "metaValue2": "default",
-                "meta": {
-                    "_thumbnail_id": [
-                        "1361"
-                    ],
-                    "_wp_page_template": [
-                        "default"
-                    ]
-                },
-                "metaKeys": [
-                    "_thumbnail_id",
-                    "_wp_page_template"
-                ],
-                "includingMetaKeys": [
-                    "_thumbnail_id"
-                ],
-                "excludingMetaKeys": [
-                    "_wp_page_template"
-                ],
-                "includingAndExcludingMetaKeys": [
-                    "_thumbnail_id"
-                ],
-                "postFormat": "standard",
-                "rawContent": "<!-- wp:paragraph -->\n<p>This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets.<br><br><\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:heading -->\n<h2>Image Block (Standard)<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:image {\"id\":1755} -->\n<figure class=\"wp-block-image\"><img src=\"https:\/\/d.pr\/i\/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"\/><\/figure>\n<!-- \/wp:image -->",
-                "rawTitle": "Released v0.6, check it out",
-                "rawExcerpt": "This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets. Image Block (Standard)",
-                "slug": "released-v0-6-check-it-out",
-                "status": "publish",
-                "tagCount": 2,
-                "tagNames": [
-                    "release",
-                    "plugin"
-                ],
-                "tags": [
-                    {
-                        "id": 13,
-                        "name": "release"
-                    },
-                    {
-                        "id": 12,
-                        "name": "plugin"
-                    }
-                ],
-                "title": "Released v0.6, check it out",
-                "url": "https:\/\/gatographql.lndo.site\/released-v0-6-check-it-out\/",
-                "urlPath": "\/released-v0-6-check-it-out\/"
-            },
-            {
-                "areCommentsOpen": true,
-                "author": {
-                    "id": 4,
-                    "name": "Contributor Johnson"
-                },
-                "categories": [
-                    {
-                        "id": 1,
-                        "name": "Uncategorized"
-                    }
-                ],
-                "categoryCount": 1,
-                "categoryNames": [
-                    "Uncategorized"
-                ],
-                "commentCount": 0,
-                "comments": [],
-                "content": "\n<h2 class=\"wp-block-heading\">Image Block (Wide)<\/h2>\n\n\n\n<figure class=\"wp-block-image alignwide\"><img decoding=\"async\" src=\"https:\/\/d.pr\/i\/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"\/><\/figure>\n\n\n\n<h2 class=\"wp-block-heading\">Image Block (Full width)<\/h2>\n\n\n\n<figure class=\"wp-block-image alignfull\"><img decoding=\"async\" src=\"https:\/\/d.pr\/i\/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"\/><\/figure>\n\n\n\n<h2 class=\"wp-block-heading\">Cover Image Block<\/h2>\n\n\n\n<div class=\"wp-block-cover has-background-dim\" style=\"background-image:url(https:\/\/d.pr\/i\/8pTmgY+)\"><div class=\"wp-block-cover__inner-container is-layout-flow wp-block-cover-is-layout-flow\">\n<p class=\"has-text-align-center has-large-font-size wp-block-paragraph\">This block can be used for Hero section.<br>Full width\u00c2 has been applied.<\/p>\n<\/div><\/div>\n\n\n\n<h2 class=\"wp-block-heading\">Gallery Block<\/h2>\n",
-                "customPostType": "post",
-                "date": "2020-12-12T03:59:07+00:00",
-                "dateStr": "December 12, 2020",
-                "wpAdminEditURL": null,
-                "excerpt": "Image Block (Wide) Image Block (Full width) Cover Image Block Gallery Block",
-                "featuredImage": {
-                    "id": 1361,
-                    "src": "https:\/\/gatographql.lndo.site\/wp-content\/uploads\/GatoGraphQL-logo.webp"
-                },
-                "hasComments": false,
-                "hasFeaturedImage": true,
-                "id": 1116,
-                "isStatus": false,
-                "isSticky": false,
-                "menuOrder": 0,
-                "metaValue": "1361",
-                "metaValue2": null,
-                "meta": {
-                    "_thumbnail_id": [
-                        "1361"
-                    ]
-                },
-                "metaKeys": [
-                    "_thumbnail_id",
-                    "meta_with_object_value",
-                    "text_field",
-                    "_text_field",
-                    "number_field",
-                    "_number_field",
-                    "date_field",
-                    "_date_field",
-                    "textarea_field",
-                    "_textarea_field",
-                    "relationship_post_id",
-                    "_relationship_post_id",
-                    "relationship_post_ids",
-                    "_relationship_post_ids",
-                    "repeater_list_field_0_list_field",
-                    "_repeater_list_field_0_list_field",
-                    "repeater_list_field_1_list_field",
-                    "_repeater_list_field_1_list_field",
-                    "repeater_list_field_2_list_field",
-                    "_repeater_list_field_2_list_field",
-                    "repeater_list_field",
-                    "_repeater_list_field",
-                    "repeater_list_field_3_list_field",
-                    "_repeater_list_field_3_list_field"
-                ],
-                "includingMetaKeys": [
-                    "_thumbnail_id"
-                ],
-                "excludingMetaKeys": [
-                    "meta_with_object_value",
-                    "text_field",
-                    "_text_field",
-                    "number_field",
-                    "_number_field",
-                    "date_field",
-                    "_date_field",
-                    "textarea_field",
-                    "_textarea_field",
-                    "relationship_post_id",
-                    "_relationship_post_id",
-                    "relationship_post_ids",
-                    "_relationship_post_ids",
-                    "repeater_list_field_0_list_field",
-                    "_repeater_list_field_0_list_field",
-                    "repeater_list_field_1_list_field",
-                    "_repeater_list_field_1_list_field",
-                    "repeater_list_field_2_list_field",
-                    "_repeater_list_field_2_list_field",
-                    "repeater_list_field",
-                    "_repeater_list_field",
-                    "repeater_list_field_3_list_field",
-                    "_repeater_list_field_3_list_field"
-                ],
-                "includingAndExcludingMetaKeys": [
-                    "_thumbnail_id"
-                ],
-                "postFormat": "standard",
-                "rawContent": "<!-- wp:heading -->\n<h2>Image Block (Wide)<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:image {\"align\":\"wide\",\"id\":1755} -->\n<figure class=\"wp-block-image alignwide\"><img src=\"https:\/\/d.pr\/i\/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"\/><\/figure>\n<!-- \/wp:image -->\n\n<!-- wp:heading -->\n<h2>Image Block (Full width)<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:image {\"align\":\"full\",\"id\":1755} -->\n<figure class=\"wp-block-image alignfull\"><img src=\"https:\/\/d.pr\/i\/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"\/><\/figure>\n<!-- \/wp:image -->\n\n<!-- wp:heading -->\n<h2>Cover Image Block<\/h2>\n<!-- \/wp:heading -->\n\n<!-- wp:cover {\"url\":\"https:\/\/d.pr\/i\/8pTmgY+\",\"id\":1755} -->\n<div class=\"wp-block-cover has-background-dim\" style=\"background-image:url(https:\/\/d.pr\/i\/8pTmgY+)\"><div class=\"wp-block-cover__inner-container\"><!-- wp:paragraph {\"align\":\"center\",\"placeholder\":\"Write title\u2026\",\"fontSize\":\"large\"} -->\n<p class=\"has-text-align-center has-large-font-size\">This block can be used for Hero section.<br>Full width\u00c2 has been applied.<\/p>\n<!-- \/wp:paragraph --><\/div><\/div>\n<!-- \/wp:cover -->\n\n<!-- wp:heading -->\n<h2>Gallery Block<\/h2>\n<!-- \/wp:heading -->",
-                "rawTitle": "Working on flat chain syntax next",
-                "rawExcerpt": "Image Block (Wide) Image Block (Full width) Cover Image Block Gallery Block",
-                "slug": "working-on-flat-chain-syntax-next",
-                "status": "publish",
-                "tagCount": 4,
-                "tagNames": [
-                    "wordpress",
-                    "plugin",
-                    "GraphQL",
-                    "features"
-                ],
-                "tags": [
-                    {
-                        "id": 15,
-                        "name": "wordpress"
-                    },
-                    {
-                        "id": 12,
-                        "name": "plugin"
-                    },
-                    {
-                        "id": 10,
-                        "name": "GraphQL"
-                    },
-                    {
-                        "id": 9,
-                        "name": "features"
-                    }
-                ],
-                "title": "Working on flat chain syntax next",
-                "url": "https:\/\/gatographql.lndo.site\/working-on-flat-chain-syntax-next\/",
-                "urlPath": "\/working-on-flat-chain-syntax-next\/"
-            }
-        ],
-        "postsByAuthorIDs": [
-            {
-                "id": 1128,
-                "title": "HTTP caching improves performance"
-            }
-        ],
-        "postsByAuthorSlug": [
-            {
-                "id": 1210,
-                "title": "PHP-only blocks (combinations)"
-            },
-            {
-                "id": 1212,
-                "title": "All blocks with entity references"
-            },
-            {
-                "id": 1200,
-                "title": "PHP-only blocks"
-            },
-            {
-                "id": 1125,
-                "title": "Public or Private API mode, for extra security"
-            },
-            {
-                "id": 1123,
-                "title": "GraphQL or REST? Why not both?"
-            },
-            {
-                "id": 1121,
-                "title": "Customize the schema for each client"
-            },
-            {
-                "id": 1,
-                "title": "Hello world!"
-            }
-        ],
-        "postsByCategoryIDs": [
-            {
-                "id": 1212,
-                "title": "All blocks with entity references"
-            },
-            {
-                "id": 1142,
-                "title": "Post with internal links, also in meta (entries starting with internal_link_)"
-            },
-            {
-                "id": 1146,
-                "title": "Post with corrupted non-breaking space"
-            },
-            {
-                "id": 1150,
-                "title": "Post with old format of the Gutenberg `core\/list` block"
-            },
-            {
-                "id": 1140,
-                "title": "Welcome to a single post full of blocks!"
-            },
-            {
-                "id": 1121,
-                "title": "Customize the schema for each client"
-            },
-            {
-                "id": 1116,
-                "title": "Working on flat chain syntax next"
-            },
-            {
-                "id": 1,
-                "title": "Hello world!"
-            }
-        ],
-        "postsByDateQuery": [
-            {
-                "id": 1,
-                "title": "Hello world!"
-            }
-        ],
-        "postsByExcludeAuthorIDs": [
-            {
-                "id": 1210,
-                "title": "PHP-only blocks (combinations)"
-            },
-            {
-                "id": 1212,
-                "title": "All blocks with entity references"
-            },
-            {
-                "id": 1200,
-                "title": "PHP-only blocks"
-            },
-            {
-                "id": 1142,
-                "title": "Post with internal links, also in meta (entries starting with internal_link_)"
-            },
-            {
-                "id": 1146,
-                "title": "Post with corrupted non-breaking space"
-            },
-            {
-                "id": 1150,
-                "title": "Post with old format of the Gutenberg `core\/list` block"
-            },
-            {
-                "id": 1140,
-                "title": "Welcome to a single post full of blocks!"
-            },
-            {
-                "id": 1125,
-                "title": "Public or Private API mode, for extra security"
-            },
-            {
-                "id": 1123,
-                "title": "GraphQL or REST? Why not both?"
-            },
-            {
-                "id": 1121,
-                "title": "Customize the schema for each client"
-            }
-        ],
-        "postsByExcludeIDs": [
-            {
-                "id": 1212,
-                "title": "All blocks with entity references"
-            },
-            {
-                "id": 1210,
-                "title": "PHP-only blocks (combinations)"
-            },
-            {
-                "id": 1200,
-                "title": "PHP-only blocks"
-            },
-            {
-                "id": 1150,
-                "title": "Post with old format of the Gutenberg `core\/list` block"
-            },
-            {
-                "id": 1146,
-                "title": "Post with corrupted non-breaking space"
-            },
-            {
-                "id": 1142,
-                "title": "Post with internal links, also in meta (entries starting with internal_link_)"
-            },
-            {
-                "id": 1140,
-                "title": "Welcome to a single post full of blocks!"
-            },
-            {
-                "id": 1125,
-                "title": "Public or Private API mode, for extra security"
-            },
-            {
-                "id": 1123,
-                "title": "GraphQL or REST? Why not both?"
-            },
-            {
-                "id": 1121,
-                "title": "Customize the schema for each client"
-            }
-        ],
-        "postsByHasPassword": [],
-        "emptyPostsByIds": [],
-        "postsByIds": [
-            {
-                "id": 1128,
-                "title": "HTTP caching improves performance"
-            },
-            {
-                "id": 1,
-                "title": "Hello world!"
-            }
-        ],
-        "postsByIsSticky": [],
-        "postsByMetaQuery": [
-            {
-                "id": 1125,
-                "title": "Public or Private API mode, for extra security"
-            },
-            {
-                "id": 1116,
-                "title": "Working on flat chain syntax next"
-            },
-            {
-                "id": 1113,
-                "title": "Released v0.6, check it out"
-            }
-        ],
-        "postsByPassword": [],
-        "postsBySearch": [
-            {
-                "id": 1142,
-                "title": "Post with internal links, also in meta (entries starting with internal_link_)"
-            },
-            {
-                "id": 1140,
-                "title": "Welcome to a single post full of blocks!"
-            },
-            {
-                "id": 1,
-                "title": "Hello world!"
-            }
-        ],
-        "postsByStatus": [],
-        "postsByTagIDs": [
-            {
-                "id": 1210,
-                "title": "PHP-only blocks (combinations)"
-            },
-            {
-                "id": 1200,
-                "title": "PHP-only blocks"
-            },
-            {
-                "id": 1125,
-                "title": "Public or Private API mode, for extra security"
-            },
-            {
-                "id": 1121,
-                "title": "Customize the schema for each client"
-            },
-            {
-                "id": 1119,
-                "title": "Nested mutations are a must have"
-            },
-            {
-                "id": 1116,
-                "title": "Working on flat chain syntax next"
-            }
-        ],
-        "postsByTagSlugs": [
-            {
-                "id": 1210,
-                "title": "PHP-only blocks (combinations)"
-            },
-            {
-                "id": 1200,
-                "title": "PHP-only blocks"
-            },
-            {
-                "id": 1119,
-                "title": "Nested mutations are a must have"
-            },
-            {
-                "id": 1116,
-                "title": "Working on flat chain syntax next"
-            },
-            {
-                "id": 1113,
-                "title": "Released v0.6, check it out"
-            }
-        ],
-        "postsBySlugs": [
-            {
-                "id": 1,
-                "title": "Hello world!",
-                "slug": "hello-world"
-            },
-            {
-                "id": 1113,
-                "title": "Released v0.6, check it out",
-                "slug": "released-v0-6-check-it-out"
-            }
-        ],
-        "postsSortedASC": [
-            {
-                "id": 1212,
-                "title": "All blocks with entity references"
-            },
-            {
-                "id": 1121,
-                "title": "Customize the schema for each client"
-            },
-            {
-                "id": 1123,
-                "title": "GraphQL or REST? Why not both?"
-            }
-        ],
-        "postsSortedDESC": [
-            {
-                "id": 1116,
-                "title": "Working on flat chain syntax next"
-            },
-            {
-                "id": 1140,
-                "title": "Welcome to a single post full of blocks!"
-            },
-            {
-                "id": 1113,
-                "title": "Released v0.6, check it out"
-            }
-        ],
-        "futurePost": {
-            "status": "future",
-            "rawStatus": "publish"
-        },
-        "postWithMeta": {
-            "object_metaValue": {
-                "_edit_lock": {
-                    "to": {
-                        "111": [
-                            "1743667747:1"
-                        ]
-                    }
-                },
-                "_pingme": {
-                    "to": {
-                        "111": [
-                            "1"
-                        ]
-                    }
-                },
-                "some_property_to_translate": {
-                    "to": {
-                        "111": [
-                            "Messi won another cup for more than 4 times by now, bleh\r\nAnd with another sentence"
-                        ]
-                    }
-                },
-                "some_property": {
-                    "to": {
-                        "111": [
-                            "Nothing about Diego?"
-                        ]
-                    }
-                }
-            },
-            "object_metaValues": [
-                {
-                    "_edit_lock": {
-                        "to": {
-                            "111": [
-                                "1743667747:1"
-                            ]
-                        }
-                    },
-                    "_pingme": {
-                        "to": {
-                            "111": [
-                                "1"
-                            ]
-                        }
-                    },
-                    "some_property_to_translate": {
-                        "to": {
-                            "111": [
-                                "Messi won another cup for more than 4 times by now, bleh\r\nAnd with another sentence"
-                            ]
-                        }
-                    },
-                    "some_property": {
-                        "to": {
-                            "111": [
-                                "Nothing about Diego?"
-                            ]
-                        }
-                    }
-                }
-            ],
-            "text_field_metaValue": "This is a text field value for ACF",
-            "number_field_metaValue": "22",
-            "date_field_metaValue": "20250426",
-            "textarea_field_metaValue": "This is a textarea field value for ACF, line 1\nline 2\nthird line",
-            "relationship_post_id_metaValue": "27",
-            "relationship_post_ids_metaValue": [
-                "1",
-                "56"
-            ]
+  "errors": [
+    {
+      "message": "There is no key with name '_thumbnail_id'",
+      "locations": [
+        {
+          "line": 34,
+          "column": 15
         }
+      ],
+      "extensions": {
+        "path": [
+          "(key: \"_thumbnail_id\")",
+          "metaValue(key: \"_thumbnail_id\")",
+          "posts(pagination: {limit: 3}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
+        ],
+        "type": "Post",
+        "field": "metaValue(key: \"_thumbnail_id\")",
+        "code": "PoPCMSSchema/Meta@e1"
+      }
+    },
+    {
+      "message": "There is no key with name '_wp_page_template'",
+      "locations": [
+        {
+          "line": 35,
+          "column": 27
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(key: \"_wp_page_template\")",
+          "metaValue2: metaValue(key: \"_wp_page_template\")",
+          "posts(pagination: {limit: 3}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
+        ],
+        "type": "Post",
+        "field": "metaValue2: metaValue(key: \"_wp_page_template\")",
+        "code": "PoPCMSSchema/Meta@e1"
+      }
+    },
+    {
+      "message": "There are no keys with names '_thumbnail_id', '_wp_page_template'",
+      "locations": [
+        {
+          "line": 36,
+          "column": 10
+        }
+      ],
+      "extensions": {
+        "path": [
+          "(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+          "meta(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+          "posts(pagination: {limit: 3}, sort: {by: ID, order: ASC}) { ... }",
+          "query { ... }"
+        ],
+        "type": "Post",
+        "field": "meta(keys: [\"_thumbnail_id\", \"_wp_page_template\"])",
+        "code": "PoPCMSSchema/Meta@e2"
+      }
     }
+  ],
+  "data": {
+    "posts": [
+      {
+        "areCommentsOpen": true,
+        "author": {
+          "id": 2,
+          "name": "Blogger Davenport"
+        },
+        "categories": [
+          {
+            "id": 1,
+            "name": "Uncategorized"
+          }
+        ],
+        "categoryCount": 1,
+        "categoryNames": [
+          "Uncategorized"
+        ],
+        "commentCount": 0,
+        "comments": [],
+        "content": "\n<p class=\"wp-block-paragraph\">Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n",
+        "customPostType": "post",
+        "date": "2020-04-17T13:06:58+00:00",
+        "dateStr": "April 17, 2020",
+        "wpAdminEditURL": null,
+        "excerpt": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!",
+        "featuredImage": null,
+        "hasComments": false,
+        "hasFeaturedImage": false,
+        "id": 1,
+        "isStatus": false,
+        "isSticky": false,
+        "menuOrder": 0,
+        "metaValue": null,
+        "metaValue2": null,
+        "meta": null,
+        "metaKeys": [],
+        "includingMetaKeys": [],
+        "excludingMetaKeys": [],
+        "includingAndExcludingMetaKeys": [],
+        "postFormat": "standard",
+        "rawContent": "<!-- wp:paragraph -->\n<p>Welcome to WordPress. This is your first post. Edit or delete it, then start writing!</p>\n<!-- /wp:paragraph -->",
+        "rawTitle": "Hello world!",
+        "rawExcerpt": "Welcome to WordPress. This is your first post. Edit or delete it, then start writing!",
+        "slug": "hello-world",
+        "status": "publish",
+        "tagCount": 0,
+        "tagNames": [],
+        "tags": [],
+        "title": "Hello world!",
+        "url": "https://gatographql.lndo.site/hello-world/",
+        "urlPath": "/hello-world/"
+      },
+      {
+        "areCommentsOpen": true,
+        "author": {
+          "id": 3,
+          "name": "Subscriber Bennett"
+        },
+        "categories": [
+          {
+            "id": 3,
+            "name": "Blog"
+          }
+        ],
+        "categoryCount": 1,
+        "categoryNames": [
+          "Blog"
+        ],
+        "commentCount": 1,
+        "comments": [
+          {
+            "id": 2
+          }
+        ],
+        "content": "\n<p class=\"wp-block-paragraph\">This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets.<br><br></p>\n\n\n\n<h2 class=\"wp-block-heading\">Image Block (Standard)</h2>\n\n\n\n<figure class=\"wp-block-image\"><img decoding=\"async\" src=\"https://d.pr/i/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"/></figure>\n",
+        "customPostType": "post",
+        "date": "2020-12-12T03:56:13+00:00",
+        "dateStr": "December 12, 2020",
+        "wpAdminEditURL": null,
+        "excerpt": "This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets. Image Block (Standard)",
+        "featuredImage": {
+          "id": 1361,
+          "src": "https://gatographql.lndo.site/wp-content/uploads/GatoGraphQL-logo.webp"
+        },
+        "hasComments": true,
+        "hasFeaturedImage": true,
+        "id": 1113,
+        "isStatus": false,
+        "isSticky": false,
+        "menuOrder": 0,
+        "metaValue": null,
+        "metaValue2": null,
+        "meta": null,
+        "metaKeys": [],
+        "includingMetaKeys": [],
+        "excludingMetaKeys": [],
+        "includingAndExcludingMetaKeys": [],
+        "postFormat": "standard",
+        "rawContent": "<!-- wp:paragraph -->\n<p>This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets.<br><br></p>\n<!-- /wp:paragraph -->\n\n<!-- wp:heading -->\n<h2>Image Block (Standard)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:image {\"id\":1755} -->\n<figure class=\"wp-block-image\"><img src=\"https://d.pr/i/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"/></figure>\n<!-- /wp:image -->",
+        "rawTitle": "Released v0.6, check it out",
+        "rawExcerpt": "This is a paragraph block. Professionally productize highly efficient results with world-class core competencies. Objectively matrix leveraged architectures vis-a-vis error-free applications. Completely maximize customized portals via fully researched metrics. Enthusiastically generate premier action items through web-enabled e-markets. Efficiently parallel task holistic intellectual capital and client-centric markets. Image Block (Standard)",
+        "slug": "released-v0-6-check-it-out",
+        "status": "publish",
+        "tagCount": 2,
+        "tagNames": [
+          "release",
+          "plugin"
+        ],
+        "tags": [
+          {
+            "id": 13,
+            "name": "release"
+          },
+          {
+            "id": 12,
+            "name": "plugin"
+          }
+        ],
+        "title": "Released v0.6, check it out",
+        "url": "https://gatographql.lndo.site/released-v0-6-check-it-out/",
+        "urlPath": "/released-v0-6-check-it-out/"
+      },
+      {
+        "areCommentsOpen": true,
+        "author": {
+          "id": 4,
+          "name": "Contributor Johnson"
+        },
+        "categories": [
+          {
+            "id": 1,
+            "name": "Uncategorized"
+          }
+        ],
+        "categoryCount": 1,
+        "categoryNames": [
+          "Uncategorized"
+        ],
+        "commentCount": 0,
+        "comments": [],
+        "content": "\n<h2 class=\"wp-block-heading\">Image Block (Wide)</h2>\n\n\n\n<figure class=\"wp-block-image alignwide\"><img decoding=\"async\" src=\"https://d.pr/i/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"/></figure>\n\n\n\n<h2 class=\"wp-block-heading\">Image Block (Full width)</h2>\n\n\n\n<figure class=\"wp-block-image alignfull\"><img decoding=\"async\" src=\"https://d.pr/i/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"/></figure>\n\n\n\n<h2 class=\"wp-block-heading\">Cover Image Block</h2>\n\n\n\n<div class=\"wp-block-cover has-background-dim\" style=\"background-image:url(https://d.pr/i/8pTmgY+)\"><div class=\"wp-block-cover__inner-container is-layout-flow wp-block-cover-is-layout-flow\">\n<p class=\"has-text-align-center has-large-font-size wp-block-paragraph\">This block can be used for Hero section.<br>Full widthÂ has been applied.</p>\n</div></div>\n\n\n\n<h2 class=\"wp-block-heading\">Gallery Block</h2>\n",
+        "customPostType": "post",
+        "date": "2020-12-12T03:59:07+00:00",
+        "dateStr": "December 12, 2020",
+        "wpAdminEditURL": null,
+        "excerpt": "Image Block (Wide) Image Block (Full width) Cover Image Block Gallery Block",
+        "featuredImage": {
+          "id": 1361,
+          "src": "https://gatographql.lndo.site/wp-content/uploads/GatoGraphQL-logo.webp"
+        },
+        "hasComments": false,
+        "hasFeaturedImage": true,
+        "id": 1116,
+        "isStatus": false,
+        "isSticky": false,
+        "menuOrder": 0,
+        "metaValue": null,
+        "metaValue2": null,
+        "meta": null,
+        "metaKeys": [
+          "meta_with_object_value",
+          "text_field",
+          "number_field",
+          "date_field",
+          "textarea_field",
+          "relationship_post_id",
+          "relationship_post_ids",
+          "repeater_list_field_0_list_field",
+          "repeater_list_field_1_list_field",
+          "repeater_list_field_2_list_field",
+          "repeater_list_field",
+          "repeater_list_field_3_list_field"
+        ],
+        "includingMetaKeys": [
+          "text_field"
+        ],
+        "excludingMetaKeys": [
+          "meta_with_object_value",
+          "text_field",
+          "number_field",
+          "date_field",
+          "textarea_field",
+          "relationship_post_id",
+          "relationship_post_ids",
+          "repeater_list_field_0_list_field",
+          "repeater_list_field_1_list_field",
+          "repeater_list_field_2_list_field",
+          "repeater_list_field",
+          "repeater_list_field_3_list_field"
+        ],
+        "includingAndExcludingMetaKeys": [
+          "text_field"
+        ],
+        "postFormat": "standard",
+        "rawContent": "<!-- wp:heading -->\n<h2>Image Block (Wide)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:image {\"align\":\"wide\",\"id\":1755} -->\n<figure class=\"wp-block-image alignwide\"><img src=\"https://d.pr/i/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:heading -->\n<h2>Image Block (Full width)</h2>\n<!-- /wp:heading -->\n\n<!-- wp:image {\"align\":\"full\",\"id\":1755} -->\n<figure class=\"wp-block-image alignfull\"><img src=\"https://d.pr/i/8pTmgY+\" alt=\"\" class=\"wp-image-1755\"/></figure>\n<!-- /wp:image -->\n\n<!-- wp:heading -->\n<h2>Cover Image Block</h2>\n<!-- /wp:heading -->\n\n<!-- wp:cover {\"url\":\"https://d.pr/i/8pTmgY+\",\"id\":1755} -->\n<div class=\"wp-block-cover has-background-dim\" style=\"background-image:url(https://d.pr/i/8pTmgY+)\"><div class=\"wp-block-cover__inner-container\"><!-- wp:paragraph {\"align\":\"center\",\"placeholder\":\"Write title…\",\"fontSize\":\"large\"} -->\n<p class=\"has-text-align-center has-large-font-size\">This block can be used for Hero section.<br>Full widthÂ has been applied.</p>\n<!-- /wp:paragraph --></div></div>\n<!-- /wp:cover -->\n\n<!-- wp:heading -->\n<h2>Gallery Block</h2>\n<!-- /wp:heading -->",
+        "rawTitle": "Working on flat chain syntax next",
+        "rawExcerpt": "Image Block (Wide) Image Block (Full width) Cover Image Block Gallery Block",
+        "slug": "working-on-flat-chain-syntax-next",
+        "status": "publish",
+        "tagCount": 4,
+        "tagNames": [
+          "wordpress",
+          "plugin",
+          "GraphQL",
+          "features"
+        ],
+        "tags": [
+          {
+            "id": 15,
+            "name": "wordpress"
+          },
+          {
+            "id": 12,
+            "name": "plugin"
+          },
+          {
+            "id": 10,
+            "name": "GraphQL"
+          },
+          {
+            "id": 9,
+            "name": "features"
+          }
+        ],
+        "title": "Working on flat chain syntax next",
+        "url": "https://gatographql.lndo.site/working-on-flat-chain-syntax-next/",
+        "urlPath": "/working-on-flat-chain-syntax-next/"
+      }
+    ],
+    "postsByAuthorIDs": [
+      {
+        "id": 1128,
+        "title": "HTTP caching improves performance"
+      }
+    ],
+    "postsByAuthorSlug": [
+      {
+        "id": 1210,
+        "title": "PHP-only blocks (combinations)"
+      },
+      {
+        "id": 1212,
+        "title": "All blocks with entity references"
+      },
+      {
+        "id": 1200,
+        "title": "PHP-only blocks"
+      },
+      {
+        "id": 1125,
+        "title": "Public or Private API mode, for extra security"
+      },
+      {
+        "id": 1123,
+        "title": "GraphQL or REST? Why not both?"
+      },
+      {
+        "id": 1121,
+        "title": "Customize the schema for each client"
+      },
+      {
+        "id": 1,
+        "title": "Hello world!"
+      }
+    ],
+    "postsByCategoryIDs": [
+      {
+        "id": 1212,
+        "title": "All blocks with entity references"
+      },
+      {
+        "id": 1142,
+        "title": "Post with internal links, also in meta (entries starting with internal_link_)"
+      },
+      {
+        "id": 1146,
+        "title": "Post with corrupted non-breaking space"
+      },
+      {
+        "id": 1150,
+        "title": "Post with old format of the Gutenberg `core/list` block"
+      },
+      {
+        "id": 1140,
+        "title": "Welcome to a single post full of blocks!"
+      },
+      {
+        "id": 1121,
+        "title": "Customize the schema for each client"
+      },
+      {
+        "id": 1116,
+        "title": "Working on flat chain syntax next"
+      },
+      {
+        "id": 1,
+        "title": "Hello world!"
+      }
+    ],
+    "postsByDateQuery": [
+      {
+        "id": 1,
+        "title": "Hello world!"
+      }
+    ],
+    "postsByExcludeAuthorIDs": [
+      {
+        "id": 1210,
+        "title": "PHP-only blocks (combinations)"
+      },
+      {
+        "id": 1212,
+        "title": "All blocks with entity references"
+      },
+      {
+        "id": 1200,
+        "title": "PHP-only blocks"
+      },
+      {
+        "id": 1142,
+        "title": "Post with internal links, also in meta (entries starting with internal_link_)"
+      },
+      {
+        "id": 1146,
+        "title": "Post with corrupted non-breaking space"
+      },
+      {
+        "id": 1150,
+        "title": "Post with old format of the Gutenberg `core/list` block"
+      },
+      {
+        "id": 1140,
+        "title": "Welcome to a single post full of blocks!"
+      },
+      {
+        "id": 1125,
+        "title": "Public or Private API mode, for extra security"
+      },
+      {
+        "id": 1123,
+        "title": "GraphQL or REST? Why not both?"
+      },
+      {
+        "id": 1121,
+        "title": "Customize the schema for each client"
+      }
+    ],
+    "postsByExcludeIDs": [
+      {
+        "id": 1212,
+        "title": "All blocks with entity references"
+      },
+      {
+        "id": 1210,
+        "title": "PHP-only blocks (combinations)"
+      },
+      {
+        "id": 1200,
+        "title": "PHP-only blocks"
+      },
+      {
+        "id": 1150,
+        "title": "Post with old format of the Gutenberg `core/list` block"
+      },
+      {
+        "id": 1146,
+        "title": "Post with corrupted non-breaking space"
+      },
+      {
+        "id": 1142,
+        "title": "Post with internal links, also in meta (entries starting with internal_link_)"
+      },
+      {
+        "id": 1140,
+        "title": "Welcome to a single post full of blocks!"
+      },
+      {
+        "id": 1125,
+        "title": "Public or Private API mode, for extra security"
+      },
+      {
+        "id": 1123,
+        "title": "GraphQL or REST? Why not both?"
+      },
+      {
+        "id": 1121,
+        "title": "Customize the schema for each client"
+      }
+    ],
+    "postsByHasPassword": [],
+    "emptyPostsByIds": [],
+    "postsByIds": [
+      {
+        "id": 1128,
+        "title": "HTTP caching improves performance"
+      },
+      {
+        "id": 1,
+        "title": "Hello world!"
+      }
+    ],
+    "postsByIsSticky": [],
+    "postsByMetaQuery": [
+      {
+        "id": 1125,
+        "title": "Public or Private API mode, for extra security"
+      },
+      {
+        "id": 1116,
+        "title": "Working on flat chain syntax next"
+      },
+      {
+        "id": 1113,
+        "title": "Released v0.6, check it out"
+      }
+    ],
+    "postsByPassword": [],
+    "postsBySearch": [
+      {
+        "id": 1142,
+        "title": "Post with internal links, also in meta (entries starting with internal_link_)"
+      },
+      {
+        "id": 1140,
+        "title": "Welcome to a single post full of blocks!"
+      },
+      {
+        "id": 1,
+        "title": "Hello world!"
+      }
+    ],
+    "postsByStatus": [],
+    "postsByTagIDs": [
+      {
+        "id": 1210,
+        "title": "PHP-only blocks (combinations)"
+      },
+      {
+        "id": 1200,
+        "title": "PHP-only blocks"
+      },
+      {
+        "id": 1125,
+        "title": "Public or Private API mode, for extra security"
+      },
+      {
+        "id": 1121,
+        "title": "Customize the schema for each client"
+      },
+      {
+        "id": 1119,
+        "title": "Nested mutations are a must have"
+      },
+      {
+        "id": 1116,
+        "title": "Working on flat chain syntax next"
+      }
+    ],
+    "postsByTagSlugs": [
+      {
+        "id": 1210,
+        "title": "PHP-only blocks (combinations)"
+      },
+      {
+        "id": 1200,
+        "title": "PHP-only blocks"
+      },
+      {
+        "id": 1119,
+        "title": "Nested mutations are a must have"
+      },
+      {
+        "id": 1116,
+        "title": "Working on flat chain syntax next"
+      },
+      {
+        "id": 1113,
+        "title": "Released v0.6, check it out"
+      }
+    ],
+    "postsBySlugs": [
+      {
+        "id": 1,
+        "title": "Hello world!",
+        "slug": "hello-world"
+      },
+      {
+        "id": 1113,
+        "title": "Released v0.6, check it out",
+        "slug": "released-v0-6-check-it-out"
+      }
+    ],
+    "postsSortedASC": [
+      {
+        "id": 1212,
+        "title": "All blocks with entity references"
+      },
+      {
+        "id": 1121,
+        "title": "Customize the schema for each client"
+      },
+      {
+        "id": 1123,
+        "title": "GraphQL or REST? Why not both?"
+      }
+    ],
+    "postsSortedDESC": [
+      {
+        "id": 1116,
+        "title": "Working on flat chain syntax next"
+      },
+      {
+        "id": 1140,
+        "title": "Welcome to a single post full of blocks!"
+      },
+      {
+        "id": 1113,
+        "title": "Released v0.6, check it out"
+      }
+    ],
+    "futurePost": {
+      "status": "future",
+      "rawStatus": "publish"
+    },
+    "postWithMeta": {
+      "object_metaValue": {
+        "_edit_lock": {
+          "to": {
+            "111": [
+              "1743667747:1"
+            ]
+          }
+        },
+        "_pingme": {
+          "to": {
+            "111": [
+              "1"
+            ]
+          }
+        },
+        "some_property_to_translate": {
+          "to": {
+            "111": [
+              "Messi won another cup for more than 4 times by now, bleh\r\nAnd with another sentence"
+            ]
+          }
+        },
+        "some_property": {
+          "to": {
+            "111": [
+              "Nothing about Diego?"
+            ]
+          }
+        }
+      },
+      "object_metaValues": [
+        {
+          "_edit_lock": {
+            "to": {
+              "111": [
+                "1743667747:1"
+              ]
+            }
+          },
+          "_pingme": {
+            "to": {
+              "111": [
+                "1"
+              ]
+            }
+          },
+          "some_property_to_translate": {
+            "to": {
+              "111": [
+                "Messi won another cup for more than 4 times by now, bleh\r\nAnd with another sentence"
+              ]
+            }
+          },
+          "some_property": {
+            "to": {
+              "111": [
+                "Nothing about Diego?"
+              ]
+            }
+          }
+        }
+      ],
+      "text_field_metaValue": "This is a text field value for ACF",
+      "number_field_metaValue": "22",
+      "date_field_metaValue": "20250426",
+      "textarea_field_metaValue": "This is a textarea field value for ACF, line 1\nline 2\nthird line",
+      "relationship_post_id_metaValue": "27",
+      "relationship_post_ids_metaValue": [
+        "1",
+        "56"
+      ]
+    }
+  }
 }

--- a/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `gatographql` will be documented in this file.
 
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## 19.2.4 - 07/09/2026
+
+### Security
+
+- Reading protected meta keys (WordPress internal keys, such as those prefixed with <code>_</code>) from custom posts, comments and taxonomy terms is now restricted to administrators, closing an information disclosure where any user, including anonymous, could read them via fields <code>metaValue</code>/<code>metaValues</code>/<code>meta</code>/<code>metaKeys</code> (#3393)
+- Protected meta keys can no longer be read or written by padding the key name with characters that the database does not tell apart from the key itself (#3393)
+
 ## 19.2.3 - 07/09/2026
 
 ### Security

--- a/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/docs/release-notes/19.2/en.md
@@ -14,7 +14,19 @@ The same protection is applied to the custom post, comment and taxonomy meta mut
 
 In `v19.2.3` this protection was hardened to also reject variants of the protected keys that differ only in letter case or trailing whitespace (such as `WP_capabilities` or `wp_capabilities `). WordPress resolves the meta key against the database column case-insensitively and ignoring trailing whitespace, so such a variant still targeted the protected row; the check now normalizes the key the same way before rejecting it ([#3392](https://github.com/GatoGraphQL/GatoGraphQL/pull/3392)).
 
-Protected **user** meta keys are also no longer **readable** by non-administrators. Previously any user, including anonymous visitors, could read them through fields `metaValue`, `metaValues`, `meta` and `metaKeys` — including application-password hashes stored under `_application_passwords`, session tokens, and the roles/capabilities keys — because the meta allow/deny list defaulted to permissive. Now administrators can read any user meta key, while every other user cannot read the protected ones (they are also omitted from the `metaKeys` list). Meta on other entities (posts, comments, taxonomies) is unaffected — for instance a product's `_price` remains readable — so this does not change public content reads.
+Protected **user** meta keys are also no longer **readable** by non-administrators. Previously any user, including anonymous visitors, could read them through fields `metaValue`, `metaValues`, `meta` and `metaKeys` — including application-password hashes stored under `_application_passwords`, session tokens, and the roles/capabilities keys — because the meta allow/deny list defaulted to permissive. Now administrators can read any user meta key, while every other user cannot read the protected ones (they are also omitted from the `metaKeys` list).
+
+In `v19.2.4` the same read protection was extended to **custom posts, comments and taxonomy terms**, which until then had their protected meta keys restricted on writing only ([#3393](https://github.com/GatoGraphQL/GatoGraphQL/pull/3393)). Any user, including anonymous visitors, could read a protected meta key on a public entry — such as a page builder's stored layout, or a key holding a third-party plugin's configuration — as long as they knew its name. Administrators can still read every meta key.
+
+This changes what a query returns on a site that reads such keys publicly: a field like `metaValue(key: "_thumbnail_id")` now produces an error for non-administrators. To expose a specific protected key again, set the meta allow/deny behavior for that entity to "Allow access" and add the key to the list, or unprotect it through WordPress' own `is_protected_meta` filter. Meta keys that are not protected by WordPress are unaffected.
+
+### Protected meta keys cannot be reached through look-alike key names
+
+(`v19.2.4`)
+
+The meta key columns are stored under a collation that treats some characters as carrying no weight at all, so a key name padded with one of them resolves, in the database, to the very same row as the protected key it imitates ([#3393](https://github.com/GatoGraphQL/GatoGraphQL/pull/3393)). The protection check compared the key name exactly, so such a name passed it while the write landed on the protected row.
+
+Protected meta keys are now resolved through the database before the check, so every name the database considers equal to a protected key is rejected as well. This applies to user, custom post, comment and taxonomy meta, on both reading and writing.
 
 ### Reading site options is restricted to administrators
 

--- a/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/readme.txt
@@ -247,6 +247,10 @@ The JavaScript source code for the blocks is under [layers/GatoGraphQLForWP/plug
 
 == Changelog ==
 
+= 19.2.4 =
+* Security - Reading protected meta keys (WordPress internal keys, such as those prefixed with <code>_</code>) from custom posts, comments and taxonomy terms is now restricted to administrators, closing an information disclosure where any user, including anonymous, could read them via fields <code>metaValue</code>/<code>metaValues</code>/<code>meta</code>/<code>metaKeys</code> (#3393)
+* Security - Protected meta keys can no longer be read or written by padding the key name with characters that the database does not tell apart from the key itself (#3393)
+
 = 19.2.3 =
 * Security - Fixed a privilege escalation vulnerability where a logged-in user could still modify protected user meta keys (such as their own role/capabilities) through the user meta mutations by varying the letter case, accenting a letter, or adding trailing whitespace to the key name, bypassing the protection added in 19.2.2 (#3392)
 * Security - The allow/deny lists for settings and meta keys are no longer bypassable by varying the letter case, accenting a letter, or adding trailing whitespace in the name, which allowed reading the value of a denylisted option, and writing and filtering by a denylisted meta key (#3392)

--- a/webservers/_shared/assets/gatographql-testing-data.xml
+++ b/webservers/_shared/assets/gatographql-testing-data.xml
@@ -152,6 +152,10 @@ Consequatur.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1907]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1907]]></wp:meta_value>
+		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_thumbnail_id]]></wp:meta_key>
 		<wp:meta_value><![CDATA[0]]></wp:meta_value>
@@ -205,6 +209,10 @@ Consequatur.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[103]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[103]]></wp:meta_value>
+		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_thumbnail_id]]></wp:meta_key>
 		<wp:meta_value><![CDATA[617]]></wp:meta_value>
@@ -242,6 +250,10 @@ Consequatur.]]></excerpt:encoded>
 		<category domain="dummy-tag" nicename="classical"><![CDATA[Classical]]></category>
 						<wp:postmeta>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[12393900]]></wp:meta_value>
+		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[12393900]]></wp:meta_value>
 		</wp:postmeta>
 							</item>
@@ -287,6 +299,10 @@ Harum quibusdam aut.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[2341]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[2341]]></wp:meta_value>
+		</wp:postmeta>
 							<wp:comment>
 			<wp:comment_id>23</wp:comment_id>
 			<wp:comment_author><![CDATA[Hubert Hoppe]]></wp:comment_author>
@@ -306,6 +322,10 @@ Harum quibusdam aut.]]></excerpt:encoded>
 						<wp:commentmeta>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
+			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
 			</wp:commentmeta>
 							</wp:comment>
 					</item>
@@ -349,6 +369,10 @@ Amet officia.]]></excerpt:encoded>
 		<category domain="dummy-category" nicename="unexpected-randomness"><![CDATA[Unexpected Randomness]]></category>
 						<wp:postmeta>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1000]]></wp:meta_value>
+		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1000]]></wp:meta_value>
 		</wp:postmeta>
 							<wp:postmeta>
@@ -404,6 +428,10 @@ Amet officia.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1342]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1342]]></wp:meta_value>
+		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_thumbnail_id]]></wp:meta_key>
 		<wp:meta_value><![CDATA[628]]></wp:meta_value>
@@ -424,6 +452,10 @@ Amet officia.]]></excerpt:encoded>
 						<wp:commentmeta>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
+			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
 			</wp:commentmeta>
 							</wp:comment>
 					</item>
@@ -463,6 +495,10 @@ Amet officia.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+		</wp:postmeta>
 							<wp:comment>
 			<wp:comment_id>14</wp:comment_id>
 			<wp:comment_author><![CDATA[Addie Crooks III]]></wp:comment_author>
@@ -481,6 +517,10 @@ Amet officia.]]></excerpt:encoded>
 						<wp:commentmeta>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
+			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
 			</wp:commentmeta>
 							</wp:comment>
 					</item>
@@ -521,6 +561,10 @@ Amet officia.]]></excerpt:encoded>
 		<category domain="dummy-tag" nicename="tango"><![CDATA[Tango]]></category>
 						<wp:postmeta>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[12893]]></wp:meta_value>
+		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[12893]]></wp:meta_value>
 		</wp:postmeta>
 							</item>
@@ -567,6 +611,10 @@ Amet officia.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[8491]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[8491]]></wp:meta_value>
+		</wp:postmeta>
 							</item>
 					<item>
 		<title><![CDATA[Recusandae vel deleniti est expedita dolores quasi]]></title>
@@ -611,6 +659,10 @@ Dolorum quo neque.]]></excerpt:encoded>
 		<category domain="dummy-tag" nicename="tango"><![CDATA[Tango]]></category>
 						<wp:postmeta>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1231]]></wp:meta_value>
+		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1231]]></wp:meta_value>
 		</wp:postmeta>
 							<wp:postmeta>
@@ -666,6 +718,10 @@ Rem quae.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_thumbnail_id]]></wp:meta_key>
 		<wp:meta_value><![CDATA[637]]></wp:meta_value>
@@ -691,6 +747,10 @@ Rem quae.]]></excerpt:encoded>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
 			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
+			</wp:commentmeta>
 							</wp:comment>
 					<wp:comment>
 			<wp:comment_id>22</wp:comment_id>
@@ -709,6 +769,10 @@ Rem quae.]]></excerpt:encoded>
 						<wp:commentmeta>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
+			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
 			</wp:commentmeta>
 							</wp:comment>
 					</item>
@@ -752,6 +816,10 @@ Rem quae.]]></excerpt:encoded>
 		<category domain="dummy-tag" nicename="tango"><![CDATA[Tango]]></category>
 						<wp:postmeta>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[4532221]]></wp:meta_value>
+		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[4532221]]></wp:meta_value>
 		</wp:postmeta>
 							<wp:postmeta>
@@ -806,6 +874,10 @@ Ea et et dolor.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1342]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1342]]></wp:meta_value>
+		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_thumbnail_id]]></wp:meta_key>
 		<wp:meta_value><![CDATA[642]]></wp:meta_value>
@@ -828,6 +900,10 @@ Ea et et dolor.]]></excerpt:encoded>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
 			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
+			</wp:commentmeta>
 							</wp:comment>
 					<wp:comment>
 			<wp:comment_id>19</wp:comment_id>
@@ -846,6 +922,10 @@ Ea et et dolor.]]></excerpt:encoded>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
 			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
+			</wp:commentmeta>
 							</wp:comment>
 					<wp:comment>
 			<wp:comment_id>20</wp:comment_id>
@@ -863,6 +943,10 @@ Ea et et dolor.]]></excerpt:encoded>
 						<wp:commentmeta>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
+			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
 			</wp:commentmeta>
 							</wp:comment>
 					<wp:comment>
@@ -883,6 +967,10 @@ Ea et et dolor.]]></excerpt:encoded>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
 			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
+			</wp:commentmeta>
 							</wp:comment>
 					<wp:comment>
 			<wp:comment_id>24</wp:comment_id>
@@ -900,6 +988,10 @@ Ea et et dolor.]]></excerpt:encoded>
 						<wp:commentmeta>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
+			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
 			</wp:commentmeta>
 							</wp:comment>
 					</item>
@@ -948,6 +1040,10 @@ Ea et et dolor.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[11234]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[11234]]></wp:meta_value>
+		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_thumbnail_id]]></wp:meta_key>
 		<wp:meta_value><![CDATA[645]]></wp:meta_value>
@@ -971,6 +1067,10 @@ Ea et et dolor.]]></excerpt:encoded>
 						<wp:commentmeta>
 	<wp:meta_key><![CDATA[_some_text_in_comment]]></wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
+			</wp:commentmeta>
+						<wp:commentmeta>
+	<wp:meta_key><![CDATA[some_text_in_comment]]></wp:meta_key>
+			<wp:meta_value><![CDATA[Some text in comment]]></wp:meta_value>
 			</wp:commentmeta>
 							</wp:comment>
 					</item>
@@ -1021,6 +1121,10 @@ Ea et et dolor.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+		</wp:postmeta>
 							</item>
 					<item>
 		<title><![CDATA[Nulla numquam totam eaque]]></title>
@@ -1061,6 +1165,10 @@ Ea et et dolor.]]></excerpt:encoded>
 		<category domain="dummy-tag" nicename="rock"><![CDATA[Rock]]></category>
 						<wp:postmeta>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[23222221]]></wp:meta_value>
+		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[23222221]]></wp:meta_value>
 		</wp:postmeta>
 							<wp:postmeta>
@@ -1177,6 +1285,10 @@ Dolorum quo neque.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1231]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1231]]></wp:meta_value>
+		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_thumbnail_id]]></wp:meta_key>
 		<wp:meta_value><![CDATA[635]]></wp:meta_value>
@@ -1229,6 +1341,10 @@ Dolorum quo neque.]]></excerpt:encoded>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1231]]></wp:meta_value>
 		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1231]]></wp:meta_value>
+		</wp:postmeta>
 							<wp:postmeta>
 		<wp:meta_key><![CDATA[_thumbnail_id]]></wp:meta_key>
 		<wp:meta_value><![CDATA[635]]></wp:meta_value>
@@ -1263,6 +1379,10 @@ Dolorum quo neque.]]></excerpt:encoded>
 		<category domain="dummy-tag" nicename="tango"><![CDATA[Tango]]></category>
 						<wp:postmeta>
 		<wp:meta_key><![CDATA[_some_random_int]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1231]]></wp:meta_value>
+		</wp:postmeta>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[some_random_int]]></wp:meta_key>
 		<wp:meta_value><![CDATA[1231]]></wp:meta_value>
 		</wp:postmeta>
 							<wp:postmeta>

--- a/webservers/_shared/setup/import-data.sh
+++ b/webservers/_shared/setup/import-data.sh
@@ -14,3 +14,7 @@ wp import /app/_shared-webserver/assets/gatographql-testing-data.xml --url="$WEB
 
 # Importing a JSON object via gatographql-data.xml doesn't work, then do here
 wp post meta update 1116 meta_with_object_value '{"_edit_lock":{"to":{"111":["1743667747:1"]}},"_pingme":{"to":{"111":["1"]}},"some_property_to_translate":{"to":{"111":["Messi won another cup for more than 4 times by now, bleh\r\nAnd with another sentence"]}},"some_property":{"to":{"111":["Nothing about Diego?"]}}}' --format=json
+
+for PAGE_ID in $(wp post list --post_type=page --orderby=ID --order=ASC --posts_per_page=3 --format=ids); do
+    wp post meta update "$PAGE_ID" some_page_meta "Page meta value for page $PAGE_ID"
+done


### PR DESCRIPTION
Release 19.2.4, with two hardening changes to meta key protection.

### Protected meta keys on posts, comments and taxonomies are administrator-only for reading

Version 19.2.2 restricted reading protected user meta keys to administrators. The same restriction now applies to the meta of the other entities (custom posts, comments and taxonomy terms), which until now could be read by anyone with access to the schema.

As before, the restriction is lifted for a key added to the allowlist in the plugin Settings, or in a Schema Configuration.

### Protected meta keys cannot be reached through look-alike key names

The meta key columns are stored under a collation that treats certain distinct strings as the same key, so a key name that differed from a protected one could still resolve to it in the database while passing the PHP check. The protection check now resolves such names to the stored key before deciding, for both reading and writing, on all four meta types.

### Notes

- Backward compatible for administrators, who keep full access to every meta key.
- The shared resolution logic lives in a new `ProtectedMetaKeyResolverTrait` in `metaquery-wp`, which all four `*meta-wp` packages already depend on, so no dependency changes were needed.
- Covered by 15 new unit tests and by a role matrix in the integration suite asserting that an administrator reads the protected keys and every other role does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTxkUBvy2xAixEpEAoYzZk
