### PR TITLE
Let an extension say a custom post has no content of its own

### DIFF
--- a/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
+++ b/layers/CMSSchema/packages/customposts-wp/src/TypeAPIs/AbstractCustomPostTypeAPI.php
@@ -6,6 +6,7 @@ namespace PoPCMSSchema\CustomPostsWP\TypeAPIs;
 
 use PoPCMSSchema\CustomPostsWP\Constants\QueryOptions;
 use PoPCMSSchema\CustomPosts\Constants\CustomPostOrderBy;
+use PoPCMSSchema\CustomPosts\Constants\HookNames;
 use PoPCMSSchema\CustomPosts\Enums\CustomPostStatus;
 use PoPCMSSchema\CustomPosts\Module;
 use PoPCMSSchema\CustomPosts\ModuleConfiguration;
@@ -505,12 +506,11 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
 
     public function getContent(string|int|object $customPostObjectOrID): ?string
     {
-        /** @var WP_Post|null */
-        $customPost = $this->getCustomPostObject($customPostObjectOrID);
-        if ($customPost === null) {
+        $rawContent = $this->getRawContent($customPostObjectOrID);
+        if ($rawContent === null) {
             return null;
         }
-        return \apply_filters('the_content', $customPost->post_content);
+        return \apply_filters('the_content', $rawContent);
     }
 
     public function getRawContent(string|int|object $customPostObjectOrID): ?string
@@ -521,7 +521,12 @@ abstract class AbstractCustomPostTypeAPI extends UpstreamAbstractCustomPostTypeA
             return null;
         }
 
-        return $customPost->post_content;
+        /** @var string */
+        return App::applyFilters(
+            HookNames::CUSTOMPOST_RAW_CONTENT,
+            $customPost->post_content,
+            $customPost
+        );
     }
 
     public function getPublishedDate(string|int|object $customPostObjectOrID, bool $gmt = false): ?string

--- a/layers/CMSSchema/packages/customposts/src/Constants/HookNames.php
+++ b/layers/CMSSchema/packages/customposts/src/Constants/HookNames.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PoPCMSSchema\CustomPosts\Constants;
+
+class HookNames
+{
+    /**
+     * Filter the content stored for a custom post, before anything reads it.
+     *
+     * A page builder that renders its own layout may keep the stored content
+     * as a derived cache of that layout, in which case the custom post has no
+     * content of its own to report.
+     */
+    public const CUSTOMPOST_RAW_CONTENT = __CLASS__ . ':customPost:rawContent';
+}

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-de_DE.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-de_DE.po
@@ -13693,13 +13693,13 @@ msgstr "URL-Skalar, z. B. https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Benutzerdefinierter Skalar, der eine XML-Zeichenkette repräsentiert"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr ""
 "Blöcke zum Ausschließen und Einschließen können nicht gleichzeitig angegeben "
 "werden"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13707,7 +13707,7 @@ msgstr ""
 "Fehler beim Parsen der Beitrags-ID %d: Dieser Beitrag scheint keinen Block-"
 "Inhalt zu enthalten."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13715,7 +13715,7 @@ msgstr ""
 "Dieses Feld ist dafür ausgelegt, Gutenberg-Blöcke zu parsen, und kann keine "
 "Classic-Editor-Inhalte lesen."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-el.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-el.po
@@ -13580,12 +13580,12 @@ msgstr "Scalar URL, όπως https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Προσαρμοσμένος scalar που αντιπροσωπεύει μια συμβολοσειρά XML"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr ""
 "Δεν είναι δυνατή η παροχή blocks για εξαίρεση και συμπερίληψη ταυτόχρονα"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13593,7 +13593,7 @@ msgstr ""
 "Σφάλμα ανάλυσης ID δημοσίευσης %d: Αυτή η δημοσίευση δεν φαίνεται να "
 "περιέχει περιεχόμενο block."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13601,7 +13601,7 @@ msgstr ""
 "Αυτό το πεδίο έχει σχεδιαστεί για ανάλυση blocks Gutenberg και δεν μπορεί να "
 "διαβάσει περιεχόμενο κλασικού επεξεργαστή."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-es_ES.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-es_ES.po
@@ -13588,12 +13588,12 @@ msgstr "Escalar de URL, como https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Escalar personalizado que representa una cadena XML"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr ""
 "No se pueden proporcionar bloques para excluir e incluir al mismo tiempo"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13601,7 +13601,7 @@ msgstr ""
 "Error al analizar el ID de entrada %d: Esta entrada no parece contener "
 "contenido de bloques."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13609,7 +13609,7 @@ msgstr ""
 "Este campo está diseñado para analizar bloques de Gutenberg y no puede leer "
 "contenido del editor clásico."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-fr_FR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-fr_FR.po
@@ -13819,11 +13819,11 @@ msgstr "Scalaire URL, tel que https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Scalaire personnalisé représentant une chaîne XML"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "Impossible de fournir des blocs à exclure et à inclure en même temps"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13831,7 +13831,7 @@ msgstr ""
 "Erreur lors de l'analyse de l'article ID %d : cet article ne semble pas "
 "contenir de contenu en blocs."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13839,7 +13839,7 @@ msgstr ""
 "Ce champ est conçu pour analyser les blocs Gutenberg et ne peut pas lire le "
 "contenu de l'éditeur classique."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-id_ID.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-id_ID.po
@@ -13208,13 +13208,13 @@ msgstr "Skalar URL, seperti https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Skalar khusus yang mewakili string XML"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr ""
 "Tidak dapat menyediakan blok untuk dikecualikan dan disertakan pada saat "
 "yang bersamaan"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13222,7 +13222,7 @@ msgstr ""
 "Kesalahan saat mengurai ID post %d: Post ini tampaknya tidak mengandung "
 "konten blok."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13230,7 +13230,7 @@ msgstr ""
 "Field ini dirancang untuk mengurai blok Gutenberg dan tidak dapat membaca "
 "konten editor klasik."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-it_IT.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-it_IT.po
@@ -13570,12 +13570,12 @@ msgstr "Scalare URL, come https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Scalare personalizzato che rappresenta una stringa XML"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr ""
 "Non è possibile fornire blocchi da escludere e includere contemporaneamente"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13583,7 +13583,7 @@ msgstr ""
 "Errore durante l'analisi dell'ID del post %d: Questo post non sembra "
 "contenere contenuto a blocchi."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13591,7 +13591,7 @@ msgstr ""
 "Questo campo è progettato per analizzare i blocchi Gutenberg e non può "
 "leggere il contenuto dell'editor classico."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ja.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ja.po
@@ -13185,11 +13185,11 @@ msgstr "URLスカラー（例：https://mysite.com/my-fabulous-page）"
 msgid "Custom scalar representing an XML string"
 msgstr "XML文字列を表すカスタムスカラー"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "除外するブロックと含めるブロックを同時に指定することはできません"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13197,7 +13197,7 @@ msgstr ""
 "投稿ID %d の解析エラー: この投稿にはブロックコンテンツが含まれていないようで"
 "す。"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13205,7 +13205,7 @@ msgstr ""
 "このフィールドはGutenbergブロックを解析するために設計されており、クラシックエ"
 "ディターのコンテンツを読み取ることができません。"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ko_KR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ko_KR.po
@@ -12819,11 +12819,11 @@ msgstr "URL 스칼라(예: https://mysite.com/my-fabulous-page)"
 msgid "Custom scalar representing an XML string"
 msgstr "XML 문자열을 나타내는 커스텀 스칼라"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "제외할 블록과 포함할 블록을 동시에 제공할 수 없습니다"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -12831,7 +12831,7 @@ msgstr ""
 "포스트 ID %d 파싱 오류: 이 포스트에는 블록 콘텐츠가 포함되어 있지 않은 것 같"
 "습니다."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -12839,7 +12839,7 @@ msgstr ""
 "이 필드는 Gutenberg 블록을 파싱하도록 설계되었으며 클래식 에디터 콘텐츠를 읽"
 "을 수 없습니다."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-nl_NL.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-nl_NL.po
@@ -13570,13 +13570,13 @@ msgstr "URL-scalair, zoals https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Aangepast scalair dat een XML-tekenreeks vertegenwoordigt"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr ""
 "Blokken om uit te sluiten en op te nemen kunnen niet tegelijkertijd worden "
 "opgegeven"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13584,7 +13584,7 @@ msgstr ""
 "Fout bij het verwerken van bericht-ID %d: Dit bericht lijkt geen blokkinhoud "
 "te bevatten."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13592,7 +13592,7 @@ msgstr ""
 "Dit veld is ontworpen om Gutenberg-blokken te verwerken en kan geen "
 "klassieke editor-inhoud lezen."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pl_PL.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pl_PL.po
@@ -13273,11 +13273,11 @@ msgstr "Skalar URL, np. https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Niestandardowy skalar reprezentujący ciąg XML"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "Nie można jednocześnie podać bloków do wykluczenia i uwzględnienia"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13285,7 +13285,7 @@ msgstr ""
 "Błąd parsowania ID wpisu %d: Ten wpis nie wydaje się zawierać treści "
 "blokowej."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13293,7 +13293,7 @@ msgstr ""
 "To pole jest przeznaczone do parsowania bloków Gutenberga i nie może "
 "odczytywać treści klasycznego edytora."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pt_BR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pt_BR.po
@@ -13448,11 +13448,11 @@ msgstr "Escalar URL, como https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Escalar personalizado representando uma string XML"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "Não é possível fornecer blocos para excluir e incluir ao mesmo tempo"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13460,7 +13460,7 @@ msgstr ""
 "Erro ao analisar o ID de post %d: Este post não parece conter conteúdo em "
 "blocos."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13468,7 +13468,7 @@ msgstr ""
 "Este campo é projetado para analisar blocos do Gutenberg e não pode ler "
 "conteúdo do editor clássico."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ru_RU.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ru_RU.po
@@ -13457,11 +13457,11 @@ msgstr "Скаляр URL, например https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Пользовательский скаляр, представляющий XML-строку"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "Нельзя одновременно указывать блоки для исключения и включения"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13469,7 +13469,7 @@ msgstr ""
 "Ошибка разбора ID записи %d: эта запись, по всей видимости, не содержит "
 "блочного контента."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13477,7 +13477,7 @@ msgstr ""
 "Это поле предназначено для разбора блоков Gutenberg и не может читать "
 "контент классического редактора."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-sv_SE.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-sv_SE.po
@@ -13255,11 +13255,11 @@ msgstr "URL-skalär, t.ex. https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Anpassad skalär som representerar en XML-sträng"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "Det går inte att ange block att exkludera och inkludera samtidigt"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13267,7 +13267,7 @@ msgstr ""
 "Fel vid tolkning av inläggs-ID %d: Det verkar inte som om detta inlägg "
 "innehåller blockinnehåll."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13275,7 +13275,7 @@ msgstr ""
 "Det här fältet är utformat för att tolka Gutenberg-block och kan inte läsa "
 "klassiskt redigeringsinnehåll."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-th.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-th.po
@@ -12716,17 +12716,17 @@ msgstr "URL scalar เช่น https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Custom scalar ที่แสดงถึงสตริง XML"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "ไม่สามารถระบุบล็อกที่จะยกเว้นและรวมพร้อมกันได้"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
 msgstr "เกิดข้อผิดพลาดในการแยกวิเคราะห์ post ID %d: โพสต์นี้ดูเหมือนจะไม่มีเนื้อหาแบบบล็อก"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -12734,7 +12734,7 @@ msgstr ""
 "ฟิลด์นี้ถูกออกแบบมาเพื่อแยกวิเคราะห์บล็อก Gutenberg และไม่สามารถอ่านเนื้อหาจาก classic "
 "editor ได้"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-tr_TR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-tr_TR.po
@@ -13181,11 +13181,11 @@ msgstr "URL skaleri, örneğin https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Bir XML dizesini temsil eden özel skaler"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "Aynı anda hariç tutulacak ve dahil edilecek bloklar sağlanamaz"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13193,7 +13193,7 @@ msgstr ""
 "%d gönderi kimliği ayrıştırılırken hata oluştu: Bu gönderi blok içeriği "
 "içermiyor gibi görünüyor."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13201,7 +13201,7 @@ msgstr ""
 "Bu alan Gutenberg bloklarını ayrıştırmak için tasarlanmıştır ve klasik "
 "düzenleyici içeriğini okuyamaz."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-vi.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-vi.po
@@ -13268,11 +13268,11 @@ msgstr "Scalar URL, chẳng hạn như https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "Scalar tùy chỉnh đại diện cho một chuỗi XML"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "Không thể cung cấp đồng thời các block để loại trừ và bao gồm"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
@@ -13280,7 +13280,7 @@ msgstr ""
 "Lỗi khi phân tích ID bài viết %d: Bài viết này dường như không chứa nội dung "
 "block."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
@@ -13288,7 +13288,7 @@ msgstr ""
 "Trường này được thiết kế để phân tích các block Gutenberg và không thể đọc "
 "nội dung của trình soạn thảo cổ điển."
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-zh_CN.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-zh_CN.po
@@ -12468,23 +12468,23 @@ msgstr "URL 标量，例如 https://mysite.com/my-fabulous-page"
 msgid "Custom scalar representing an XML string"
 msgstr "表示 XML 字符串的自定义标量"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr "不能同时提供要排除和要包含的块"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid ""
 "Error parsing post ID %d: This post does not appear to contain block content."
 msgstr "解析文章 ID %d 时出错：该文章似乎不包含块内容。"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid ""
 "This fields is designed to parse Gutenberg blocks and can not read classic "
 "editor content."
 msgstr "此字段用于解析 Gutenberg 块，无法读取经典编辑器内容。"
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid ""
 "This post either does not contain block content, or its block content has "
 "errors. (Edit the post within the WordPress editor, fix the errors, save, "

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql.pot
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql.pot
@@ -11203,20 +11203,20 @@ msgstr ""
 msgid "Custom scalar representing an XML string"
 msgstr ""
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:238
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:251
 msgid "Cannot provide blocks to exclude and include at the same time"
 msgstr ""
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:255
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:268
 #, php-format
 msgid "Error parsing post ID %d: This post does not appear to contain block content."
 msgstr ""
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:258
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:271
 msgid "This fields is designed to parse Gutenberg blocks and can not read classic editor content."
 msgstr ""
 
-#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:303
+#: WPSchema/packages/block-content-parser/src/BlockContentParser.php:316
 msgid "This post either does not contain block content, or its block content has errors. (Edit the post within the WordPress editor, fix the errors, save, and try again.)"
 msgstr ""
 

--- a/layers/WPSchema/packages/block-content-parser/composer.json
+++ b/layers/WPSchema/packages/block-content-parser/composer.json
@@ -15,7 +15,8 @@
     "require": {
         "php": "^8.1",
         "getpop/dom-crawler": "^19.3",
-        "getpop/engine-wp": "^19.3"
+        "getpop/engine-wp": "^19.3",
+        "pop-cms-schema/customposts": "^19.3"
     },
     "require-dev": {
         "johnpbloch/wordpress": "^6.6",

--- a/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
+++ b/layers/WPSchema/packages/block-content-parser/src/BlockContentParser.php
@@ -6,6 +6,7 @@ namespace PoPWPSchema\BlockContentParser;
 
 use DOMNode;
 use PoPWPSchema\BlockContentParser\Exception\BlockContentParserException;
+use PoPCMSSchema\CustomPosts\TypeAPIs\CustomPostTypeAPIInterface;
 use PoPWPSchema\BlockContentParser\ObjectModels\BlockContentParserPayload;
 use PoP\ComponentModel\StaticHelpers\MethodHelpers;
 use PoP\DOMCrawler\Crawler;
@@ -34,6 +35,18 @@ class BlockContentParser extends AbstractBasicService implements BlockContentPar
 {
     private bool $includeInnerContent = false;
 
+    private ?CustomPostTypeAPIInterface $customPostTypeAPI = null;
+
+    final protected function getCustomPostTypeAPI(): CustomPostTypeAPIInterface
+    {
+        if ($this->customPostTypeAPI === null) {
+            /** @var CustomPostTypeAPIInterface */
+            $customPostTypeAPI = $this->instanceManager->getInstance(CustomPostTypeAPIInterface::class);
+            $this->customPostTypeAPI = $customPostTypeAPI;
+        }
+        return $this->customPostTypeAPI;
+    }
+
     /**
      * @param array<string,mixed> $options An associative array of options. Can contain keys:
      *              'filter': An associative array of options for filtering blocks. Can contain keys:
@@ -59,7 +72,7 @@ class BlockContentParser extends AbstractBasicService implements BlockContentPar
                 return null;
             }
         }
-        $customPostContent = $customPost->post_content;
+        $customPostContent = (string) $this->getCustomPostTypeAPI()->getRawContent($customPost);
         // If the post has no content, don't parse it or it'll produce an error
         if ($customPostContent === '') {
             return new BlockContentParserPayload(


### PR DESCRIPTION
## Why

A page builder that renders its own layout may keep `post_content` as a derived copy of that layout, rewritten on every save so that WordPress search and excerpts have something to read. Elementor does this.

Reporting that copy as the custom post's content offers the same text twice under two different shapes, and the copy is the shape nothing can act on: it carries no block delimiters, so parsing it as blocks fails with `This post does not appear to contain block content`, and writing to it is undone by the builder's next save.

Until now an extension had no way to say so, because each field reached for `$customPost->post_content` on its own.

## What

- New filter `PoPCMSSchema\CustomPosts\Constants\HookNames::CUSTOMPOST_RAW_CONTENT`, applied in `AbstractCustomPostTypeAPI::getRawContent()`, receiving the content and the `WP_Post`.
- `getContent()` now builds on `getRawContent()` rather than reading the property itself.
- `BlockContentParser::parseCustomPostIntoBlockDataItems()` obtains the content through `CustomPostTypeAPIInterface::getRawContent()` instead of reading the property, so the block fields answer consistently with `content` and `rawContent`.

One filter therefore covers `content`, `rawContent`, `blocks`, `blockDataItems` and `blockFlattenedDataItems`.

## Behaviour

Nothing changes on its own: with no subscriber the filter returns the content unaltered. The parser already short-circuits on an empty string, returning no blocks and no error, so a subscriber returning `''` needs no further handling.