### PR TITLE
Let a custom-settings page name its own submit button and its own screen

### DIFF
--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-de_DE.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-de_DE.po
@@ -12274,14 +12274,14 @@ msgstr "<strong>Kompatibel</strong> mit Ihrer WordPress-Version"
 msgid "There are no items to be configured"
 msgstr "Es gibt keine zu konfigurierenden Elemente"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Alle Änderungen speichern (Registerkarte '%s')"
@@ -12729,11 +12729,11 @@ msgstr "Support wird Kunden mit einer aktiven Lizenz von %s bereitgestellt."
 msgid "Send your message to our support team:"
 msgstr "Senden Sie Ihre Nachricht an unser Support-Team:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Es wurden keine IDs ausgewählt."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "Die folgenden IDs wurden ausgewählt: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-el.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-el.po
@@ -12167,14 +12167,14 @@ msgstr "<strong>Συμβατό</strong> με την έκδοσή σας του W
 msgid "There are no items to be configured"
 msgstr "Δεν υπάρχουν στοιχεία για ρύθμιση"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Αποθήκευση όλων των αλλαγών (καρτέλα '%s')"
@@ -12624,11 +12624,11 @@ msgstr "Η υποστήριξη παρέχεται σε πελάτες με εν
 msgid "Send your message to our support team:"
 msgstr "Στείλτε το μήνυμά σας στην ομάδα υποστήριξής μας:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Δεν επιλέχθηκαν ID."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "Επιλέχθηκαν τα παρακάτω ID: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-es_ES.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-es_ES.po
@@ -12174,14 +12174,14 @@ msgstr "<strong>Compatible</strong> con tu versión de WordPress"
 msgid "There are no items to be configured"
 msgstr "No hay elementos que configurar"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Guardar todos los cambios (pestaña '%s')"
@@ -12629,11 +12629,11 @@ msgstr "El soporte se ofrece a los clientes con una licencia activa de %s."
 msgid "Send your message to our support team:"
 msgstr "Envía tu mensaje a nuestro equipo de soporte:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "No se seleccionaron IDs."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "Se seleccionaron los siguientes IDs: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-fr_FR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-fr_FR.po
@@ -12404,14 +12404,14 @@ msgstr "<strong>Compatible</strong> avec votre version de WordPress"
 msgid "There are no items to be configured"
 msgstr "Aucun élément à configurer"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Enregistrer toutes les modifications (onglet « %s »)"
@@ -12861,11 +12861,11 @@ msgstr ""
 msgid "Send your message to our support team:"
 msgstr "Envoyez votre message à notre équipe d'assistance :"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Aucun identifiant n'a été sélectionné."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "Les ID suivants ont été sélectionnés : <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-id_ID.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-id_ID.po
@@ -11814,14 +11814,14 @@ msgstr "<strong>Kompatibel</strong> dengan versi WordPress Anda"
 msgid "There are no items to be configured"
 msgstr "Tidak ada item yang perlu dikonfigurasi"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Simpan Semua Perubahan (tab '%s')"
@@ -12264,11 +12264,11 @@ msgstr "Dukungan diberikan kepada pelanggan dengan lisensi aktif dari %s."
 msgid "Send your message to our support team:"
 msgstr "Kirim pesan Anda ke tim dukungan kami:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Tidak ada ID yang dipilih."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "ID berikut telah dipilih: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-it_IT.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-it_IT.po
@@ -12165,14 +12165,14 @@ msgstr "<strong>Compatibile</strong> con la tua versione di WordPress"
 msgid "There are no items to be configured"
 msgstr "Non ci sono elementi da configurare"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Salva tutte le modifiche (scheda '%s')"
@@ -12621,11 +12621,11 @@ msgstr "Il supporto è fornito ai clienti con una licenza attiva di %s."
 msgid "Send your message to our support team:"
 msgstr "Invia il tuo messaggio al nostro team di supporto:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Nessun ID è stato selezionato."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "I seguenti ID sono stati selezionati: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ja.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ja.po
@@ -11812,14 +11812,14 @@ msgstr "お使いのWordPressバージョンと<strong>互換性あり</strong>"
 msgid "There are no items to be configured"
 msgstr "設定するアイテムがありません"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "すべての変更を保存（'%s' タブ）"
@@ -12263,11 +12263,11 @@ msgstr "サポートは%sのアクティブなライセンスをお持ちのお�
 msgid "Send your message to our support team:"
 msgstr "サポートチームにメッセージを送信してください："
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "IDが選択されていません。"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "以下のIDが選択されました：<strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ko_KR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ko_KR.po
@@ -11457,14 +11457,14 @@ msgstr "WordPress 버전과 <strong>호환</strong>됩니다"
 msgid "There are no items to be configured"
 msgstr "구성할 항목이 없습니다"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "모든 변경 사항 저장 ('%s' 탭)"
@@ -11908,11 +11908,11 @@ msgstr "%s의 활성 라이선스를 보유한 고객에게 지원이 제공됩�
 msgid "Send your message to our support team:"
 msgstr "지원 팀에 메시지를 보내십시오:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "선택된 ID가 없습니다."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "다음 ID가 선택되었습니다: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-nl_NL.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-nl_NL.po
@@ -12163,14 +12163,14 @@ msgstr "<strong>Compatibel</strong> met uw versie van WordPress"
 msgid "There are no items to be configured"
 msgstr "Er zijn geen items om te configureren"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Alle wijzigingen opslaan (tabblad '%s')"
@@ -12619,11 +12619,11 @@ msgstr ""
 msgid "Send your message to our support team:"
 msgstr "Stuur uw bericht naar ons ondersteuningsteam:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Er zijn geen ID's geselecteerd."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "De volgende ID's zijn geselecteerd: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pl_PL.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pl_PL.po
@@ -11871,14 +11871,14 @@ msgstr "<strong>Zgodny</strong> z Twoją wersją WordPress"
 msgid "There are no items to be configured"
 msgstr "Brak elementów do skonfigurowania"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Zapisz wszystkie zmiany (zakładka '%s')"
@@ -12325,11 +12325,11 @@ msgstr "Wsparcie jest zapewniane klientom z aktywną licencją %s."
 msgid "Send your message to our support team:"
 msgstr "Wyślij wiadomość do naszego zespołu wsparcia:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Nie wybrano żadnych identyfikatorów."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "Wybrano następujące identyfikatory: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pt_BR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-pt_BR.po
@@ -12049,14 +12049,14 @@ msgstr "<strong>Compatível</strong> com sua versão do WordPress"
 msgid "There are no items to be configured"
 msgstr "Não há itens a serem configurados"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Salvar todas as alterações (aba '%s')"
@@ -12502,11 +12502,11 @@ msgstr "O suporte é fornecido a clientes com uma licença ativa de %s."
 msgid "Send your message to our support team:"
 msgstr "Envie sua mensagem para nossa equipe de suporte:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Nenhum ID foi selecionado."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "Os seguintes IDs foram selecionados: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ru_RU.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-ru_RU.po
@@ -12054,14 +12054,14 @@ msgstr "<strong>Совместим</strong> с вашей версией WordPre
 msgid "There are no items to be configured"
 msgstr "Нет элементов для настройки"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Сохранить все изменения (вкладка «%s»)"
@@ -12508,11 +12508,11 @@ msgstr "Поддержка предоставляется клиентам с а
 msgid "Send your message to our support team:"
 msgstr "Отправьте ваше сообщение в нашу службу поддержки:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Ни один ID не был выбран."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "Были выбраны следующие ID: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-sv_SE.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-sv_SE.po
@@ -11863,14 +11863,14 @@ msgstr "<strong>Kompatibel</strong> med din version av WordPress"
 msgid "There are no items to be configured"
 msgstr "Det finns inga objekt att konfigurera"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Spara alla ändringar (fliken '%s')"
@@ -12316,11 +12316,11 @@ msgstr "Support ges till kunder med en aktiv licens för %s."
 msgid "Send your message to our support team:"
 msgstr "Skicka ditt meddelande till vårt supportteam:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Inga ID:n valdes."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "Följande ID:n valdes: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-th.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-th.po
@@ -11366,14 +11366,14 @@ msgstr "<strong>เข้ากันได้</strong> กับ WordPress เ�
 msgid "There are no items to be configured"
 msgstr "ไม่มีรายการที่ต้องกำหนดค่า"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "บันทึกการเปลี่ยนแปลงทั้งหมด (แท็บ '%s')"
@@ -11810,11 +11810,11 @@ msgstr "การสนับสนุนมอบให้แก่ลูกค
 msgid "Send your message to our support team:"
 msgstr "ส่งข้อความของคุณถึงทีมสนับสนุนของเรา:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "ไม่มี ID ใดถูกเลือก"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "ID ต่อไปนี้ถูกเลือก: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-tr_TR.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-tr_TR.po
@@ -11789,14 +11789,14 @@ msgstr "WordPress sürümünüzle <strong>Uyumlu</strong>"
 msgid "There are no items to be configured"
 msgstr "Yapılandırılacak öğe yok"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Tüm Değişiklikleri Kaydet ('%s' sekmesi)"
@@ -12244,11 +12244,11 @@ msgstr "Destek, aktif %s lisansına sahip müşterilere sağlanmaktadır."
 msgid "Send your message to our support team:"
 msgstr "Destek ekibimize mesajınızı gönderin:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Hiçbir ID seçilmedi."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "Aşağıdaki ID'ler seçildi: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-vi.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-vi.po
@@ -11873,14 +11873,14 @@ msgstr "<strong>Tương thích</strong> với phiên bản WordPress của bạn
 msgid "There are no items to be configured"
 msgstr "Không có mục nào cần cấu hình"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "Lưu tất cả thay đổi (tab '%s')"
@@ -12323,11 +12323,11 @@ msgstr ""
 msgid "Send your message to our support team:"
 msgstr "Gửi tin nhắn của bạn đến đội ngũ hỗ trợ của chúng tôi:"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "Không có ID nào được chọn."
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "Các ID sau đã được chọn: <strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-zh_CN.po
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql-zh_CN.po
@@ -11147,14 +11147,14 @@ msgstr "<strong>兼容</strong>您的 WordPress 版本"
 msgid "There are no items to be configured"
 msgstr "没有需要配置的项目"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr "%s — %s"
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr "保存所有更改（'%s' 标签页）"
@@ -11588,11 +11588,11 @@ msgstr "支持服务仅提供给拥有 %s 有效许可证的客户。"
 msgid "Send your message to our support team:"
 msgstr "向我们的支持团队发送消息："
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr "未选择任何ID。"
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr "已选择以下ID：<strong>%s</strong>"

--- a/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql.pot
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/languages/gatographql.pot
@@ -10100,14 +10100,14 @@ msgstr ""
 msgid "There are no items to be configured"
 msgstr ""
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:525
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:527
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractTableMenuPage.php:20
 #: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractVerticalTabDocsMenuPage.php:208
 #, php-format
 msgid "%s — %s"
 msgstr ""
 
-#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:884
+#: GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php:899
 #, php-format
 msgid "Save All Changes ('%s' tab)"
 msgstr ""
@@ -10511,11 +10511,11 @@ msgstr ""
 msgid "Send your message to our support team:"
 msgstr ""
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:86
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:88
 msgid "No IDs were selected."
 msgstr ""
 
-#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:92
+#: GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php:94
 #, php-format
 msgid "The following IDs were selected: <strong>%s</strong>"
 msgstr ""

--- a/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php
+++ b/layers/GatoGraphQLForWP/plugins/gatographql/src/Services/MenuPages/AbstractSettingsMenuPage.php
@@ -497,7 +497,9 @@ abstract class AbstractSettingsMenuPage extends AbstractPluginMenuPage
                                                     }
                                                     if ($settingsCategoryResolver->addOptionsFormSubmitButton($settingsCategory)) {
                                                         submit_button(
-                                                            $this->getSubmitButtonLabel($settingsCategoryResolver, $settingsCategory)
+                                                            $this->getSubmitButtonLabel($settingsCategoryResolver, $settingsCategory),
+                                                            'primary',
+                                                            $this->getSubmitButtonName($settingsCategoryResolver, $settingsCategory)
                                                         );
                                                     }
                                                     ?>
@@ -873,6 +875,19 @@ abstract class AbstractSettingsMenuPage extends AbstractPluginMenuPage
                 <?php echo $label_safe; ?>
             </label>
         <?php
+    }
+
+    /**
+     * Get the name of the submit button for a settings category.
+     *
+     * WordPress names it `submit` unless told otherwise, which is a name
+     * the screen the form posts to may well give a meaning of its own. A
+     * page whose button does something other than save these settings can
+     * give it a name that says so.
+     */
+    protected function getSubmitButtonName(SettingsCategoryResolverInterface $settingsCategoryResolver, string $settingsCategory): string
+    {
+        return 'submit';
     }
 
     /**

--- a/layers/GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Helpers/ExecuteBulkActionHelperInterface.php
+++ b/layers/GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Helpers/ExecuteBulkActionHelperInterface.php
@@ -9,7 +9,7 @@ interface ExecuteBulkActionHelperInterface
     public function getExecuteActionWithCustomSettingsBulkActionName(string $bulkActionName): string;
 
     /**
-     * @param array<string,int> $entityIDs
+     * @param array<string|int> $entityIDs
      */
     public function getExecuteActionWithCustomSettingsPageURL(
         string $screenID,

--- a/layers/GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/PluginManagement/AbstractPluginOptionsFormHandler.php
+++ b/layers/GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/PluginManagement/AbstractPluginOptionsFormHandler.php
@@ -24,8 +24,7 @@ abstract class AbstractPluginOptionsFormHandler extends UpstreamPluginOptionsFor
         string $module,
         string $option,
     ): mixed {
-        global $pagenow;
-        if (!in_array($pagenow, $this->getSupportedBulkActionPages())) {
+        if (!$this->isSupportedBulkActionPage()) {
             return parent::maybeOverrideValueFromForm($value, $module, $option);
         }
 
@@ -68,6 +67,41 @@ abstract class AbstractPluginOptionsFormHandler extends UpstreamPluginOptionsFor
 
         $formOrigin = App::request(SettingsMenuPage::FORM_ORIGIN);
         return in_array($formOrigin, $formTargets);
+    }
+
+    protected function isSupportedBulkActionPage(): bool
+    {
+        global $pagenow;
+
+        if (in_array($pagenow, $this->getSupportedBulkActionPages())) {
+            return true;
+        }
+
+        /**
+         * A screen added by a plugin is served by `admin.php`, which by
+         * itself says nothing about which screen it is. Those are named by
+         * their `page` query param instead, so that allowing one of them
+         * does not allow every plugin's settings screen along with it.
+         */
+        $pageParams = $this->getSupportedBulkActionPageParams()[$pagenow] ?? null;
+        if ($pageParams === null) {
+            return false;
+        }
+
+        $page = App::request('page') ?? App::query('page');
+        return in_array($page, $pageParams);
+    }
+
+    /**
+     * The screens supported by their `page` query param, as
+     * `[ '<pagenow>' => [ '<page>', ... ] ]`. Empty by default: a screen is
+     * named either here or by `getSupportedBulkActionPages()`, never both.
+     *
+     * @return array<string,string[]>
+     */
+    protected function getSupportedBulkActionPageParams(): array
+    {
+        return [];
     }
 
     /**

--- a/layers/GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php
+++ b/layers/GatoGraphQLStandaloneForWP/plugin-packages/gatographql/src/Services/MenuPages/AbstractExecuteActionWithCustomSettingsMenuPage.php
@@ -14,6 +14,8 @@ use PoP\ComponentModel\Misc\GeneralUtils;
 
 abstract class AbstractExecuteActionWithCustomSettingsMenuPage extends AbstractSettingsMenuPage
 {
+    public final const SUBMIT_BUTTON_NAME = 'gatographql-execute-action';
+
     /**
      * The upstream method will print several <form> tags,
      * for the different settings categories.
@@ -183,6 +185,18 @@ abstract class AbstractExecuteActionWithCustomSettingsMenuPage extends AbstractS
     protected function getSubmitButtonLabel(SettingsCategoryResolverInterface $settingsCategoryResolver, string $settingsCategory): string
     {
         return $this->getActionName();
+    }
+
+    /**
+     * This button runs the action on the selected entities; it does not
+     * save these settings, which are carried along with the request and
+     * apply to that run alone. Naming it `submit` would hand the screen it
+     * posts back to a parameter that screen may already read as its own
+     * "Save" button having been pressed.
+     */
+    protected function getSubmitButtonName(SettingsCategoryResolverInterface $settingsCategoryResolver, string $settingsCategory): string
+    {
+        return self::SUBMIT_BUTTON_NAME;
     }
 
     abstract protected function getActionName(): string;


### PR DESCRIPTION
Three small seams so an "execute action with custom settings" page can work on a screen it was not written for. All three keep today's behaviour as the default.

## A settings page can name its own submit button

`AbstractSettingsMenuPage` calls `submit_button($label)`, and WordPress names every submit button `submit` unless told otherwise. On the settings page itself that is fine. On an "execute action with custom settings" page it is not: that form posts back to whichever screen the bulk action came from, and its button means "run this action on the selected entities", not "save these settings" — the settings travel with the request and apply to that run alone. A screen that reads `$_POST['submit']` as its own Save button having been pressed will therefore misread the request.

`getSubmitButtonName()` sits next to the `getSubmitButtonLabel()` that class already has, and answers `submit` for everything that does not override it. `AbstractExecuteActionWithCustomSettingsMenuPage` overrides it.

## A screen can be named by its `page` query param

`AbstractPluginOptionsFormHandler` decides whether to read custom settings out of the request by matching `$pagenow` against `getSupportedBulkActionPages()` — `edit.php`, `upload.php`, `edit-tags.php`, `users.php`.

A screen added by a plugin is served by `admin.php`, which says nothing about which screen it is, so listing it there would allow every plugin's settings screen along with it. `getSupportedBulkActionPageParams()` names such a screen by its `page` query param instead — `[ 'admin.php' => [ 'my-screen' ] ]` — and is empty by default, so nothing changes for anyone who does not set it.

## The bulk action IDs are annotated as the strings they can be

`ExecuteBulkActionHelperInterface` documented `$entityIDs` as `array<string,int>`. The implementation documents it as `array<string|int>` and only ever joins the values into a URL, so the interface was the one that was wrong.

## Notes

No changelog entry: nothing here changes what the plugin does on its own, and the only visible difference — the HTML `name` of a button on the custom-settings pages — is not something a user sees.

PHPStan level 8 and PSR-12 pass on all four files.
